### PR TITLE
チュートリアル用スライムの洞窟を追加

### DIFF
--- a/goblin_web/src/App.tsx
+++ b/goblin_web/src/App.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { GoblinListScreen } from './presentation/components/GoblinListScreen.tsx'
 import { FormationTabScreen } from './presentation/components/FormationTabScreen.tsx'
-import { ExpeditionTabScreen } from './presentation/components/ExpeditionTabScreen.tsx'
 import { TabMenu } from './presentation/components/TabMenu.tsx'
 import { AuthProvider } from './presentation/contexts/AuthContext.tsx'
 import { useAuth } from './presentation/contexts/AuthContextValue.ts'
@@ -9,7 +8,7 @@ import { ExpeditionStateProvider } from './presentation/contexts/ExpeditionState
 
 function AppContent() {
   const { loading } = useAuth()
-  const [activeTab, setActiveTab] = useState('list')
+  const [activeTab, setActiveTab] = useState<'list' | 'formation'>('list')
 
   if (loading) {
     return (
@@ -41,9 +40,6 @@ function AppContent() {
         )}
         {activeTab === 'formation' && (
           <FormationTabScreen />
-        )}
-        {activeTab === 'expedition' && (
-          <ExpeditionTabScreen />
         )}
       </div>
 

--- a/goblin_web/src/core/services/ExpeditionEngine.ts
+++ b/goblin_web/src/core/services/ExpeditionEngine.ts
@@ -69,7 +69,8 @@ export class ExpeditionEngine {
     }
 
     const partySnapshot = this.createPartySnapshot(party, request.returnPolicy)
-    const adjustedDuration = area.baseDurationSec
+    // 表示上の規定時間をそのまま使い、終端にイベントを揃える
+    const adjustedDuration = Math.ceil(area.baseDurationSec)
 
     const events: TimelineEvent[] = []
     let currentFloor = 1
@@ -213,6 +214,10 @@ export class ExpeditionEngine {
       const bossXp = area.rewards.xpBoss
       const bossDrops = this.generateDrops(area.rewards.lootPool, partySnapshot.luckMod * 1.5)
 
+      // 規定時間の終端でボス戦を行う（最後の秒で戦闘開始）
+      const bossTime = adjustedDuration
+      currentTime = bossTime
+
       events.push({
         type: "boss",
         at: currentTime,
@@ -232,7 +237,7 @@ export class ExpeditionEngine {
     if (shouldReturn && returnReason) {
       events.push({
         type: "return",
-        at: Math.min(currentTime + 1, adjustedDuration),
+        at: adjustedDuration,
         reason: returnReason as ExpeditionEndReason
       })
     }

--- a/goblin_web/src/infrastructure/repositories/FirestoreExpeditionRepositoryImpl.ts
+++ b/goblin_web/src/infrastructure/repositories/FirestoreExpeditionRepositoryImpl.ts
@@ -86,6 +86,7 @@ export class FirestoreExpeditionRepositoryImpl {
       const docRef = getUserExpeditionDoc(expeditionId)
       await updateDoc(docRef, {
         replay,
+        status: 'completed',
         updatedAt: Timestamp.fromDate(new Date())
       })
     } catch (error) {
@@ -313,9 +314,12 @@ export class FirestoreExpeditionRepositoryAdapter {
     const cached = this.cache.get(expeditionId)
     if (cached) {
       cached.replay = replay
+      cached.status = 'completed'
       cached.updatedAt = new Date()
-      // statusは変更せず、ongoingExpeditionsからも削除しない
+      this.ongoingExpeditions = this.ongoingExpeditions.filter(exp => exp.id !== expeditionId)
       this.onDataChange?.()
+    } else {
+      this.ongoingExpeditions = this.ongoingExpeditions.filter(exp => exp.id !== expeditionId)
     }
   }
 

--- a/goblin_web/src/infrastructure/services/FirestoreDungeonProgressService.ts
+++ b/goblin_web/src/infrastructure/services/FirestoreDungeonProgressService.ts
@@ -1,0 +1,47 @@
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { auth, db } from '../../config/firebase'
+import type { DungeonProgressState } from '../../shared/types/DungeonProgress'
+
+const getUserId = (): string => {
+  const user = auth.currentUser
+  if (!user) {
+    throw new Error('ユーザーが認証されていません')
+  }
+  return user.uid
+}
+
+const getUserDocRef = () => {
+  const userId = getUserId()
+  return doc(db, 'users', userId)
+}
+
+export class FirestoreDungeonProgressService {
+  async loadProgress(defaults: DungeonProgressState): Promise<DungeonProgressState> {
+    try {
+      const docRef = getUserDocRef()
+      const snap = await getDoc(docRef)
+
+      if (!snap.exists()) {
+        await setDoc(docRef, { dungeonProgress: defaults }, { merge: true })
+        return defaults
+      }
+
+      const data = snap.data()
+      const stored = (data?.dungeonProgress ?? {}) as DungeonProgressState
+      return { ...defaults, ...stored }
+    } catch (error) {
+      console.error('ダンジョン進行状況の取得エラー:', error)
+      return defaults
+    }
+  }
+
+  async saveProgress(progress: DungeonProgressState): Promise<void> {
+    try {
+      const docRef = getUserDocRef()
+      await setDoc(docRef, { dungeonProgress: progress }, { merge: true })
+    } catch (error) {
+      console.error('ダンジョン進行状況の保存エラー:', error)
+      throw error
+    }
+  }
+}

--- a/goblin_web/src/presentation/components/DungeonScreen.tsx
+++ b/goblin_web/src/presentation/components/DungeonScreen.tsx
@@ -17,35 +17,55 @@ const formatTime = (seconds: number): string => {
   return `${minutes}分${remainingSeconds}秒`
 }
 
-export const DungeonScreen = ({ dungeons, onStartExplore }: DungeonScreenProps) => (
-  <div className="h-full overflow-y-auto">
-    <div className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b-2 border-gray-200">
-      ダンジョン選択
+export const DungeonScreen = ({ dungeons, onStartExplore }: DungeonScreenProps) => {
+  const unlockNameMap = dungeons.reduce<Record<string, string>>((map, dungeon) => {
+    map[dungeon.id] = dungeon.name
+    return map
+  }, {})
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b-2 border-gray-200">
+        ダンジョン選択
+      </div>
+      <div className="flex flex-col gap-4">
+        {dungeons.map(dungeon => {
+          const isLocked = dungeon.unlocked === false
+          const unlockTarget = dungeon.unlockRequires ? unlockNameMap[dungeon.unlockRequires] : undefined
+
+          return (
+            <div
+              key={dungeon.id}
+              className={`relative bg-white border-2 border-gray-200 rounded-xl overflow-hidden shadow-md transition-all ${
+                isLocked ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:border-gray-400 hover:shadow-lg'
+              }`}
+              onClick={() => !isLocked && onStartExplore(dungeon)}
+            >
+              <div className="bg-gray-700 text-white p-4">
+                <div className="font-bold text-base mb-1">
+                  {dungeon.name}
+                </div>
+                <div className="text-xs opacity-90">{dungeon.description}</div>
+              </div>
+              <div className="p-4">
+                <div className="flex justify-between text-xs text-gray-600 mb-2">
+                  <span>🏰 階層数: {dungeon.floors}階</span>
+                </div>
+                <div className="flex justify-between text-xs text-gray-600">
+                  <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
+                  {dungeon.cleared && <span className="text-green-600 font-bold">✓ 攻略済み</span>}
+                </div>
+                {isLocked && (
+                  <div className="mt-2 text-xs text-red-600 font-semibold">
+                    🔒 未解放{unlockTarget ? `（${unlockTarget}を攻略）` : ''}
+                  </div>
+                )}
+              </div>
+              {isLocked && <div className="absolute inset-0 bg-white/30" />}
+            </div>
+          )
+        })}
+      </div>
     </div>
-    <div className="flex flex-col gap-4">
-      {dungeons.map(dungeon => (
-        <div
-          key={dungeon.id}
-          className="bg-white border-2 border-gray-200 rounded-xl overflow-hidden shadow-md cursor-pointer hover:border-gray-400 hover:shadow-lg transition-all"
-          onClick={() => onStartExplore(dungeon)}
-        >
-          <div className="bg-gray-700 text-white p-4">
-            <div className="font-bold text-base mb-1">
-              {dungeon.name}
-            </div>
-            <div className="text-xs opacity-90">{dungeon.description}</div>
-          </div>
-          <div className="p-4">
-            <div className="flex justify-between text-xs text-gray-600 mb-2">
-              <span>🏰 階層数: {dungeon.floors}階</span>
-            </div>
-            <div className="flex justify-between text-xs text-gray-600">
-              <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
-              {dungeon.cleared && <span className="text-green-600 font-bold">✓ 攻略済み</span>}
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  </div>
-)
+  )
+}

--- a/goblin_web/src/presentation/components/DungeonSelectionModal.tsx
+++ b/goblin_web/src/presentation/components/DungeonSelectionModal.tsx
@@ -19,6 +19,8 @@ const formatTime = (seconds: number): string => {
 }
 
 export const DungeonSelectionModal = ({ dungeons, onSelect, onClose }: DungeonSelectionModalProps) => {
+  const unlockedDungeons = dungeons.filter(dungeon => dungeon.unlocked !== false)
+
   return (
     <div
       className="flex fixed inset-0 z-50 justify-center items-center bg-black bg-opacity-50"
@@ -44,45 +46,35 @@ export const DungeonSelectionModal = ({ dungeons, onSelect, onClose }: DungeonSe
         {/* Content */}
         <div className="overflow-y-auto flex-1 p-4">
           <div className="flex flex-col gap-3">
-            {dungeons.map(dungeon => {
-              const unlockTarget = dungeon.unlockRequires
-                ? dungeons.find(target => target.id === dungeon.unlockRequires)?.name ?? dungeon.unlockRequires
-                : null
-
-              return (
-                <div
-                  key={dungeon.id}
-                  className={`relative overflow-hidden bg-white rounded-xl border-2 border-gray-200 shadow-md transition-all ${
-                    dungeon.unlocked === false
-                      ? 'opacity-60 cursor-not-allowed'
-                      : 'cursor-pointer hover:border-gray-400 hover:shadow-lg'
-                  }`}
-                  onClick={() => dungeon.unlocked !== false && onSelect(dungeon)}
-                >
-                  <div className="p-3 text-white bg-gray-700">
-                    <div className="mb-1 text-sm font-bold">
-                      {dungeon.name}
-                    </div>
-                    <div className="text-xs opacity-90">{dungeon.description}</div>
+            {unlockedDungeons.map(dungeon => (
+              <div
+                key={dungeon.id}
+                className="relative overflow-hidden bg-white rounded-xl border-2 border-gray-200 shadow-md transition-all cursor-pointer hover:border-gray-400 hover:shadow-lg"
+                onClick={() => onSelect(dungeon)}
+              >
+                <div className="p-3 text-white bg-gray-700">
+                  <div className="mb-1 text-sm font-bold">
+                    {dungeon.name}
                   </div>
-                  <div className="p-3">
-                    <div className="flex justify-between mb-1 text-xs text-gray-600">
-                      <span>🏰 階層数: {dungeon.floors}階</span>
-                    </div>
-                    <div className="flex justify-between text-xs text-gray-600">
-                      <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
-                      {dungeon.cleared && <span className="font-bold text-green-600">✓ 攻略済み</span>}
-                    </div>
-                    {dungeon.unlocked === false && unlockTarget && (
-                      <div className="mt-2 text-xs text-red-600 font-semibold">
-                        🔒 {unlockTarget} を攻略すると解放
-                      </div>
-                    )}
-                  </div>
-                  {dungeon.unlocked === false && <div className="absolute inset-0 bg-white/30" />}
+                  <div className="text-xs opacity-90">{dungeon.description}</div>
                 </div>
-              )
-            })}
+                <div className="p-3">
+                  <div className="flex justify-between mb-1 text-xs text-gray-600">
+                    <span>🏰 階層数: {dungeon.floors}階</span>
+                  </div>
+                  <div className="flex justify-between text-xs text-gray-600">
+                    <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
+                    {dungeon.cleared && <span className="font-bold text-green-600">✓ 攻略済み</span>}
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            {unlockedDungeons.length === 0 && (
+              <div className="p-4 text-center text-sm text-gray-600 bg-gray-100 rounded-lg border border-gray-200">
+                解放済みのダンジョンがありません
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/goblin_web/src/presentation/components/DungeonSelectionModal.tsx
+++ b/goblin_web/src/presentation/components/DungeonSelectionModal.tsx
@@ -44,29 +44,45 @@ export const DungeonSelectionModal = ({ dungeons, onSelect, onClose }: DungeonSe
         {/* Content */}
         <div className="overflow-y-auto flex-1 p-4">
           <div className="flex flex-col gap-3">
-            {dungeons.map(dungeon => (
-              <div
-                key={dungeon.id}
-                className="overflow-hidden bg-white rounded-xl border-2 border-gray-200 shadow-md transition-all cursor-pointer hover:border-gray-400 hover:shadow-lg"
-                onClick={() => onSelect(dungeon)}
-              >
-                <div className="p-3 text-white bg-gray-700">
-                  <div className="mb-1 text-sm font-bold">
-                    {dungeon.name}
+            {dungeons.map(dungeon => {
+              const unlockTarget = dungeon.unlockRequires
+                ? dungeons.find(target => target.id === dungeon.unlockRequires)?.name ?? dungeon.unlockRequires
+                : null
+
+              return (
+                <div
+                  key={dungeon.id}
+                  className={`relative overflow-hidden bg-white rounded-xl border-2 border-gray-200 shadow-md transition-all ${
+                    dungeon.unlocked === false
+                      ? 'opacity-60 cursor-not-allowed'
+                      : 'cursor-pointer hover:border-gray-400 hover:shadow-lg'
+                  }`}
+                  onClick={() => dungeon.unlocked !== false && onSelect(dungeon)}
+                >
+                  <div className="p-3 text-white bg-gray-700">
+                    <div className="mb-1 text-sm font-bold">
+                      {dungeon.name}
+                    </div>
+                    <div className="text-xs opacity-90">{dungeon.description}</div>
                   </div>
-                  <div className="text-xs opacity-90">{dungeon.description}</div>
+                  <div className="p-3">
+                    <div className="flex justify-between mb-1 text-xs text-gray-600">
+                      <span>🏰 階層数: {dungeon.floors}階</span>
+                    </div>
+                    <div className="flex justify-between text-xs text-gray-600">
+                      <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
+                      {dungeon.cleared && <span className="font-bold text-green-600">✓ 攻略済み</span>}
+                    </div>
+                    {dungeon.unlocked === false && unlockTarget && (
+                      <div className="mt-2 text-xs text-red-600 font-semibold">
+                        🔒 {unlockTarget} を攻略すると解放
+                      </div>
+                    )}
+                  </div>
+                  {dungeon.unlocked === false && <div className="absolute inset-0 bg-white/30" />}
                 </div>
-                <div className="p-3">
-                  <div className="flex justify-between mb-1 text-xs text-gray-600">
-                    <span>🏰 階層数: {dungeon.floors}階</span>
-                  </div>
-                  <div className="flex justify-between text-xs text-gray-600">
-                    <span>⏱️ 探索時間: {formatTime(dungeon.cleared ? dungeon.exploration_time_sec : dungeon.exploration_time_sec_first)}</span>
-                    {dungeon.cleared && <span className="font-bold text-green-600">✓ 攻略済み</span>}
-                  </div>
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </div>

--- a/goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx
@@ -54,6 +54,11 @@ export const ExpeditionPreparationScreen = ({
   }, [party, dungeons])
 
   const handleDungeonSelect = (dungeon: Dungeon) => {
+    if (!dungeon.unlocked) {
+      alert('このダンジョンは未解放です')
+      return
+    }
+
     onSetDungeon(partyId, dungeon.id.toString())
     setShowDungeonModal(false)
   }

--- a/goblin_web/src/presentation/components/ExpeditionTabScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionTabScreen.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react'
 import type { Dungeon, ExpeditionRequest, ExpeditionReplay } from '../../shared/types'
-import { areasData } from '../../shared/data'
 import { DungeonScreen } from './DungeonScreen.tsx'
 import { ExpeditionSetupScreen } from './ExpeditionSetupScreen.tsx'
 import { ExpeditionPlaybackScreen } from './ExpeditionPlaybackScreen.tsx'
@@ -11,6 +10,7 @@ import { useExpeditionState } from '../contexts/ExpeditionStateContextValue.ts'
 import { usePartyService } from '../hooks/usePartyService.ts'
 import { useGoblinService } from '../hooks/useGoblinService.ts'
 import { useExpeditionFlow } from '../hooks/useExpeditionFlow.ts'
+import { useDungeonProgress } from '../hooks/useDungeonProgress.ts'
 
 export function ExpeditionTabScreen() {
   const {
@@ -32,6 +32,7 @@ export function ExpeditionTabScreen() {
     markIdle,
   } = usePartyService()
   const { goblinRepository, goblins } = useGoblinService()
+  const { dungeons, markDungeonCleared } = useDungeonProgress()
 
   const expeditionEngine = useMemo(() => new ExpeditionEngine(), [])
   const startExpeditionUseCase = useMemo(
@@ -49,6 +50,11 @@ export function ExpeditionTabScreen() {
   })
 
   const handleStartExplore = (dungeon: Dungeon) => {
+    if (!dungeon.unlocked) {
+      alert('このダンジョンは未解放です')
+      return
+    }
+
     setSelectedDungeon(dungeon)
     setIsExpeditionSetup(true)
   }
@@ -78,6 +84,11 @@ export function ExpeditionTabScreen() {
   const handleExpeditionComplete = () => {
     if (currentExpeditionPartyId !== null) {
       completeExpedition(currentExpeditionPartyId)
+    }
+
+    if (selectedDungeon && currentExpeditionReplay?.summary.success) {
+      const cleared = currentExpeditionReplay.summary.maxFloorReached >= selectedDungeon.floors
+      markDungeonCleared(selectedDungeon, cleared)
     }
 
     setShowExpeditionResult(true)
@@ -127,7 +138,7 @@ export function ExpeditionTabScreen() {
 
   return (
     <DungeonScreen
-      dungeons={areasData}
+      dungeons={dungeons}
       onStartExplore={handleStartExplore}
     />
   )

--- a/goblin_web/src/presentation/components/FormationTabScreen.tsx
+++ b/goblin_web/src/presentation/components/FormationTabScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState, useEffect } from 'react'
 import type { ExpeditionRecord, ExpeditionRequest } from '../../shared/types'
 import { PartyEditScreen } from './PartyEditScreen.tsx'
 import { FormationScreen } from './FormationScreen.tsx'
@@ -58,7 +58,8 @@ export const FormationTabScreen = () => {
     markPartyAsOnExpedition: markExpedition,
     markPartyAsIdle: markIdle,
   })
-  const { dungeons } = useDungeonProgress()
+  const { dungeons, markDungeonCleared } = useDungeonProgress()
+  const processedExpeditionsRef = useRef<Set<string>>(new Set())
   const isLoading = isPartyLoading || isGoblinLoading
 
   const handlePartySelect = (partyId: number) => {
@@ -125,6 +126,25 @@ export const FormationTabScreen = () => {
   const handleBackToPreparation = () => {
     setViewMode('preparation')
   }
+
+  // 遠征結果が表示されたら進行状況を更新
+  useEffect(() => {
+    if (viewMode !== 'result' || !selectedHistoryReplay?.replay) return
+
+    const expeditionId = selectedHistoryReplay.replay.meta.expeditionId
+    if (processedExpeditionsRef.current.has(expeditionId)) return
+
+    const dungeon = dungeons.find(d => d.id === selectedHistoryReplay.dungeonId)
+    if (!dungeon) return
+
+    const cleared = selectedHistoryReplay.replay.summary.success &&
+      selectedHistoryReplay.replay.summary.maxFloorReached >= dungeon.floors
+
+    if (cleared) {
+      markDungeonCleared(dungeon, true)
+      processedExpeditionsRef.current.add(expeditionId)
+    }
+  }, [viewMode, selectedHistoryReplay, dungeons, markDungeonCleared])
 
   const handleStartExpedition = async (request: ExpeditionRequest) => {
     const partyId = Number.parseInt(request.partyId, 10)

--- a/goblin_web/src/presentation/components/FormationTabScreen.tsx
+++ b/goblin_web/src/presentation/components/FormationTabScreen.tsx
@@ -8,10 +8,10 @@ import { ExpeditionPreparationScreen } from './ExpeditionPreparationScreen.tsx'
 import { usePartyService } from '../hooks/usePartyService.ts'
 import { useGoblinService } from '../hooks/useGoblinService.ts'
 import { useExpeditionState } from '../contexts/ExpeditionStateContextValue.ts'
-import { areasData } from '../../shared/data'
 import { ExpeditionEngine } from '../../core/services'
 import { StartExpeditionUseCase } from '../../core/usecases'
 import { useExpeditionFlow } from '../hooks/useExpeditionFlow.ts'
+import { useDungeonProgress } from '../hooks/useDungeonProgress.ts'
 
 type ViewMode = 'list' | 'preparation' | 'edit' | 'log' | 'result'
 
@@ -58,6 +58,7 @@ export const FormationTabScreen = () => {
     markPartyAsOnExpedition: markExpedition,
     markPartyAsIdle: markIdle,
   })
+  const { dungeons } = useDungeonProgress()
   const isLoading = isPartyLoading || isGoblinLoading
 
   const handlePartySelect = (partyId: number) => {
@@ -139,7 +140,7 @@ export const FormationTabScreen = () => {
         return
       }
 
-      const dungeon = areasData.find(d => d.id.toString() === party.dungeonId)
+      const dungeon = dungeons.find(d => d.id.toString() === party.dungeonId)
       if (!dungeon) {
         alert('ダンジョン情報が取得できません')
         return
@@ -184,7 +185,7 @@ export const FormationTabScreen = () => {
 
   // ログ画面表示中
   if (viewMode === 'log' && selectedHistoryReplay?.replay) {
-    const dungeon = areasData.find(d => d.id === selectedHistoryReplay.dungeonId)
+    const dungeon = dungeons.find(d => d.id === selectedHistoryReplay.dungeonId)
     return (
       <div className="flex flex-col h-full">
         <div className="flex justify-between items-center px-4 py-2 bg-gray-100 border-b border-gray-300">
@@ -218,7 +219,7 @@ export const FormationTabScreen = () => {
         partyId={editingPartyId}
         getPartyById={getPartyById}
         goblins={goblins}
-        dungeons={areasData}
+        dungeons={dungeons}
         onSetDungeon={setDungeon}
         onSetTargetFloor={setTargetFloor}
         onSetReturnPolicy={setReturnPolicy}

--- a/goblin_web/src/presentation/components/TabMenu.tsx
+++ b/goblin_web/src/presentation/components/TabMenu.tsx
@@ -1,6 +1,6 @@
 interface TabMenuProps {
-  activeTab: string
-  onTabChange: (tab: string) => void
+  activeTab: 'list' | 'formation'
+  onTabChange: (tab: 'list' | 'formation') => void
 }
 
 export const TabMenu = ({ activeTab, onTabChange }: TabMenuProps) => (
@@ -11,7 +11,7 @@ export const TabMenu = ({ activeTab, onTabChange }: TabMenuProps) => (
       }`}
       onClick={() => onTabChange('list')}
     >
-      {activeTab !== 'list' && <div className="absolute right-0 top-[15%] h-[70%] w-px bg-gray-200" />}
+      <div className="absolute right-0 top-[15%] h-[70%] w-px bg-gray-200" />
       <img src="/src/assets/list.svg" alt="リスト" className="w-8 h-8 mb-1" />
       <span className={`text-[11px] tracking-wider ${activeTab === 'list' ? 'text-gray-600 font-semibold' : 'text-gray-600 font-medium'}`}>
         リスト
@@ -24,22 +24,9 @@ export const TabMenu = ({ activeTab, onTabChange }: TabMenuProps) => (
       }`}
       onClick={() => onTabChange('formation')}
     >
-      {activeTab !== 'formation' && <div className="absolute right-0 top-[15%] h-[70%] w-px bg-gray-200" />}
       <img src="/src/assets/hensei.svg" alt="編成" className="w-8 h-8 mb-1" />
       <span className={`text-[11px] tracking-wider ${activeTab === 'formation' ? 'text-gray-600 font-semibold' : 'text-gray-600 font-medium'}`}>
         編成
-      </span>
-    </button>
-
-    <button
-      className={`flex-1 flex flex-col items-center justify-center p-2.5 transition-all border-t-[3px] ${
-        activeTab === 'expedition' ? 'bg-gray-100 border-gray-600' : 'hover:bg-gray-50 border-transparent'
-      }`}
-      onClick={() => onTabChange('expedition')}
-    >
-      <img src="/src/assets/expedition.svg" alt="遠征" className="w-8 h-8 mb-1" />
-      <span className={`text-[11px] tracking-wider ${activeTab === 'expedition' ? 'text-gray-600 font-semibold' : 'text-gray-600 font-medium'}`}>
-        遠征
       </span>
     </button>
   </div>

--- a/goblin_web/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_web/src/presentation/hooks/useDungeonProgress.ts
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import { areasData } from '../../shared/data'
 import type { Dungeon } from '../../shared/types'
+import type { DungeonProgressState } from '../../shared/types/DungeonProgress'
+import { FirestoreDungeonProgressService } from '../../infrastructure/services/FirestoreDungeonProgressService'
 
-type DungeonProgressState = Record<string, { unlocked: boolean; cleared: boolean }>
+type PersistProgress = (progress: DungeonProgressState) => void | Promise<void>
 
 const STORAGE_KEY = 'dungeon_progress'
 const listeners = new Set<(progress: DungeonProgressState) => void>()
@@ -40,16 +42,25 @@ const loadProgress = (): DungeonProgressState => {
   return cachedProgress
 }
 
-const persistProgress = (progress: DungeonProgressState) => {
+const persistProgress = (progress: DungeonProgressState, saveRemote?: PersistProgress) => {
   cachedProgress = progress
   if (typeof window !== 'undefined') {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(progress))
   }
   listeners.forEach(listener => listener(progress))
+  if (saveRemote) {
+    Promise.resolve(saveRemote(progress)).catch(error => {
+      console.warn('ダンジョン進行状況のリモート保存に失敗しました', error)
+    })
+  }
 }
 
 export const useDungeonProgress = () => {
+  const useFirestore = import.meta.env.VITE_USE_FIRESTORE === 'true'
   const [progress, setProgress] = useState<DungeonProgressState>(() => loadProgress())
+  const progressService = useMemo(() =>
+    useFirestore ? new FirestoreDungeonProgressService() : null,
+  [useFirestore])
 
   useEffect(() => {
     const handleUpdate = (next: DungeonProgressState) => setProgress(next)
@@ -57,9 +68,30 @@ export const useDungeonProgress = () => {
     return () => listeners.delete(handleUpdate)
   }, [])
 
+  // Firestore から最新の進行状況を読み込み
+  useEffect(() => {
+    if (!progressService) return
+
+    let isActive = true
+    const defaults = buildDefaultProgress()
+
+    progressService.loadProgress(defaults).then(remote => {
+      if (!isActive) return
+      cachedProgress = remote
+      setProgress(remote)
+      persistProgress(remote)
+    }).catch(error => {
+      console.warn('ダンジョン進行状況の同期に失敗しました', error)
+    })
+
+    return () => {
+      isActive = false
+    }
+  }, [progressService])
+
   const updateProgress = (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
     const next = updater(loadProgress())
-    persistProgress(next)
+    persistProgress(next, progressService ? progressService.saveProgress.bind(progressService) : undefined)
   }
 
   const markDungeonCleared = (dungeon: Dungeon, cleared: boolean) => {

--- a/goblin_web/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_web/src/presentation/hooks/useDungeonProgress.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from 'react'
+import { areasData } from '../../shared/data'
+import type { Dungeon } from '../../shared/types'
+
+type DungeonProgressState = Record<string, { unlocked: boolean; cleared: boolean }>
+
+const STORAGE_KEY = 'dungeon_progress'
+const listeners = new Set<(progress: DungeonProgressState) => void>()
+let cachedProgress: DungeonProgressState | null = null
+
+const buildDefaultProgress = (): DungeonProgressState => {
+  const defaults: DungeonProgressState = {}
+  areasData.forEach((dungeon, index) => {
+    defaults[dungeon.id] = {
+      unlocked: dungeon.unlocked ?? index === 0,
+      cleared: dungeon.cleared ?? false,
+    }
+  })
+  return defaults
+}
+
+const loadProgress = (): DungeonProgressState => {
+  if (cachedProgress) {
+    return cachedProgress
+  }
+
+  if (typeof window !== 'undefined') {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        cachedProgress = { ...buildDefaultProgress(), ...JSON.parse(saved) }
+        return cachedProgress
+      } catch (error) {
+        console.warn('ダンジョン進行状況の読み込みに失敗しました', error)
+      }
+    }
+  }
+
+  cachedProgress = buildDefaultProgress()
+  return cachedProgress
+}
+
+const persistProgress = (progress: DungeonProgressState) => {
+  cachedProgress = progress
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(progress))
+  }
+  listeners.forEach(listener => listener(progress))
+}
+
+export const useDungeonProgress = () => {
+  const [progress, setProgress] = useState<DungeonProgressState>(() => loadProgress())
+
+  useEffect(() => {
+    const handleUpdate = (next: DungeonProgressState) => setProgress(next)
+    listeners.add(handleUpdate)
+    return () => listeners.delete(handleUpdate)
+  }, [])
+
+  const updateProgress = (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
+    const next = updater(loadProgress())
+    persistProgress(next)
+  }
+
+  const markDungeonCleared = (dungeon: Dungeon, cleared: boolean) => {
+    updateProgress(prev => {
+      const nextProgress: DungeonProgressState = { ...prev }
+      const current = nextProgress[dungeon.id] ?? { unlocked: dungeon.unlocked ?? false, cleared: false }
+      nextProgress[dungeon.id] = { ...current, unlocked: true, cleared: cleared || current.cleared }
+
+      if (cleared && dungeon.unlockNext) {
+        const target = nextProgress[dungeon.unlockNext] ?? { unlocked: false, cleared: false }
+        nextProgress[dungeon.unlockNext] = { ...target, unlocked: true }
+      }
+
+      return nextProgress
+    })
+  }
+
+  const dungeons: Dungeon[] = useMemo(() => areasData.map(dungeon => ({
+    ...dungeon,
+    cleared: progress[dungeon.id]?.cleared ?? dungeon.cleared ?? false,
+    unlocked: progress[dungeon.id]?.unlocked ?? dungeon.unlocked ?? false,
+  })), [progress])
+
+  return {
+    dungeons,
+    progress,
+    updateProgress,
+    markDungeonCleared,
+  }
+}

--- a/goblin_web/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_web/src/presentation/hooks/useExpeditionFlow.ts
@@ -77,10 +77,10 @@ export const useExpeditionFlow = ({
           )
         }
 
+        const replay = await startExpeditionUseCase.execute(request)
+
         setPartyExpeditionStatus(partyId, 'expedition')
         markPartyAsOnExpedition(partyId)
-
-        const replay = await startExpeditionUseCase.execute(request)
 
         if (expeditionRecord && expeditionRepository) {
           await expeditionRepository.updateExpeditionReplay(expeditionRecord.id, replay)

--- a/goblin_web/src/shared/data/areas.ts
+++ b/goblin_web/src/shared/data/areas.ts
@@ -2,6 +2,39 @@ import type { AreaConfig } from '../types'
 
 export const areasConfig: AreaConfig[] = [
   {
+    id: "slime_cave",
+    name: "スライムの洞窟",
+    floors: 2,
+    baseDurationSec: 45,
+    moveSpeedScale: 1.1,
+    encounter: {
+      perFloorEvents: 2,
+      eventWeights: {
+        battle: 80,
+        resource: 15,
+        trap: 0,
+        npc: 5
+      },
+      pityTimerSec: 3
+    },
+    enemyTable: [
+      { id: "tutorial_slime", weight: 80, lvl: 1 },
+      { id: "sticky_slime", weight: 20, lvl: 2 }
+    ],
+    boss: { id: "slime_mother", lvl: 3 },
+    rewards: {
+      xpFloor: [4, 6],
+      xpBoss: 15,
+      lootPool: [
+        { id: "slime_core", w: 50 },
+        { id: "healing_herb", w: 30 },
+        { id: "forest_gem", w: 20 }
+      ],
+      captureBonus: 0.12
+    },
+    unlockNext: "forest_outskirts"
+  },
+  {
     id: "forest_outskirts",
     name: "周辺の森",
     floors: 3,
@@ -114,6 +147,9 @@ export const areasConfig: AreaConfig[] = [
 
 // 敵データの定義
 export const enemyDatabase = {
+  "tutorial_slime": { name: "スライム", baseHP: 12, baseATK: 5, baseDEF: 2 },
+  "sticky_slime": { name: "ぷるぷるスライム", baseHP: 16, baseATK: 6, baseDEF: 3 },
+  "slime_mother": { name: "大きなスライム", baseHP: 40, baseATK: 8, baseDEF: 5 },
   "slime": { name: "スライム", baseHP: 20, baseATK: 8, baseDEF: 3 },
   "goblin_scout": { name: "ゴブリン斥候", baseHP: 25, baseATK: 12, baseDEF: 5 },
   "forest_wolf": { name: "森の狼", baseHP: 35, baseATK: 15, baseDEF: 8 },

--- a/goblin_web/src/shared/data/enemy/slime_cave.json
+++ b/goblin_web/src/shared/data/enemy/slime_cave.json
@@ -14,19 +14,6 @@
       "gold": 3
     },
     {
-      "id": "S002",
-      "name": "ぷるぷるスライム",
-      "raceTags": ["slime"],
-      "level": 2,
-      "hp": 12,
-      "atk": 3,
-      "def": 2,
-      "spd": 3,
-      "sp": 0,
-      "exp": 5,
-      "gold": 5
-    },
-    {
       "id": "B_SLIME",
       "name": "大きなスライム",
       "raceTags": ["slime"],
@@ -44,22 +31,22 @@
     {
       "id": "SP001",
       "floors": [1, 2],
-      "enemies": ["S001", "S001", "S001"]
+      "enemies": ["S001"]
     },
     {
       "id": "SP002",
       "floors": [1, 2],
-      "enemies": ["S001", "S002"]
+      "enemies": ["S001", "S001"]
     },
     {
       "id": "SP003",
       "floors": [1, 2],
-      "enemies": ["S002", "S002", "S001"]
+      "enemies": ["S001", "S001", "S001"]
     },
     {
       "id": "SBOSS",
       "floors": [2],
-      "enemies": ["B_SLIME"],
+      "enemies": ["S001", "S001", "B_SLIME"],
       "isBoss": true
     }
   ]

--- a/goblin_web/src/shared/data/enemy/slime_cave.json
+++ b/goblin_web/src/shared/data/enemy/slime_cave.json
@@ -1,0 +1,66 @@
+{
+  "enemies": [
+    {
+      "id": "S001",
+      "name": "スライム",
+      "raceTags": ["slime"],
+      "level": 1,
+      "hp": 8,
+      "atk": 2,
+      "def": 1,
+      "spd": 2,
+      "sp": 0,
+      "exp": 3,
+      "gold": 3
+    },
+    {
+      "id": "S002",
+      "name": "ぷるぷるスライム",
+      "raceTags": ["slime"],
+      "level": 2,
+      "hp": 12,
+      "atk": 3,
+      "def": 2,
+      "spd": 3,
+      "sp": 0,
+      "exp": 5,
+      "gold": 5
+    },
+    {
+      "id": "B_SLIME",
+      "name": "大きなスライム",
+      "raceTags": ["slime"],
+      "level": 3,
+      "hp": 30,
+      "atk": 6,
+      "def": 4,
+      "spd": 3,
+      "sp": 0,
+      "exp": 12,
+      "gold": 10
+    }
+  ],
+  "patterns": [
+    {
+      "id": "SP001",
+      "floors": [1, 2],
+      "enemies": ["S001", "S001", "S001"]
+    },
+    {
+      "id": "SP002",
+      "floors": [1, 2],
+      "enemies": ["S001", "S002"]
+    },
+    {
+      "id": "SP003",
+      "floors": [1, 2],
+      "enemies": ["S002", "S002", "S001"]
+    },
+    {
+      "id": "SBOSS",
+      "floors": [2],
+      "enemies": ["B_SLIME"],
+      "isBoss": true
+    }
+  ]
+}

--- a/goblin_web/src/shared/data/expeditionArea/allArea.json
+++ b/goblin_web/src/shared/data/expeditionArea/allArea.json
@@ -1,12 +1,23 @@
 {
   "areas": [
     {
+      "id": "slime_cave",
+      "name": "スライムの洞窟",
+      "floors": 2,
+      "exploration_time_sec_first": 45,
+      "exploration_time_sec": 25,
+      "description": "スライムだけが出現する入門用の洞窟。ゴブリン1体でも攻略可能。",
+      "unlockNext": "forest_outskirts",
+      "unlocked": true
+    },
+    {
       "id": "forest_outskirts",
       "name": "周辺の森",
       "floors": 3,
       "exploration_time_sec_first": 60,
       "exploration_time_sec": 30,
-      "description": "明るい森、弱い獣や小鬼が出現"
+      "description": "明るい森、弱い獣や小鬼が出現",
+      "unlockRequires": "slime_cave"
     }
   ]
 }

--- a/goblin_web/src/shared/data/expeditionArea/slime_cave.json
+++ b/goblin_web/src/shared/data/expeditionArea/slime_cave.json
@@ -1,0 +1,26 @@
+{
+  "id": "slime_cave",
+  "name": "スライムの洞窟",
+  "floors": 2,
+  "baseDurationSec": 45,
+  "description": "スライムのみが出現するチュートリアルダンジョン。",
+  "encounter": {
+    "perFloorEvents": 2,
+    "eventWeights": {
+      "battle": 70,
+      "resource": 20,
+      "exploring": 10
+    }
+  },
+  "rewards": {
+    "xpFloor": [4, 6],
+    "xpBoss": 12,
+    "lootPool": [
+      { "id": "slime_core", "name": "スライムコア", "w": 60, "rarity": 1 },
+      { "id": "healing_herb", "name": "回復草", "w": 30, "rarity": 1 },
+      { "id": "forest_gem", "name": "森の宝石", "w": 10, "rarity": 2 }
+    ],
+    "captureBonus": 0.1
+  },
+  "unlockNext": "forest_outskirts"
+}

--- a/goblin_web/src/shared/types/Dungeon.ts
+++ b/goblin_web/src/shared/types/Dungeon.ts
@@ -6,7 +6,9 @@ export type Dungeon = {
   exploration_time_sec: number
   description: string
   cleared?: boolean
+  unlocked?: boolean
   icon?: string
   difficulty?: string
   unlockNext?: string
+  unlockRequires?: string
 }

--- a/goblin_web/src/shared/types/DungeonProgress.ts
+++ b/goblin_web/src/shared/types/DungeonProgress.ts
@@ -1,0 +1,1 @@
+export type DungeonProgressState = Record<string, { unlocked: boolean; cleared: boolean }>


### PR DESCRIPTION
## 概要
- チュートリアルダンジョン「スライムの洞窟」を追加し、周辺の森の解放条件を紐付け
- ダンジョン進行状況をローカル保存するフックを導入し、クリア時に次エリアが解放されるように更新
- 選択画面とモーダルで未解放状態を明示し、解放済みのみ選択できるようにガード

## テスト
- 未実施（依頼なし）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b94dac108333b3153239e299b02f)