### PR TITLE
feat: ゴブリン詳細画面に追放機能を追加

### DIFF
--- a/goblin_web/src/presentation/components/GoblinDetailModal.tsx
+++ b/goblin_web/src/presentation/components/GoblinDetailModal.tsx
@@ -21,6 +21,7 @@ export const GoblinDetailModal = ({
 }: GoblinDetailModalProps) => {
   const [items, setItems] = useState<Item[]>([])
   const [currentGoblin, setCurrentGoblin] = useState<Goblin | null>(goblin)
+  const [showBanishConfirm, setShowBanishConfirm] = useState(false)
   const equipItemUseCase = useMemo(
     () => new EquipItemUseCase(goblinRepository, itemRepository),
     [goblinRepository, itemRepository]
@@ -72,6 +73,13 @@ export const GoblinDetailModal = ({
       const updatedGoblin = goblinRepository.getGoblin(currentGoblin.id)
       setCurrentGoblin(initializeEquipment(updatedGoblin))
     }
+  }
+
+  const handleBanish = () => {
+    if (!currentGoblin) return
+    goblinRepository.deleteGoblin(currentGoblin.id)
+    setShowBanishConfirm(false)
+    onClose()
   }
 
   if (!currentGoblin) return null
@@ -200,8 +208,44 @@ export const GoblinDetailModal = ({
             </div>
           </div>
           )}
+
+          <div className="mt-6">
+            <button
+              onClick={() => setShowBanishConfirm(true)}
+              className="w-full py-3 text-white bg-red-600 rounded-lg font-bold hover:bg-red-700 transition-colors"
+            >
+              このゴブリンを追放する
+            </button>
+          </div>
         </div>
       </div>
+
+      {showBanishConfirm && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 max-w-sm mx-4 shadow-2xl">
+            <h3 className="text-xl font-bold text-gray-800 mb-4">追放の確認</h3>
+            <p className="text-gray-600 mb-6">
+              本当に <span className="font-bold text-gray-800">{currentGoblin.name}</span> を追放しますか？
+              <br />
+              この操作は取り消せません。
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowBanishConfirm(false)}
+                className="flex-1 py-2 text-gray-700 bg-gray-200 rounded-lg font-bold hover:bg-gray-300 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleBanish}
+                className="flex-1 py-2 text-white bg-red-600 rounded-lg font-bold hover:bg-red-700 transition-colors"
+              >
+                追放する
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ゴブリン詳細画面に追放ボタンを追加
- 追放確認ダイアログを実装
- `goblinRepository.deleteGoblin()` を使用してFirestoreから削除

## 変更内容
- 装備セクションの下に「このゴブリンを追放する」ボタンを配置
- 追放ボタンクリック時に確認ダイアログを表示
- 確認ダイアログにはゴブリン名と「取り消せません」という警告を表示
- 「追放する」ボタンで実際に削除を実行し、モーダルを閉じる

## Test plan
- [ ] ゴブリン詳細画面を開いて追放ボタンが表示されることを確認
- [ ] 追放ボタンをクリックして確認ダイアログが表示されることを確認
- [ ] キャンセルボタンで追放がキャンセルされることを確認
- [ ] 追放するボタンでゴブリンが削除され、一覧から消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)