### PR TITLE
feat: Phase 5-6 SQLite連携とUI実装

### DIFF
--- a/goblin_native/app.json
+++ b/goblin_native/app.json
@@ -31,7 +31,8 @@
       "bundler": "metro"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-sqlite"
     ],
     "experiments": {
       "typedRoutes": true

--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -1,111 +1,161 @@
-import { useState } from 'react'
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Modal } from 'react-native'
+import { useState, useCallback } from 'react'
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Modal, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-
-// Sample pending goblins
-const pendingGoblins = [
-  { id: 101, name: 'Newcomer Gob', level: 1, stats: { hp: 15, atk: 5, def: 3, spd: 8 } },
-  { id: 102, name: 'Lost Goblin', level: 2, stats: { hp: 20, atk: 7, def: 4, spd: 9 } },
-]
+import { useBaseState } from '@/presentation/hooks/useBaseState'
+import { usePendingGoblins } from '@/presentation/hooks/usePendingGoblins'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import type { Goblin } from '@/shared/types'
 
 export default function BaseManagementScreen() {
-  const [baseLevel] = useState(3)
-  const [resources] = useState({ gold: 1250, food: 45 })
-  const [selectedGoblin, setSelectedGoblin] = useState<typeof pendingGoblins[0] | null>(null)
-  const [modalVisible, setModalVisible] = useState(false)
+  const { baseState, isLoading: baseLoading, rank, capacity, upgradeRank } = useBaseState()
+  const { pendingGoblins, isLoading: pendingLoading, removePendingGoblin } = usePendingGoblins()
+  const { goblins, saveGoblin } = useGoblinService()
 
-  const handleAcceptGoblin = (goblin: typeof pendingGoblins[0]) => {
+  const [selectedGoblin, setSelectedGoblin] = useState<Goblin | null>(null)
+  const [modalVisible, setModalVisible] = useState(false)
+  const [upgradeModalVisible, setUpgradeModalVisible] = useState(false)
+
+  const currentGoblinCount = goblins.length
+  const canAcceptMore = currentGoblinCount < capacity
+
+  const handleAcceptGoblin = useCallback((goblin: Goblin) => {
+    if (!canAcceptMore) return
     setSelectedGoblin(goblin)
     setModalVisible(true)
-  }
+  }, [canAcceptMore])
 
-  const handleConfirmAccept = () => {
-    // TODO: Implement accept logic
-    console.log('Accepted goblin:', selectedGoblin?.name)
+  const handleConfirmAccept = useCallback(() => {
+    if (!selectedGoblin) return
+
+    // ゴブリンを正式に受け入れ（goblinsテーブルに追加）
+    saveGoblin(selectedGoblin)
+    // 待機リストから削除
+    removePendingGoblin(selectedGoblin.id)
+
     setModalVisible(false)
     setSelectedGoblin(null)
+  }, [selectedGoblin, saveGoblin, removePendingGoblin])
+
+  const handleUpgradeBase = useCallback(() => {
+    setUpgradeModalVisible(true)
+  }, [])
+
+  const handleConfirmUpgrade = useCallback(() => {
+    upgradeRank()
+    setUpgradeModalVisible(false)
+  }, [upgradeRank])
+
+  if (baseLoading || pendingLoading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3B82F6" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    )
   }
 
   return (
-    <ScrollView style={styles.container}>
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Base Status</Text>
-        <View style={styles.card}>
-          <View style={styles.baseInfo}>
-            <Text style={styles.baseLevelLabel}>Base Level</Text>
-            <Text style={styles.baseLevelValue}>{baseLevel}</Text>
-          </View>
-          <View style={styles.resourcesContainer}>
-            <View style={styles.resourceItem}>
-              <Text style={styles.resourceValue}>{resources.gold}</Text>
-              <Text style={styles.resourceLabel}>Gold</Text>
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollView}>
+        {/* 拠点ステータス */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>拠点ステータス</Text>
+          <View style={styles.card}>
+            <View style={styles.baseInfo}>
+              <Text style={styles.baseLevelLabel}>拠点ランク</Text>
+              <Text style={styles.baseLevelValue}>{rank}</Text>
             </View>
-            <View style={styles.resourceItem}>
-              <Text style={styles.resourceValue}>{resources.food}</Text>
-              <Text style={styles.resourceLabel}>Food</Text>
-            </View>
-          </View>
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Pending Goblins</Text>
-        <Text style={styles.sectionSubtitle}>New goblins waiting to join your kingdom</Text>
-        {pendingGoblins.length > 0 ? (
-          pendingGoblins.map((goblin) => (
-            <View key={goblin.id} style={styles.pendingCard}>
-              <View style={styles.pendingInfo}>
-                <View style={styles.goblinIcon}>
-                  <Text style={styles.goblinIconText}>?</Text>
-                </View>
-                <View style={styles.goblinDetails}>
-                  <Text style={styles.goblinName}>{goblin.name}</Text>
-                  <Text style={styles.goblinStats}>
-                    Lv.{goblin.level} | HP:{goblin.stats.hp} ATK:{goblin.stats.atk}
-                  </Text>
-                </View>
+            <View style={styles.capacityContainer}>
+              <Text style={styles.capacityLabel}>収容人数</Text>
+              <Text style={styles.capacityValue}>
+                {currentGoblinCount} / {capacity}
+              </Text>
+              <View style={styles.capacityBar}>
+                <View
+                  style={[
+                    styles.capacityFill,
+                    { width: `${Math.min((currentGoblinCount / capacity) * 100, 100)}%` }
+                  ]}
+                />
               </View>
-              <TouchableOpacity
-                style={styles.acceptButton}
-                onPress={() => handleAcceptGoblin(goblin)}
-              >
-                <Text style={styles.acceptButtonText}>Accept</Text>
-              </TouchableOpacity>
             </View>
-          ))
-        ) : (
-          <View style={styles.emptyState}>
-            <Text style={styles.emptyStateText}>No pending goblins at the moment</Text>
+            <TouchableOpacity
+              style={styles.upgradeButton}
+              onPress={handleUpgradeBase}
+            >
+              <Text style={styles.upgradeButtonText}>拠点をアップグレード</Text>
+            </TouchableOpacity>
           </View>
-        )}
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Facilities</Text>
-        <View style={styles.facilitiesGrid}>
-          <TouchableOpacity style={styles.facilityCard}>
-            <Text style={styles.facilityIcon}>T</Text>
-            <Text style={styles.facilityName}>Training</Text>
-            <Text style={styles.facilityLevel}>Lv.2</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.facilityCard}>
-            <Text style={styles.facilityIcon}>S</Text>
-            <Text style={styles.facilityName}>Smithy</Text>
-            <Text style={styles.facilityLevel}>Lv.1</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.facilityCard}>
-            <Text style={styles.facilityIcon}>F</Text>
-            <Text style={styles.facilityName}>Farm</Text>
-            <Text style={styles.facilityLevel}>Lv.3</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.facilityCard}>
-            <Text style={styles.facilityIcon}>M</Text>
-            <Text style={styles.facilityName}>Market</Text>
-            <Text style={styles.facilityLevel}>Lv.1</Text>
-          </TouchableOpacity>
         </View>
-      </View>
 
+        {/* 待機中ゴブリン */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>待機中ゴブリン</Text>
+          <Text style={styles.sectionSubtitle}>拠点への参加を待っているゴブリン</Text>
+          {pendingGoblins.length > 0 ? (
+            pendingGoblins.map((goblin) => (
+              <View key={goblin.id} style={styles.pendingCard}>
+                <View style={styles.pendingInfo}>
+                  <View style={styles.goblinIcon}>
+                    <Text style={styles.goblinIconText}>?</Text>
+                  </View>
+                  <View style={styles.goblinDetails}>
+                    <Text style={styles.goblinName}>{goblin.name}</Text>
+                    <Text style={styles.goblinStats}>
+                      Lv.{goblin.level} | HP:{goblin.stats.hp} ATK:{goblin.stats.atk} DEF:{goblin.stats.def}
+                    </Text>
+                    {goblin.race && (
+                      <Text style={styles.goblinRace}>{goblin.race}</Text>
+                    )}
+                  </View>
+                </View>
+                <TouchableOpacity
+                  style={[
+                    styles.acceptButton,
+                    !canAcceptMore && styles.acceptButtonDisabled
+                  ]}
+                  onPress={() => handleAcceptGoblin(goblin)}
+                  disabled={!canAcceptMore}
+                >
+                  <Text style={styles.acceptButtonText}>
+                    {canAcceptMore ? '受け入れ' : '満員'}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            ))
+          ) : (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyStateIcon}>-</Text>
+              <Text style={styles.emptyStateText}>待機中のゴブリンはいません</Text>
+            </View>
+          )}
+        </View>
+
+        {/* 現在のゴブリン一覧 */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>所属ゴブリン ({currentGoblinCount})</Text>
+          <View style={styles.goblinListContainer}>
+            {goblins.slice(0, 6).map((goblin) => (
+              <View key={goblin.id} style={styles.goblinMiniCard}>
+                <View style={styles.goblinMiniAvatar}>
+                  <Text style={styles.goblinMiniAvatarText}>G</Text>
+                </View>
+                <Text style={styles.goblinMiniName} numberOfLines={1}>{goblin.name}</Text>
+                <Text style={styles.goblinMiniLevel}>Lv.{goblin.level}</Text>
+              </View>
+            ))}
+            {goblins.length > 6 && (
+              <View style={styles.goblinMiniCard}>
+                <Text style={styles.moreText}>+{goblins.length - 6}</Text>
+              </View>
+            )}
+          </View>
+        </View>
+      </ScrollView>
+
+      {/* ゴブリン受け入れ確認モーダル */}
       <Modal
         visible={modalVisible}
         animationType="fade"
@@ -114,13 +164,31 @@ export default function BaseManagementScreen() {
       >
         <View style={styles.modalOverlay}>
           <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>Accept Goblin?</Text>
+            <Text style={styles.modalTitle}>ゴブリンを受け入れますか？</Text>
             {selectedGoblin && (
               <>
                 <Text style={styles.modalGoblinName}>{selectedGoblin.name}</Text>
                 <Text style={styles.modalStats}>
-                  Level {selectedGoblin.level} - HP:{selectedGoblin.stats.hp} ATK:{selectedGoblin.stats.atk} DEF:{selectedGoblin.stats.def}
+                  Lv.{selectedGoblin.level}
                 </Text>
+                <View style={styles.modalStatsGrid}>
+                  <View style={styles.modalStatItem}>
+                    <Text style={styles.modalStatValue}>{selectedGoblin.stats.hp}</Text>
+                    <Text style={styles.modalStatLabel}>HP</Text>
+                  </View>
+                  <View style={styles.modalStatItem}>
+                    <Text style={styles.modalStatValue}>{selectedGoblin.stats.atk}</Text>
+                    <Text style={styles.modalStatLabel}>ATK</Text>
+                  </View>
+                  <View style={styles.modalStatItem}>
+                    <Text style={styles.modalStatValue}>{selectedGoblin.stats.def}</Text>
+                    <Text style={styles.modalStatLabel}>DEF</Text>
+                  </View>
+                  <View style={styles.modalStatItem}>
+                    <Text style={styles.modalStatValue}>{selectedGoblin.stats.spd}</Text>
+                    <Text style={styles.modalStatLabel}>SPD</Text>
+                  </View>
+                </View>
               </>
             )}
             <View style={styles.modalButtons}>
@@ -128,23 +196,70 @@ export default function BaseManagementScreen() {
                 style={styles.modalCancelButton}
                 onPress={() => setModalVisible(false)}
               >
-                <Text style={styles.modalCancelText}>Cancel</Text>
+                <Text style={styles.modalCancelText}>キャンセル</Text>
               </TouchableOpacity>
               <TouchableOpacity style={styles.modalConfirmButton} onPress={handleConfirmAccept}>
-                <Text style={styles.modalConfirmText}>Accept</Text>
+                <Text style={styles.modalConfirmText}>受け入れる</Text>
               </TouchableOpacity>
             </View>
           </View>
         </View>
       </Modal>
-    </ScrollView>
+
+      {/* アップグレード確認モーダル */}
+      <Modal
+        visible={upgradeModalVisible}
+        animationType="fade"
+        transparent
+        onRequestClose={() => setUpgradeModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>拠点をアップグレード</Text>
+            <Text style={styles.upgradeInfo}>
+              ランク {rank} → {rank + 1}
+            </Text>
+            <Text style={styles.upgradeEffect}>
+              収容人数: {capacity} → {capacity + 4}
+            </Text>
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={styles.modalCancelButton}
+                onPress={() => setUpgradeModalVisible(false)}
+              >
+                <Text style={styles.modalCancelText}>キャンセル</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalConfirmButton, styles.upgradeConfirmButton]}
+                onPress={handleConfirmUpgrade}
+              >
+                <Text style={styles.modalConfirmText}>アップグレード</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: '#1F2937',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#9CA3AF',
+  },
+  scrollView: {
+    flex: 1,
   },
   section: {
     padding: 16,
@@ -152,23 +267,19 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: '#FFFFFF',
     marginBottom: 4,
   },
   sectionSubtitle: {
     fontSize: 14,
-    color: '#6B7280',
+    color: '#9CA3AF',
     marginBottom: 12,
   },
   card: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
+    backgroundColor: '#374151',
+    borderRadius: 16,
     padding: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
+    marginTop: 8,
   },
   baseInfo: {
     alignItems: 'center',
@@ -176,32 +287,51 @@ const styles = StyleSheet.create({
   },
   baseLevelLabel: {
     fontSize: 14,
-    color: '#6B7280',
+    color: '#9CA3AF',
   },
   baseLevelValue: {
-    fontSize: 48,
+    fontSize: 56,
     fontWeight: 'bold',
     color: '#3B82F6',
   },
-  resourcesContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
+  capacityContainer: {
+    marginBottom: 16,
   },
-  resourceItem: {
+  capacityLabel: {
+    fontSize: 14,
+    color: '#9CA3AF',
+    marginBottom: 4,
+  },
+  capacityValue: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#FFFFFF',
+    marginBottom: 8,
+  },
+  capacityBar: {
+    height: 8,
+    backgroundColor: '#4B5563',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  capacityFill: {
+    height: '100%',
+    backgroundColor: '#10B981',
+    borderRadius: 4,
+  },
+  upgradeButton: {
+    backgroundColor: '#3B82F6',
+    padding: 14,
+    borderRadius: 10,
     alignItems: 'center',
   },
-  resourceValue: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#1F2937',
-  },
-  resourceLabel: {
-    fontSize: 14,
-    color: '#6B7280',
-    marginTop: 4,
+  upgradeButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FFFFFF',
   },
   pendingCard: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#374151',
     borderRadius: 12,
     padding: 16,
     flexDirection: 'row',
@@ -209,7 +339,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginBottom: 12,
     borderWidth: 2,
-    borderColor: '#FCD34D',
+    borderColor: '#F59E0B',
     borderStyle: 'dashed',
   },
   pendingInfo: {
@@ -237,12 +367,17 @@ const styles = StyleSheet.create({
   goblinName: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#1F2937',
+    color: '#FFFFFF',
   },
   goblinStats: {
     fontSize: 12,
-    color: '#6B7280',
+    color: '#9CA3AF',
     marginTop: 4,
+  },
+  goblinRace: {
+    fontSize: 11,
+    color: '#6B7280',
+    marginTop: 2,
   },
   acceptButton: {
     backgroundColor: '#10B981',
@@ -250,102 +385,160 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 8,
   },
+  acceptButtonDisabled: {
+    backgroundColor: '#6B7280',
+  },
   acceptButtonText: {
     fontSize: 14,
     fontWeight: '600',
     color: '#FFFFFF',
   },
   emptyState: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#374151',
     borderRadius: 12,
     padding: 32,
     alignItems: 'center',
+  },
+  emptyStateIcon: {
+    fontSize: 32,
+    color: '#6B7280',
+    marginBottom: 8,
   },
   emptyStateText: {
     fontSize: 14,
     color: '#9CA3AF',
   },
-  facilitiesGrid: {
+  goblinListContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginHorizontal: -6,
+    gap: 8,
+    marginTop: 8,
   },
-  facilityCard: {
-    width: '50%',
-    padding: 6,
+  goblinMiniCard: {
+    backgroundColor: '#374151',
+    borderRadius: 8,
+    padding: 12,
+    alignItems: 'center',
+    width: 80,
   },
-  facilityIcon: {
-    fontSize: 32,
-    fontWeight: 'bold',
-    color: '#3B82F6',
-    marginBottom: 8,
+  goblinMiniAvatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: '#10B981',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 4,
   },
-  facilityName: {
+  goblinMiniAvatarText: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#1F2937',
+    fontWeight: 'bold',
+    color: '#FFFFFF',
   },
-  facilityLevel: {
-    fontSize: 12,
-    color: '#6B7280',
-    marginTop: 4,
+  goblinMiniName: {
+    fontSize: 11,
+    color: '#FFFFFF',
+    textAlign: 'center',
+  },
+  goblinMiniLevel: {
+    fontSize: 10,
+    color: '#9CA3AF',
+    marginTop: 2,
+  },
+  moreText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#9CA3AF',
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
     justifyContent: 'center',
     alignItems: 'center',
   },
   modalContent: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: '#374151',
     borderRadius: 16,
     padding: 24,
-    width: '80%',
+    width: '85%',
     alignItems: 'center',
   },
   modalTitle: {
     fontSize: 20,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: '#FFFFFF',
     marginBottom: 16,
   },
   modalGoblinName: {
-    fontSize: 18,
-    fontWeight: '600',
+    fontSize: 24,
+    fontWeight: 'bold',
     color: '#10B981',
     marginBottom: 8,
   },
   modalStats: {
     fontSize: 14,
-    color: '#6B7280',
+    color: '#9CA3AF',
+    marginBottom: 16,
+  },
+  modalStatsGrid: {
+    flexDirection: 'row',
+    gap: 16,
     marginBottom: 24,
+  },
+  modalStatItem: {
+    alignItems: 'center',
+  },
+  modalStatValue: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+  },
+  modalStatLabel: {
+    fontSize: 12,
+    color: '#9CA3AF',
+    marginTop: 2,
   },
   modalButtons: {
     flexDirection: 'row',
     gap: 12,
+    width: '100%',
   },
   modalCancelButton: {
     flex: 1,
-    backgroundColor: '#E5E7EB',
-    paddingVertical: 12,
-    borderRadius: 8,
+    backgroundColor: '#4B5563',
+    paddingVertical: 14,
+    borderRadius: 10,
     alignItems: 'center',
   },
   modalCancelText: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#4B5563',
+    color: '#FFFFFF',
   },
   modalConfirmButton: {
     flex: 1,
     backgroundColor: '#10B981',
-    paddingVertical: 12,
-    borderRadius: 8,
+    paddingVertical: 14,
+    borderRadius: 10,
     alignItems: 'center',
+  },
+  upgradeConfirmButton: {
+    backgroundColor: '#3B82F6',
   },
   modalConfirmText: {
     fontSize: 16,
     fontWeight: '600',
     color: '#FFFFFF',
+  },
+  upgradeInfo: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#3B82F6',
+    marginBottom: 8,
+  },
+  upgradeEffect: {
+    fontSize: 16,
+    color: '#10B981',
+    marginBottom: 24,
   },
 })

--- a/goblin_native/app/(tabs)/formation/edit.tsx
+++ b/goblin_native/app/(tabs)/formation/edit.tsx
@@ -1,50 +1,154 @@
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native'
+import { useState, useCallback, useMemo } from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator, TextInput, Alert } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import type { Goblin } from '@/shared/types'
 
-const availableGoblins = [
-  { id: 1, name: 'Goburo', level: 5, selected: true },
-  { id: 2, name: 'Gobichi', level: 3, selected: true },
-  { id: 3, name: 'Gobimi', level: 7, selected: false },
-]
+const MAX_PARTY_SIZE = 4
 
 export default function PartyEditScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { parties, isLoading: partiesLoading, updateMembers, getPartyById } = usePartyService()
+  const { goblins, isLoading: goblinsLoading } = useGoblinService()
 
-  const handleSave = () => {
+  const party = useMemo(() => {
+    if (!partyId) return null
+    return getPartyById(parseInt(partyId, 10))
+  }, [partyId, parties, getPartyById])
+
+  const [selectedIds, setSelectedIds] = useState<number[]>(() => party?.memberIds || [])
+  const [partyName, setPartyName] = useState(() => party?.name || '')
+
+  // 他のパーティに所属しているゴブリンIDを取得
+  const assignedToOtherParty = useMemo(() => {
+    const ids = new Set<number>()
+    parties.forEach(p => {
+      if (p.id !== parseInt(partyId || '0', 10)) {
+        p.memberIds.forEach(id => ids.add(id))
+      }
+    })
+    return ids
+  }, [parties, partyId])
+
+  const handleToggleGoblin = useCallback((goblinId: number) => {
+    setSelectedIds(prev => {
+      if (prev.includes(goblinId)) {
+        return prev.filter(id => id !== goblinId)
+      }
+      if (prev.length >= MAX_PARTY_SIZE) {
+        Alert.alert('上限に達しています', `パーティメンバーは最大${MAX_PARTY_SIZE}人までです`)
+        return prev
+      }
+      return [...prev, goblinId]
+    })
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (!partyId) return
+
+    if (selectedIds.length === 0) {
+      Alert.alert('メンバーを選択してください', 'パーティには最低1人のメンバーが必要です')
+      return
+    }
+
+    updateMembers(parseInt(partyId, 10), selectedIds)
     router.back()
+  }, [partyId, selectedIds, updateMembers])
+
+  if (partiesLoading || goblinsLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#3B82F6" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    )
+  }
+
+  if (!party) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorText}>パーティが見つかりません</Text>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <Text style={styles.backButtonText}>戻る</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  const renderGoblinItem = ({ item }: { item: Goblin }) => {
+    const isSelected = selectedIds.includes(item.id)
+    const isAssignedElsewhere = assignedToOtherParty.has(item.id)
+
+    return (
+      <TouchableOpacity
+        style={[
+          styles.goblinItem,
+          isSelected && styles.goblinSelected,
+          isAssignedElsewhere && styles.goblinDisabled,
+        ]}
+        onPress={() => !isAssignedElsewhere && handleToggleGoblin(item.id)}
+        disabled={isAssignedElsewhere}
+      >
+        <View style={styles.goblinIcon}>
+          <Text style={styles.goblinIconText}>G</Text>
+        </View>
+        <View style={styles.goblinInfo}>
+          <Text style={[styles.goblinName, isAssignedElsewhere && styles.disabledText]}>
+            {item.name}
+          </Text>
+          <Text style={[styles.goblinLevel, isAssignedElsewhere && styles.disabledText]}>
+            Lv.{item.level} | HP:{item.stats.hp} ATK:{item.stats.atk}
+          </Text>
+          {isAssignedElsewhere && (
+            <Text style={styles.assignedText}>他のパーティに所属中</Text>
+          )}
+        </View>
+        <View style={[styles.checkbox, isSelected && styles.checkboxSelected]}>
+          {isSelected && <Text style={styles.checkmark}>✓</Text>}
+        </View>
+      </TouchableOpacity>
+    )
   }
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Edit Party #{partyId}</Text>
-      <Text style={styles.subtitle}>Select members for your party</Text>
+      <View style={styles.header}>
+        <Text style={styles.title}>パーティ編集</Text>
+        <TextInput
+          style={styles.nameInput}
+          value={partyName}
+          onChangeText={setPartyName}
+          placeholder="パーティ名"
+        />
+      </View>
 
-      <FlatList
-        data={availableGoblins}
-        keyExtractor={(item) => String(item.id)}
-        renderItem={({ item }) => (
-          <TouchableOpacity
-            style={[styles.goblinItem, item.selected && styles.goblinSelected]}
-          >
-            <View style={styles.goblinInfo}>
-              <Text style={styles.goblinName}>{item.name}</Text>
-              <Text style={styles.goblinLevel}>Lv.{item.level}</Text>
-            </View>
-            <View style={[styles.checkbox, item.selected && styles.checkboxSelected]}>
-              {item.selected && <Text style={styles.checkmark}>V</Text>}
-            </View>
-          </TouchableOpacity>
-        )}
-        contentContainerStyle={styles.listContent}
-        ItemSeparatorComponent={() => <View style={styles.separator} />}
-      />
+      <View style={styles.selectionInfo}>
+        <Text style={styles.selectionText}>
+          メンバー: {selectedIds.length} / {MAX_PARTY_SIZE}
+        </Text>
+      </View>
+
+      {goblins.length === 0 ? (
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>利用可能なゴブリンがいません</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={goblins}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderGoblinItem}
+          contentContainerStyle={styles.listContent}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+        />
+      )}
 
       <View style={styles.buttonContainer}>
         <TouchableOpacity style={styles.cancelButton} onPress={() => router.back()}>
-          <Text style={styles.cancelButtonText}>Cancel</Text>
+          <Text style={styles.cancelButtonText}>キャンセル</Text>
         </TouchableOpacity>
         <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
-          <Text style={styles.saveButtonText}>Save</Text>
+          <Text style={styles.saveButtonText}>保存</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -56,18 +160,78 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#F9FAFB',
   },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  errorText: {
+    fontSize: 18,
+    color: '#EF4444',
+    marginBottom: 16,
+  },
+  backButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: '#3B82F6',
+    borderRadius: 8,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  header: {
+    backgroundColor: '#FFFFFF',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
     color: '#1F2937',
-    padding: 16,
-    paddingBottom: 4,
+    marginBottom: 12,
   },
-  subtitle: {
+  nameInput: {
+    fontSize: 16,
+    padding: 12,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  selectionInfo: {
+    padding: 16,
+    backgroundColor: '#EFF6FF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#DBEAFE',
+  },
+  selectionText: {
     fontSize: 14,
+    fontWeight: '600',
+    color: '#1D4ED8',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  emptyText: {
+    fontSize: 16,
     color: '#6B7280',
-    paddingHorizontal: 16,
-    paddingBottom: 16,
   },
   listContent: {
     padding: 16,
@@ -81,13 +245,30 @@ const styles = StyleSheet.create({
     padding: 16,
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
     borderWidth: 2,
     borderColor: '#E5E7EB',
   },
   goblinSelected: {
     borderColor: '#3B82F6',
     backgroundColor: '#EFF6FF',
+  },
+  goblinDisabled: {
+    opacity: 0.5,
+    backgroundColor: '#F3F4F6',
+  },
+  goblinIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#10B981',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  goblinIconText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
   },
   goblinInfo: {
     flex: 1,
@@ -100,7 +281,15 @@ const styles = StyleSheet.create({
   goblinLevel: {
     fontSize: 14,
     color: '#6B7280',
-    marginTop: 4,
+    marginTop: 2,
+  },
+  disabledText: {
+    color: '#9CA3AF',
+  },
+  assignedText: {
+    fontSize: 12,
+    color: '#EF4444',
+    marginTop: 2,
   },
   checkbox: {
     width: 24,
@@ -118,11 +307,15 @@ const styles = StyleSheet.create({
   checkmark: {
     color: '#FFFFFF',
     fontWeight: 'bold',
+    fontSize: 14,
   },
   buttonContainer: {
     flexDirection: 'row',
     padding: 16,
     gap: 12,
+    backgroundColor: '#FFFFFF',
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
   },
   cancelButton: {
     flex: 1,

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -1,39 +1,26 @@
-import { useState } from 'react'
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native'
+import { useCallback } from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator, Alert } from 'react-native'
 import { router } from 'expo-router'
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import type { Party, PartyStatus } from '@/shared/types'
-
-// Sample data for demonstration
-const sampleParties: Party[] = [
-  {
-    id: 1,
-    name: 'Alpha Squad',
-    memberIds: [1, 2],
-    status: 'idle' as PartyStatus,
-    dungeonId: '1',
-    targetFloor: null,
-    returnPolicy: 'never',
-  },
-  {
-    id: 2,
-    name: 'Bravo Team',
-    memberIds: [3],
-    status: 'idle' as PartyStatus,
-    dungeonId: '2',
-    targetFloor: 3,
-    returnPolicy: 'if_any_ko',
-  },
-]
 
 interface PartyCardProps {
   party: Party
+  memberCount: number
   onPress: () => void
+  onEdit: () => void
 }
 
-function PartyCard({ party, onPress }: PartyCardProps) {
+function PartyCard({ party, memberCount, onPress, onEdit }: PartyCardProps) {
   const statusColors: Record<PartyStatus, string> = {
     idle: '#10B981',
     expedition: '#3B82F6',
+  }
+
+  const statusLabels: Record<PartyStatus, string> = {
+    idle: '待機中',
+    expedition: '遠征中',
   }
 
   const status = party.status ?? 'idle'
@@ -43,13 +30,29 @@ function PartyCard({ party, onPress }: PartyCardProps) {
       <View style={styles.cardHeader}>
         <Text style={styles.partyName}>{party.name}</Text>
         <View style={[styles.statusBadge, { backgroundColor: statusColors[status] }]}>
-          <Text style={styles.statusText}>{status}</Text>
+          <Text style={styles.statusText}>{statusLabels[status]}</Text>
         </View>
       </View>
       <View style={styles.cardBody}>
-        <Text style={styles.memberCount}>Members: {party.memberIds.length}</Text>
+        <Text style={styles.memberCount}>メンバー: {memberCount}人</Text>
         {party.dungeonId && (
-          <Text style={styles.dungeonInfo}>Dungeon: {party.dungeonId}</Text>
+          <Text style={styles.dungeonInfo}>ダンジョン: {party.dungeonId}</Text>
+        )}
+      </View>
+      <View style={styles.cardActions}>
+        <TouchableOpacity
+          style={styles.editButton}
+          onPress={(e) => {
+            e.stopPropagation?.()
+            onEdit()
+          }}
+        >
+          <Text style={styles.editButtonText}>編集</Text>
+        </TouchableOpacity>
+        {status === 'idle' && (
+          <TouchableOpacity style={styles.expeditionButton} onPress={onPress}>
+            <Text style={styles.expeditionButtonText}>遠征準備</Text>
+          </TouchableOpacity>
         )}
       </View>
     </TouchableOpacity>
@@ -57,18 +60,62 @@ function PartyCard({ party, onPress }: PartyCardProps) {
 }
 
 export default function FormationScreen() {
-  const [parties] = useState<Party[]>(sampleParties)
+  const { parties, isLoading, createParty } = usePartyService()
+  const { goblins, isLoading: goblinsLoading } = useGoblinService()
 
-  const handlePartyPress = (party: Party) => {
+  const handlePartyPress = useCallback((party: Party) => {
+    const status = party.status ?? 'idle'
+    if (status === 'expedition') {
+      // 遠征中のパーティはプレイバック画面へ
+      router.push({
+        pathname: '/formation/playback',
+        params: { partyId: party.id.toString() },
+      })
+    } else {
+      // 待機中のパーティは遠征準備画面へ
+      router.push({
+        pathname: '/formation/preparation',
+        params: { partyId: party.id.toString() },
+      })
+    }
+  }, [])
+
+  const handleEditPress = useCallback((party: Party) => {
     router.push({
-      pathname: '/formation/preparation',
+      pathname: '/formation/edit',
       params: { partyId: party.id.toString() },
     })
-  }
+  }, [])
 
-  const handleCreateParty = () => {
-    // TODO: Implement party creation
-    console.log('Create new party')
+  const handleCreateParty = useCallback(() => {
+    if (goblins.length === 0) {
+      Alert.alert('ゴブリンがいません', 'パーティを作成するにはゴブリンが必要です')
+      return
+    }
+
+    // 次のパーティIDを推定（createPartyが内部で計算するが、遷移用に必要）
+    const maxId = parties.reduce((max, p) => Math.max(max, p.id), 0)
+    const expectedNewId = maxId + 1
+
+    const created = createParty({
+      name: `パーティ ${expectedNewId}`,
+      memberIds: [],
+    })
+
+    // 作成後に編集画面へ遷移
+    router.push({
+      pathname: '/formation/edit',
+      params: { partyId: created.id.toString() },
+    })
+  }, [parties, goblins.length, createParty])
+
+  if (isLoading || goblinsLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#3B82F6" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    )
   }
 
   return (
@@ -77,14 +124,27 @@ export default function FormationScreen() {
         data={parties}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
-          <PartyCard party={item} onPress={() => handlePartyPress(item)} />
+          <PartyCard
+            party={item}
+            memberCount={item.memberIds.length}
+            onPress={() => handlePartyPress(item)}
+            onEdit={() => handleEditPress(item)}
+          />
         )}
         contentContainerStyle={styles.listContent}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
         ListHeaderComponent={() => (
           <TouchableOpacity style={styles.createButton} onPress={handleCreateParty}>
-            <Text style={styles.createButtonText}>+ Create New Party</Text>
+            <Text style={styles.createButtonText}>+ 新しいパーティを作成</Text>
           </TouchableOpacity>
+        )}
+        ListEmptyComponent={() => (
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyTitle}>パーティがありません</Text>
+            <Text style={styles.emptyDescription}>
+              上のボタンから新しいパーティを作成しましょう
+            </Text>
+          </View>
         )}
       />
     </View>
@@ -95,6 +155,32 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#F9FAFB',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  emptyContainer: {
+    padding: 32,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  emptyDescription: {
+    fontSize: 14,
+    color: '#6B7280',
+    textAlign: 'center',
   },
   listContent: {
     padding: 16,
@@ -132,11 +218,11 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '600',
     color: '#FFFFFF',
-    textTransform: 'uppercase',
   },
   cardBody: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    marginBottom: 12,
   },
   memberCount: {
     fontSize: 14,
@@ -145,6 +231,33 @@ const styles = StyleSheet.create({
   dungeonInfo: {
     fontSize: 14,
     color: '#6B7280',
+  },
+  cardActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+  },
+  editButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#E5E7EB',
+  },
+  editButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+  },
+  expeditionButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#3B82F6',
+  },
+  expeditionButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#FFFFFF',
   },
   createButton: {
     backgroundColor: '#3B82F6',

--- a/goblin_native/app/(tabs)/formation/log.tsx
+++ b/goblin_native/app/(tabs)/formation/log.tsx
@@ -1,54 +1,142 @@
-import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native'
+import { useMemo, useCallback } from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
 
-// Sample log data
-const sampleLog = [
-  { time: '00:00', event: 'Party enters Forest Outskirts' },
-  { time: '00:05', event: 'Arrived at Floor 1' },
-  { time: '00:10', event: 'Encountered Slime x2' },
-  { time: '00:15', event: 'Goburo attacks Slime for 12 damage' },
-  { time: '00:16', event: 'Gobichi attacks Slime for 8 damage' },
-  { time: '00:17', event: 'Slime defeated!' },
-  { time: '00:20', event: 'Victory! Gained 25 EXP' },
-  { time: '00:30', event: 'Found treasure chest containing Health Potion' },
-  { time: '00:35', event: 'Arrived at Floor 2' },
-  { time: '00:40', event: 'Encountered Wolf x1' },
-  { time: '00:45', event: 'Goburo attacks Wolf for 15 damage' },
-  { time: '00:46', event: 'Wolf attacks Gobichi for 5 damage' },
-  { time: '00:47', event: 'Gobichi attacks Wolf for 10 damage' },
-  { time: '00:48', event: 'Wolf defeated!' },
-  { time: '00:50', event: 'Victory! Gained 40 EXP' },
-  { time: '01:00', event: 'Arrived at Floor 3' },
-  { time: '01:05', event: 'Boss encountered: Giant Slime' },
-  { time: '01:10', event: 'Goburo uses Power Strike for 25 damage' },
-  { time: '01:12', event: 'Giant Slime attacks party for 8 damage' },
-  { time: '01:15', event: 'Gobichi heals party for 10 HP' },
-  { time: '01:20', event: 'Goburo attacks for 12 damage' },
-  { time: '01:22', event: 'Giant Slime defeated!' },
-  { time: '01:25', event: 'Expedition Complete! Found Iron Sword' },
-]
+interface LogEntry {
+  time: string
+  event: string
+  type: 'move' | 'battle' | 'item' | 'victory' | 'defeat' | 'info'
+}
+
+// イベントタイプに基づいて色を返す
+const getEventColor = (type: LogEntry['type']): string => {
+  switch (type) {
+    case 'move':
+      return '#3B82F6'
+    case 'battle':
+      return '#EF4444'
+    case 'item':
+      return '#F59E0B'
+    case 'victory':
+      return '#10B981'
+    case 'defeat':
+      return '#DC2626'
+    case 'info':
+    default:
+      return '#6B7280'
+  }
+}
 
 export default function ExpeditionLogScreen() {
-  const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { partyId, dungeonId } = useLocalSearchParams<{ partyId: string; dungeonId?: string }>()
 
-  const handleBack = () => {
+  const { getPartyById } = usePartyService()
+  const { dungeons } = useDungeonProgress()
+
+  const party = useMemo(() => {
+    if (!partyId) return null
+    return getPartyById(parseInt(partyId, 10))
+  }, [partyId, getPartyById])
+
+  const dungeon = useMemo(() => {
+    const id = dungeonId || party?.dungeonId
+    return dungeons.find(d => d.id === id)
+  }, [dungeons, dungeonId, party?.dungeonId])
+
+  // サンプルログデータ（将来的にはExpeditionRepositoryから取得）
+  const logEntries: LogEntry[] = useMemo(() => {
+    if (!dungeon) return []
+
+    const entries: LogEntry[] = []
+    const floors = dungeon.floors || 3
+
+    entries.push({
+      time: '00:00',
+      event: `${dungeon.name}への遠征を開始`,
+      type: 'move',
+    })
+
+    for (let floor = 1; floor <= floors; floor++) {
+      const baseTime = floor * 10
+      entries.push({
+        time: `00:${String(baseTime).padStart(2, '0')}`,
+        event: `${floor}階に到達`,
+        type: 'move',
+      })
+
+      // ランダムなイベントをシミュレート
+      entries.push({
+        time: `00:${String(baseTime + 2).padStart(2, '0')}`,
+        event: '敵と遭遇！',
+        type: 'battle',
+      })
+
+      entries.push({
+        time: `00:${String(baseTime + 5).padStart(2, '0')}`,
+        event: '戦闘に勝利！経験値を獲得',
+        type: 'victory',
+      })
+
+      if (floor % 2 === 0) {
+        entries.push({
+          time: `00:${String(baseTime + 7).padStart(2, '0')}`,
+          event: '宝箱を発見！',
+          type: 'item',
+        })
+      }
+    }
+
+    entries.push({
+      time: `00:${String(floors * 10 + 10).padStart(2, '0')}`,
+      event: 'ボスと遭遇！',
+      type: 'battle',
+    })
+
+    entries.push({
+      time: `00:${String(floors * 10 + 15).padStart(2, '0')}`,
+      event: 'ボスを撃破！ダンジョン踏破',
+      type: 'victory',
+    })
+
+    return entries
+  }, [dungeon])
+
+  const handleBack = useCallback(() => {
     router.back()
+  }, [])
+
+  if (!party) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3B82F6" />
+        </View>
+      </SafeAreaView>
+    )
   }
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Expedition Log</Text>
-        <Text style={styles.subtitle}>Party #{partyId}</Text>
+        <Text style={styles.title}>遠征ログ</Text>
+        <Text style={styles.subtitle}>
+          {party.name} → {dungeon?.name || '不明'}
+        </Text>
       </View>
 
       <FlatList
-        data={sampleLog}
+        data={logEntries}
         keyExtractor={(_, index) => String(index)}
         renderItem={({ item }) => (
           <View style={styles.logItem}>
-            <Text style={styles.logTime}>{item.time}</Text>
-            <Text style={styles.logEvent}>{item.event}</Text>
+            <View style={[styles.logDot, { backgroundColor: getEventColor(item.type) }]} />
+            <View style={styles.logContent}>
+              <Text style={styles.logTime}>{item.time}</Text>
+              <Text style={styles.logEvent}>{item.event}</Text>
+            </View>
           </View>
         )}
         contentContainerStyle={styles.listContent}
@@ -56,59 +144,75 @@ export default function ExpeditionLogScreen() {
       />
 
       <TouchableOpacity style={styles.backButton} onPress={handleBack}>
-        <Text style={styles.backButtonText}>Back to Results</Text>
+        <Text style={styles.backButtonText}>戻る</Text>
       </TouchableOpacity>
-    </View>
+    </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: '#1F2937',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   header: {
-    padding: 16,
-    backgroundColor: '#FFFFFF',
+    padding: 20,
+    backgroundColor: '#111827',
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: '#374151',
   },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: '#FFFFFF',
   },
   subtitle: {
     fontSize: 14,
-    color: '#6B7280',
+    color: '#9CA3AF',
     marginTop: 4,
   },
   listContent: {
     padding: 16,
   },
   separator: {
-    height: 8,
+    height: 4,
   },
   logItem: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 8,
-    padding: 12,
+    backgroundColor: '#374151',
+    borderRadius: 10,
+    padding: 14,
     flexDirection: 'row',
-    alignItems: 'flex-start',
+    alignItems: 'center',
+  },
+  logDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginRight: 12,
+  },
+  logContent: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   logTime: {
     fontSize: 12,
     fontWeight: '600',
-    color: '#6B7280',
+    color: '#9CA3AF',
     width: 50,
   },
   logEvent: {
     fontSize: 14,
-    color: '#1F2937',
+    color: '#FFFFFF',
     flex: 1,
   },
   backButton: {
-    backgroundColor: '#3B82F6',
+    backgroundColor: '#374151',
     margin: 16,
     padding: 16,
     borderRadius: 12,

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -1,66 +1,226 @@
-import { useState, useEffect, useRef } from 'react'
-import { View, Text, StyleSheet, Animated, TouchableOpacity } from 'react-native'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
+import type { TimelineEvent, Goblin } from '@/shared/types'
 
-// Simulated expedition events
-const sampleEvents = [
-  { time: 0, type: 'move_start', message: 'Party enters the dungeon...' },
-  { time: 1000, type: 'floor_arrive', message: 'Arrived at Floor 1' },
-  { time: 2000, type: 'encounter', message: 'Encountered Slime x2!' },
-  { time: 3000, type: 'battle', message: 'Battle in progress...' },
-  { time: 4000, type: 'victory', message: 'Victory! Gained 50 EXP' },
-  { time: 5000, type: 'floor_arrive', message: 'Arrived at Floor 2' },
-  { time: 6000, type: 'treasure', message: 'Found a treasure chest!' },
-  { time: 7000, type: 'floor_arrive', message: 'Arrived at Floor 3' },
-  { time: 8000, type: 'boss', message: 'Boss appeared: Giant Slime!' },
-  { time: 9000, type: 'battle', message: 'Epic battle!' },
-  { time: 10000, type: 'complete', message: 'Expedition Complete!' },
-]
+interface DisplayEvent {
+  type: string
+  message: string
+  color: string
+  icon: string
+}
 
 export default function ExpeditionPlaybackScreen() {
-  const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { partyId, dungeonId, returnPolicy } = useLocalSearchParams<{
+    partyId: string
+    dungeonId: string
+    returnPolicy: string
+  }>()
+
+  const { getPartyById, markExpedition, markIdle } = usePartyService()
+  const { goblins } = useGoblinService()
+  const { dungeons } = useDungeonProgress()
+
+  const party = useMemo(() => {
+    if (!partyId) return null
+    return getPartyById(parseInt(partyId, 10))
+  }, [partyId, getPartyById])
+
+  const dungeon = useMemo(() => {
+    const id = dungeonId || party?.dungeonId
+    return dungeons.find(d => d.id === id)
+  }, [dungeons, dungeonId, party?.dungeonId])
+
+  const partyMembers = useMemo(() => {
+    if (!party) return []
+    return party.memberIds
+      .map(id => goblins.find(g => g.id === id))
+      .filter((g): g is Goblin => g !== undefined)
+  }, [party, goblins])
+
+  const [events, setEvents] = useState<DisplayEvent[]>([])
   const [currentEventIndex, setCurrentEventIndex] = useState(0)
   const [isComplete, setIsComplete] = useState(false)
+  const [expeditionResult, setExpeditionResult] = useState<{
+    success: boolean
+    xpGained: number
+    maxFloor: number
+  } | null>(null)
+
   const progressAnim = useRef(new Animated.Value(0)).current
 
+  // 遠征イベントをシミュレート
   useEffect(() => {
-    // Start progress animation
+    if (!dungeon || !party || partyMembers.length === 0) return
+
+    // パーティを遠征状態に設定
+    markExpedition(party.id)
+
+    const floors = dungeon.floors
+    const generatedEvents: DisplayEvent[] = []
+
+    // 開始イベント
+    generatedEvents.push({
+      type: 'move_start',
+      message: `${dungeon.name}への遠征を開始...`,
+      color: '#6B7280',
+      icon: '>',
+    })
+
+    // 各階層のイベントを生成
+    for (let floor = 1; floor <= floors; floor++) {
+      generatedEvents.push({
+        type: 'floor_arrive',
+        message: `${floor}階に到着`,
+        color: '#3B82F6',
+        icon: 'F',
+      })
+
+      // ランダムなイベント
+      const eventRoll = Math.random()
+      if (eventRoll < 0.7) {
+        // 戦闘
+        generatedEvents.push({
+          type: 'encounter',
+          message: `敵と遭遇！`,
+          color: '#F59E0B',
+          icon: '!',
+        })
+        generatedEvents.push({
+          type: 'battle',
+          message: '戦闘中...',
+          color: '#EF4444',
+          icon: 'X',
+        })
+        generatedEvents.push({
+          type: 'victory',
+          message: `勝利！経験値を獲得`,
+          color: '#10B981',
+          icon: 'V',
+        })
+      } else if (eventRoll < 0.9) {
+        // 探索
+        generatedEvents.push({
+          type: 'exploring',
+          message: '探索中...',
+          color: '#8B5CF6',
+          icon: '?',
+        })
+      }
+    }
+
+    // ボス戦
+    generatedEvents.push({
+      type: 'boss',
+      message: `ボス出現！`,
+      color: '#DC2626',
+      icon: 'B',
+    })
+    generatedEvents.push({
+      type: 'battle',
+      message: '激闘中...',
+      color: '#EF4444',
+      icon: 'X',
+    })
+
+    // 結果（80%の確率で成功）
+    const success = Math.random() < 0.8
+    if (success) {
+      generatedEvents.push({
+        type: 'complete',
+        message: 'ダンジョン踏破！',
+        color: '#10B981',
+        icon: '*',
+      })
+    } else {
+      generatedEvents.push({
+        type: 'return',
+        message: '撤退...',
+        color: '#EF4444',
+        icon: '<',
+      })
+    }
+
+    setEvents(generatedEvents)
+    setExpeditionResult({
+      success,
+      xpGained: floors * 50 + (success ? 100 : 0),
+      maxFloor: success ? floors : Math.floor(floors * 0.7),
+    })
+
+    // プログレスアニメーション
+    const duration = generatedEvents.length * 800
     Animated.timing(progressAnim, {
       toValue: 1,
-      duration: 10000,
+      duration,
       useNativeDriver: false,
     }).start()
 
-    // Event progression
+    // イベント進行
+    let eventIndex = 0
     const interval = setInterval(() => {
-      setCurrentEventIndex((prev) => {
-        if (prev < sampleEvents.length - 1) {
-          return prev + 1
-        }
+      if (eventIndex < generatedEvents.length - 1) {
+        eventIndex++
+        setCurrentEventIndex(eventIndex)
+      } else {
         setIsComplete(true)
+        markIdle(party.id)
         clearInterval(interval)
-        return prev
-      })
-    }, 1000)
+      }
+    }, 800)
 
-    return () => clearInterval(interval)
-  }, [])
+    return () => {
+      clearInterval(interval)
+      if (party) {
+        markIdle(party.id)
+      }
+    }
+  }, [dungeon, party, partyMembers.length])
 
-  const handleViewResults = () => {
+  const handleViewResults = useCallback(() => {
     router.replace({
       pathname: '/formation/result',
-      params: { partyId },
+      params: {
+        partyId,
+        dungeonId: dungeonId || party?.dungeonId || '',
+        success: expeditionResult?.success ? 'true' : 'false',
+        xpGained: String(expeditionResult?.xpGained || 0),
+        maxFloor: String(expeditionResult?.maxFloor || 0),
+      },
     })
+  }, [partyId, dungeonId, party?.dungeonId, expeditionResult])
+
+  if (!party || !dungeon) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3B82F6" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    )
   }
 
-  const currentEvent = sampleEvents[currentEventIndex]
+  const currentEvent = events[currentEventIndex]
 
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Expedition in Progress</Text>
-        <Text style={styles.subtitle}>Party #{partyId}</Text>
+        <Text style={styles.title}>遠征中</Text>
+        <Text style={styles.subtitle}>{party.name} → {dungeon.name}</Text>
+      </View>
+
+      <View style={styles.partyInfo}>
+        {partyMembers.map(member => (
+          <View key={member.id} style={styles.memberBadge}>
+            <Text style={styles.memberIcon}>G</Text>
+            <Text style={styles.memberName}>{member.name}</Text>
+          </View>
+        ))}
       </View>
 
       <View style={styles.progressContainer}>
@@ -77,64 +237,50 @@ export default function ExpeditionPlaybackScreen() {
         />
       </View>
 
-      <View style={styles.eventContainer}>
-        <View style={[styles.eventIcon, { backgroundColor: getEventColor(currentEvent.type) }]}>
-          <Text style={styles.eventIconText}>{getEventIcon(currentEvent.type)}</Text>
+      {currentEvent && (
+        <View style={styles.eventContainer}>
+          <View style={[styles.eventIcon, { backgroundColor: currentEvent.color }]}>
+            <Text style={styles.eventIconText}>{currentEvent.icon}</Text>
+          </View>
+          <Text style={styles.eventMessage}>{currentEvent.message}</Text>
         </View>
-        <Text style={styles.eventMessage}>{currentEvent.message}</Text>
-      </View>
+      )}
 
       <View style={styles.eventLog}>
-        <Text style={styles.logTitle}>Event Log</Text>
-        {sampleEvents.slice(0, currentEventIndex + 1).reverse().map((event, index) => (
-          <View key={index} style={styles.logItem}>
-            <View style={[styles.logDot, { backgroundColor: getEventColor(event.type) }]} />
-            <Text style={styles.logText}>{event.message}</Text>
-          </View>
-        ))}
+        <Text style={styles.logTitle}>イベントログ</Text>
+        <ScrollView style={styles.logScroll}>
+          {events.slice(0, currentEventIndex + 1).reverse().map((event, index) => (
+            <View key={index} style={styles.logItem}>
+              <View style={[styles.logDot, { backgroundColor: event.color }]} />
+              <Text style={styles.logText}>{event.message}</Text>
+            </View>
+          ))}
+        </ScrollView>
       </View>
 
       {isComplete && (
         <TouchableOpacity style={styles.resultButton} onPress={handleViewResults}>
-          <Text style={styles.resultButtonText}>View Results</Text>
+          <Text style={styles.resultButtonText}>結果を見る</Text>
         </TouchableOpacity>
       )}
     </SafeAreaView>
   )
 }
 
-function getEventColor(type: string): string {
-  const colors: Record<string, string> = {
-    move_start: '#6B7280',
-    floor_arrive: '#3B82F6',
-    encounter: '#F59E0B',
-    battle: '#EF4444',
-    victory: '#10B981',
-    treasure: '#8B5CF6',
-    boss: '#DC2626',
-    complete: '#10B981',
-  }
-  return colors[type] || '#6B7280'
-}
-
-function getEventIcon(type: string): string {
-  const icons: Record<string, string> = {
-    move_start: '>',
-    floor_arrive: 'F',
-    encounter: '!',
-    battle: 'X',
-    victory: 'V',
-    treasure: '$',
-    boss: 'B',
-    complete: '*',
-  }
-  return icons[type] || '?'
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#1F2937',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#9CA3AF',
   },
   header: {
     padding: 20,
@@ -149,6 +295,31 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#9CA3AF',
     marginTop: 4,
+  },
+  partyInfo: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+    marginBottom: 16,
+    gap: 8,
+  },
+  memberBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#374151',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    gap: 4,
+  },
+  memberIcon: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#10B981',
+  },
+  memberName: {
+    fontSize: 12,
+    color: '#FFFFFF',
   },
   progressContainer: {
     height: 8,
@@ -197,6 +368,9 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#9CA3AF',
     marginBottom: 12,
+  },
+  logScroll: {
+    flex: 1,
   },
   logItem: {
     flexDirection: 'row',

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -1,78 +1,204 @@
-import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native'
+import { useState, useCallback, useMemo } from 'react'
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator, Alert } from 'react-native'
 import { router, useLocalSearchParams } from 'expo-router'
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
+import type { ExpeditionRequest, Goblin, Dungeon } from '@/shared/types'
+
+type ReturnPolicy = ExpeditionRequest['returnPolicy']
+
+const RETURN_POLICIES: { value: ReturnPolicy; label: string; description: string }[] = [
+  { value: 'never', label: '最後まで探索', description: '目標階に到達するまで探索を続けます' },
+  { value: 'until_floor2', label: '2階で帰還', description: '2階に到達したら帰還します' },
+  { value: 'until_floor3', label: '3階で帰還', description: '3階に到達したら帰還します' },
+  { value: 'if_any_ko', label: '誰かが倒れたら', description: 'パーティの誰かが倒れたら帰還します' },
+  { value: 'last_one', label: '最後の1人まで', description: '最後の1人になるまで探索を続けます' },
+]
 
 export default function ExpeditionPreparationScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { parties, isLoading: partiesLoading, getPartyById, setDungeon, setReturnPolicy } = usePartyService()
+  const { goblins, isLoading: goblinsLoading } = useGoblinService()
+  const { dungeons, isLoading: dungeonsLoading } = useDungeonProgress()
 
-  const handleEditParty = () => {
+  const party = useMemo(() => {
+    if (!partyId) return null
+    return getPartyById(parseInt(partyId, 10))
+  }, [partyId, parties, getPartyById])
+
+  const [selectedDungeonId, setSelectedDungeonId] = useState<string | undefined>(party?.dungeonId)
+  const [selectedReturnPolicy, setSelectedReturnPolicy] = useState<ReturnPolicy>(party?.returnPolicy ?? 'never')
+
+  const partyMembers = useMemo(() => {
+    if (!party) return []
+    return party.memberIds
+      .map(id => goblins.find(g => g.id === id))
+      .filter((g): g is Goblin => g !== undefined)
+  }, [party, goblins])
+
+  const unlockedDungeons = useMemo(() => {
+    return dungeons.filter(d => d.unlocked)
+  }, [dungeons])
+
+  const selectedDungeon = useMemo(() => {
+    return dungeons.find(d => d.id === selectedDungeonId)
+  }, [dungeons, selectedDungeonId])
+
+  const handleEditParty = useCallback(() => {
     router.push({
       pathname: '/formation/edit',
       params: { partyId },
     })
-  }
+  }, [partyId])
 
-  const handleStartExpedition = () => {
+  const handleSelectDungeon = useCallback((dungeon: Dungeon) => {
+    setSelectedDungeonId(dungeon.id)
+    if (partyId) {
+      setDungeon(parseInt(partyId, 10), dungeon.id)
+    }
+  }, [partyId, setDungeon])
+
+  const handleSelectReturnPolicy = useCallback((policy: ReturnPolicy) => {
+    setSelectedReturnPolicy(policy)
+    if (partyId) {
+      setReturnPolicy(parseInt(partyId, 10), policy)
+    }
+  }, [partyId, setReturnPolicy])
+
+  const handleStartExpedition = useCallback(() => {
+    if (!selectedDungeonId) {
+      Alert.alert('ダンジョンを選択してください', '遠征先のダンジョンを選択する必要があります')
+      return
+    }
+
+    if (partyMembers.length === 0) {
+      Alert.alert('メンバーがいません', 'パーティにメンバーを追加してください')
+      return
+    }
+
+    // TODO: 遠征を開始し、プレイバック画面へ遷移
     router.push({
       pathname: '/formation/playback',
-      params: { partyId },
+      params: {
+        partyId,
+        dungeonId: selectedDungeonId,
+        returnPolicy: selectedReturnPolicy,
+      },
     })
+  }, [partyId, selectedDungeonId, selectedReturnPolicy, partyMembers.length])
+
+  if (partiesLoading || goblinsLoading || dungeonsLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#10B981" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    )
   }
 
-  const handleBack = () => {
-    router.back()
+  if (!party) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorText}>パーティが見つかりません</Text>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <Text style={styles.backButtonText}>戻る</Text>
+        </TouchableOpacity>
+      </View>
+    )
   }
 
   return (
     <ScrollView style={styles.container}>
+      {/* パーティメンバー */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Party #{partyId}</Text>
+        <Text style={styles.sectionTitle}>{party.name}</Text>
         <View style={styles.card}>
-          <Text style={styles.cardText}>Party members will be displayed here</Text>
+          {partyMembers.length === 0 ? (
+            <Text style={styles.emptyText}>メンバーがいません</Text>
+          ) : (
+            <View style={styles.membersGrid}>
+              {partyMembers.map(member => (
+                <View key={member.id} style={styles.memberItem}>
+                  <View style={styles.memberIcon}>
+                    <Text style={styles.memberIconText}>G</Text>
+                  </View>
+                  <Text style={styles.memberName}>{member.name}</Text>
+                  <Text style={styles.memberLevel}>Lv.{member.level}</Text>
+                </View>
+              ))}
+            </View>
+          )}
           <TouchableOpacity style={styles.editButton} onPress={handleEditParty}>
-            <Text style={styles.editButtonText}>Edit Members</Text>
+            <Text style={styles.editButtonText}>メンバー編集</Text>
           </TouchableOpacity>
         </View>
       </View>
 
+      {/* ダンジョン選択 */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Dungeon Selection</Text>
+        <Text style={styles.sectionTitle}>ダンジョン選択</Text>
         <View style={styles.card}>
-          <TouchableOpacity style={styles.dungeonOption}>
-            <Text style={styles.dungeonName}>Forest Outskirts</Text>
-            <Text style={styles.dungeonInfo}>Floors: 3 | Difficulty: Easy</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.dungeonOption}>
-            <Text style={styles.dungeonName}>Mossy Cave</Text>
-            <Text style={styles.dungeonInfo}>Floors: 5 | Difficulty: Normal</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.dungeonOption}>
-            <Text style={styles.dungeonName}>Old Mine</Text>
-            <Text style={styles.dungeonInfo}>Floors: 7 | Difficulty: Hard</Text>
-          </TouchableOpacity>
+          {unlockedDungeons.length === 0 ? (
+            <Text style={styles.emptyText}>解放済みのダンジョンがありません</Text>
+          ) : (
+            unlockedDungeons.map(dungeon => (
+              <TouchableOpacity
+                key={dungeon.id}
+                style={[
+                  styles.dungeonOption,
+                  selectedDungeonId === dungeon.id && styles.dungeonSelected,
+                ]}
+                onPress={() => handleSelectDungeon(dungeon)}
+              >
+                <View style={styles.dungeonHeader}>
+                  <Text style={styles.dungeonName}>{dungeon.name}</Text>
+                  {dungeon.cleared && (
+                    <View style={styles.clearedBadge}>
+                      <Text style={styles.clearedText}>クリア済</Text>
+                    </View>
+                  )}
+                </View>
+                <Text style={styles.dungeonInfo}>
+                  階層: {dungeon.floors} | 難易度: {dungeon.difficulty || '?'}
+                </Text>
+              </TouchableOpacity>
+            ))
+          )}
         </View>
       </View>
 
+      {/* 帰還ポリシー */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Return Policy</Text>
+        <Text style={styles.sectionTitle}>帰還ポリシー</Text>
         <View style={styles.card}>
-          <TouchableOpacity style={[styles.policyOption, styles.policySelected]}>
-            <Text style={styles.policyName}>Never Retreat</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.policyOption}>
-            <Text style={styles.policyName}>If Any KO</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.policyOption}>
-            <Text style={styles.policyName}>Last One Standing</Text>
-          </TouchableOpacity>
+          {RETURN_POLICIES.map(policy => (
+            <TouchableOpacity
+              key={policy.value}
+              style={[
+                styles.policyOption,
+                selectedReturnPolicy === policy.value && styles.policySelected,
+              ]}
+              onPress={() => handleSelectReturnPolicy(policy.value)}
+            >
+              <Text style={styles.policyName}>{policy.label}</Text>
+              <Text style={styles.policyDescription}>{policy.description}</Text>
+            </TouchableOpacity>
+          ))}
         </View>
       </View>
 
+      {/* 遠征開始ボタン */}
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
-          <Text style={styles.backButtonText}>Back</Text>
+        <TouchableOpacity style={styles.cancelButton} onPress={() => router.back()}>
+          <Text style={styles.cancelButtonText}>戻る</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.startButton} onPress={handleStartExpedition}>
-          <Text style={styles.startButtonText}>Start Expedition</Text>
+        <TouchableOpacity
+          style={[styles.startButton, (!selectedDungeonId || partyMembers.length === 0) && styles.startButtonDisabled]}
+          onPress={handleStartExpedition}
+          disabled={!selectedDungeonId || partyMembers.length === 0}
+        >
+          <Text style={styles.startButtonText}>遠征開始</Text>
         </TouchableOpacity>
       </View>
     </ScrollView>
@@ -83,6 +209,38 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#F9FAFB',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  errorText: {
+    fontSize: 18,
+    color: '#EF4444',
+    marginBottom: 16,
+  },
+  backButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    backgroundColor: '#3B82F6',
+    borderRadius: 8,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
   },
   section: {
     padding: 16,
@@ -103,10 +261,44 @@ const styles = StyleSheet.create({
     shadowRadius: 2,
     elevation: 2,
   },
-  cardText: {
+  emptyText: {
     fontSize: 14,
     color: '#6B7280',
+    textAlign: 'center',
     marginBottom: 12,
+  },
+  membersGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 12,
+    gap: 12,
+  },
+  memberItem: {
+    alignItems: 'center',
+    width: 70,
+  },
+  memberIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#10B981',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 4,
+  },
+  memberIconText: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+  },
+  memberName: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#1F2937',
+  },
+  memberLevel: {
+    fontSize: 10,
+    color: '#6B7280',
   },
   editButton: {
     backgroundColor: '#E5E7EB',
@@ -121,13 +313,36 @@ const styles = StyleSheet.create({
   },
   dungeonOption: {
     paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    marginBottom: 8,
+    backgroundColor: '#F3F4F6',
+  },
+  dungeonSelected: {
+    backgroundColor: '#DBEAFE',
+    borderWidth: 2,
+    borderColor: '#3B82F6',
+  },
+  dungeonHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   dungeonName: {
     fontSize: 16,
     fontWeight: '600',
     color: '#1F2937',
+  },
+  clearedBadge: {
+    backgroundColor: '#10B981',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  clearedText: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: '#FFFFFF',
   },
   dungeonInfo: {
     fontSize: 12,
@@ -136,7 +351,7 @@ const styles = StyleSheet.create({
   },
   policyOption: {
     paddingVertical: 12,
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
     borderRadius: 8,
     marginBottom: 8,
     backgroundColor: '#F3F4F6',
@@ -151,19 +366,24 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#1F2937',
   },
+  policyDescription: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 2,
+  },
   buttonContainer: {
     flexDirection: 'row',
     padding: 16,
     gap: 12,
   },
-  backButton: {
+  cancelButton: {
     flex: 1,
     backgroundColor: '#E5E7EB',
     borderRadius: 12,
     padding: 16,
     alignItems: 'center',
   },
-  backButtonText: {
+  cancelButtonText: {
     fontSize: 16,
     fontWeight: '600',
     color: '#4B5563',
@@ -174,6 +394,9 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     alignItems: 'center',
+  },
+  startButtonDisabled: {
+    backgroundColor: '#9CA3AF',
   },
   startButtonText: {
     fontSize: 16,

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -1,95 +1,151 @@
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native'
+import { useMemo, useCallback } from 'react'
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Animated } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
-
-// Sample result data
-const sampleResult = {
-  success: true,
-  floorsCleared: 3,
-  totalExp: 150,
-  goldEarned: 85,
-  itemsFound: ['Health Potion', 'Iron Sword'],
-  casualties: 0,
-}
+import { usePartyService } from '@/presentation/hooks/usePartyService'
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
+import type { Goblin } from '@/shared/types'
 
 export default function ExpeditionResultScreen() {
-  const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { partyId, dungeonId, success, xpGained, maxFloor } = useLocalSearchParams<{
+    partyId: string
+    dungeonId: string
+    success: string
+    xpGained: string
+    maxFloor: string
+  }>()
 
-  const handleViewLog = () => {
+  const { getPartyById } = usePartyService()
+  const { goblins } = useGoblinService()
+  const { dungeons } = useDungeonProgress()
+
+  const party = useMemo(() => {
+    if (!partyId) return null
+    return getPartyById(parseInt(partyId, 10))
+  }, [partyId, getPartyById])
+
+  const dungeon = useMemo(() => {
+    const id = dungeonId || party?.dungeonId
+    return dungeons.find(d => d.id === id)
+  }, [dungeons, dungeonId, party?.dungeonId])
+
+  const partyMembers = useMemo(() => {
+    if (!party) return []
+    return party.memberIds
+      .map(id => goblins.find(g => g.id === id))
+      .filter((g): g is Goblin => g !== undefined)
+  }, [party, goblins])
+
+  const isSuccess = success === 'true'
+  const expGained = parseInt(xpGained || '0', 10)
+  const floorsCleared = parseInt(maxFloor || '0', 10)
+
+  const handleViewLog = useCallback(() => {
     router.push({
       pathname: '/formation/log',
       params: { partyId },
     })
-  }
+  }, [partyId])
 
-  const handleBackToList = () => {
+  const handleBackToList = useCallback(() => {
     router.replace('/formation')
-  }
+  }, [])
 
   return (
-    <ScrollView style={styles.container}>
-      <View style={styles.header}>
-        <View style={[styles.resultBadge, sampleResult.success ? styles.successBadge : styles.failureBadge]}>
-          <Text style={styles.resultText}>{sampleResult.success ? 'SUCCESS' : 'FAILED'}</Text>
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollView}>
+        <View style={styles.header}>
+          <View style={[styles.resultBadge, isSuccess ? styles.successBadge : styles.failureBadge]}>
+            <Text style={styles.resultText}>{isSuccess ? '踏破成功' : '撤退'}</Text>
+          </View>
+          <Text style={styles.title}>遠征完了</Text>
+          {party && dungeon && (
+            <Text style={styles.subtitle}>{party.name} → {dungeon.name}</Text>
+          )}
         </View>
-        <Text style={styles.title}>Expedition Complete</Text>
-        <Text style={styles.subtitle}>Party #{partyId}</Text>
-      </View>
 
-      <View style={styles.statsGrid}>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>{sampleResult.floorsCleared}</Text>
-          <Text style={styles.statLabel}>Floors Cleared</Text>
+        <View style={styles.statsGrid}>
+          <View style={styles.statCard}>
+            <Text style={[styles.statValue, isSuccess ? styles.successValue : styles.failureValue]}>
+              {floorsCleared}
+            </Text>
+            <Text style={styles.statLabel}>到達階層</Text>
+          </View>
+          <View style={styles.statCard}>
+            <Text style={[styles.statValue, styles.expValue]}>{expGained}</Text>
+            <Text style={styles.statLabel}>獲得経験値</Text>
+          </View>
         </View>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>{sampleResult.totalExp}</Text>
-          <Text style={styles.statLabel}>EXP Gained</Text>
-        </View>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>{sampleResult.goldEarned}</Text>
-          <Text style={styles.statLabel}>Gold Earned</Text>
-        </View>
-        <View style={styles.statCard}>
-          <Text style={styles.statValue}>{sampleResult.casualties}</Text>
-          <Text style={styles.statLabel}>Casualties</Text>
-        </View>
-      </View>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Items Found</Text>
-        <View style={styles.itemList}>
-          {sampleResult.itemsFound.map((item, index) => (
-            <View key={index} style={styles.itemCard}>
-              <Text style={styles.itemName}>{item}</Text>
-            </View>
-          ))}
+        {/* パーティメンバー */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>参加メンバー</Text>
+          <View style={styles.memberList}>
+            {partyMembers.map(member => (
+              <View key={member.id} style={styles.memberCard}>
+                <View style={styles.memberAvatar}>
+                  <Text style={styles.memberAvatarText}>G</Text>
+                </View>
+                <View style={styles.memberInfo}>
+                  <Text style={styles.memberName}>{member.name}</Text>
+                  <Text style={styles.memberLevel}>Lv.{member.level}</Text>
+                </View>
+                <View style={styles.expBadge}>
+                  <Text style={styles.expBadgeText}>+{Math.floor(expGained / Math.max(partyMembers.length, 1))} EXP</Text>
+                </View>
+              </View>
+            ))}
+          </View>
         </View>
-      </View>
 
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity style={styles.logButton} onPress={handleViewLog}>
-          <Text style={styles.logButtonText}>View Detailed Log</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.doneButton} onPress={handleBackToList}>
-          <Text style={styles.doneButtonText}>Done</Text>
-        </TouchableOpacity>
-      </View>
-    </ScrollView>
+        {/* 結果サマリー */}
+        <View style={styles.summarySection}>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>ダンジョン</Text>
+            <Text style={styles.summaryValue}>{dungeon?.name || '不明'}</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>総階層</Text>
+            <Text style={styles.summaryValue}>{dungeon?.floors || 0}階</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>結果</Text>
+            <Text style={[styles.summaryValue, isSuccess ? styles.successText : styles.failureText]}>
+              {isSuccess ? '完全踏破' : `${floorsCleared}階で撤退`}
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity style={styles.logButton} onPress={handleViewLog}>
+            <Text style={styles.logButtonText}>詳細ログを見る</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.doneButton} onPress={handleBackToList}>
+            <Text style={styles.doneButtonText}>完了</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F9FAFB',
+    backgroundColor: '#1F2937',
+  },
+  scrollView: {
+    flex: 1,
   },
   header: {
     alignItems: 'center',
     padding: 24,
   },
   resultBadge: {
-    paddingHorizontal: 24,
-    paddingVertical: 8,
-    borderRadius: 20,
+    paddingHorizontal: 32,
+    paddingVertical: 12,
+    borderRadius: 24,
     marginBottom: 16,
   },
   successBadge: {
@@ -99,40 +155,49 @@ const styles = StyleSheet.create({
     backgroundColor: '#EF4444',
   },
   resultText: {
-    fontSize: 18,
+    fontSize: 20,
     fontWeight: 'bold',
     color: '#FFFFFF',
   },
   title: {
     fontSize: 28,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: '#FFFFFF',
   },
   subtitle: {
     fontSize: 16,
-    color: '#6B7280',
-    marginTop: 4,
+    color: '#9CA3AF',
+    marginTop: 8,
   },
   statsGrid: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
-    padding: 12,
+    padding: 16,
+    gap: 12,
   },
   statCard: {
-    width: '50%',
-    padding: 8,
+    flex: 1,
+    backgroundColor: '#374151',
+    borderRadius: 16,
+    padding: 20,
+    alignItems: 'center',
   },
   statValue: {
-    fontSize: 36,
+    fontSize: 48,
     fontWeight: 'bold',
+  },
+  successValue: {
+    color: '#10B981',
+  },
+  failureValue: {
+    color: '#F59E0B',
+  },
+  expValue: {
     color: '#3B82F6',
-    textAlign: 'center',
   },
   statLabel: {
     fontSize: 14,
-    color: '#6B7280',
-    textAlign: 'center',
-    marginTop: 4,
+    color: '#9CA3AF',
+    marginTop: 8,
   },
   section: {
     padding: 16,
@@ -140,33 +205,91 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 18,
     fontWeight: 'bold',
-    color: '#1F2937',
+    color: '#FFFFFF',
     marginBottom: 12,
   },
-  itemList: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+  memberList: {
     gap: 8,
   },
-  itemCard: {
-    backgroundColor: '#FFFFFF',
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
+  memberCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#374151',
+    borderRadius: 12,
+    padding: 12,
   },
-  itemName: {
+  memberAvatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#10B981',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  memberAvatarText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+  },
+  memberInfo: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  memberName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+  memberLevel: {
+    fontSize: 12,
+    color: '#9CA3AF',
+    marginTop: 2,
+  },
+  expBadge: {
+    backgroundColor: '#3B82F6',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  expBadgeText: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+  },
+  summarySection: {
+    backgroundColor: '#111827',
+    margin: 16,
+    borderRadius: 12,
+    padding: 16,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#374151',
+  },
+  summaryLabel: {
+    fontSize: 14,
+    color: '#9CA3AF',
+  },
+  summaryValue: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#4B5563',
+    color: '#FFFFFF',
+  },
+  successText: {
+    color: '#10B981',
+  },
+  failureText: {
+    color: '#F59E0B',
   },
   buttonContainer: {
     padding: 16,
     gap: 12,
   },
   logButton: {
-    backgroundColor: '#E5E7EB',
+    backgroundColor: '#374151',
     borderRadius: 12,
     padding: 16,
     alignItems: 'center',
@@ -174,17 +297,17 @@ const styles = StyleSheet.create({
   logButtonText: {
     fontSize: 16,
     fontWeight: '600',
-    color: '#4B5563',
+    color: '#FFFFFF',
   },
   doneButton: {
-    backgroundColor: '#3B82F6',
+    backgroundColor: '#10B981',
     borderRadius: 12,
     padding: 16,
     alignItems: 'center',
   },
   doneButtonText: {
     fontSize: 16,
-    fontWeight: '600',
+    fontWeight: 'bold',
     color: '#FFFFFF',
   },
 })

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -1,44 +1,9 @@
 import { useState, useCallback } from 'react'
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView } from 'react-native'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import type { Goblin } from '@/shared/types'
-
-// Sample data for demonstration
-const sampleGoblins: Goblin[] = [
-  {
-    id: 1,
-    name: 'Goburo',
-    race: 'goblin',
-    level: 5,
-    experience: 120,
-    avatar: 'goblin_1',
-    stats: { hp: 30, atk: 12, def: 8, spd: 10, sp: 5 },
-    factors: [],
-    individualValue: 50,
-  },
-  {
-    id: 2,
-    name: 'Gobichi',
-    race: 'goblin',
-    level: 3,
-    experience: 45,
-    avatar: 'goblin_2',
-    stats: { hp: 25, atk: 10, def: 6, spd: 12, sp: 4 },
-    factors: [],
-    individualValue: 60,
-  },
-  {
-    id: 3,
-    name: 'Gobimi',
-    race: 'goblin',
-    level: 7,
-    experience: 280,
-    avatar: 'goblin_3',
-    stats: { hp: 40, atk: 18, def: 12, spd: 8, sp: 6 },
-    factors: [],
-    individualValue: 70,
-  },
-]
+import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import type { Goblin, Factor } from '@/shared/types'
+import { getFactor } from '@/shared/data/factors'
 
 interface GoblinCardProps {
   goblin: Goblin
@@ -54,6 +19,21 @@ function GoblinCard({ goblin, onPress }: GoblinCardProps) {
       <View style={styles.cardInfo}>
         <Text style={styles.goblinName}>{goblin.name}</Text>
         <Text style={styles.goblinLevel}>Lv.{goblin.level}</Text>
+        {goblin.factors && goblin.factors.length > 0 && (
+          <View style={styles.factorRow}>
+            {goblin.factors.slice(0, 3).map((factorId, idx) => {
+              const factor = getFactor(factorId)
+              return (
+                <View key={idx} style={styles.factorBadge}>
+                  <Text style={styles.factorText}>{factor?.name?.charAt(0) || '?'}</Text>
+                </View>
+              )
+            })}
+            {goblin.factors.length > 3 && (
+              <Text style={styles.moreFactors}>+{goblin.factors.length - 3}</Text>
+            )}
+          </View>
+        )}
       </View>
       <View style={styles.statsContainer}>
         <Text style={styles.statText}>HP:{goblin.stats.hp}</Text>
@@ -72,6 +52,10 @@ interface GoblinDetailModalProps {
 function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps) {
   if (!goblin) return null
 
+  const goblinFactors = goblin.factors?.map(factorId =>
+    getFactor(factorId)
+  ).filter((f): f is Factor => f !== undefined) || []
+
   return (
     <Modal
       visible={visible}
@@ -88,18 +72,66 @@ function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps)
         </View>
         <ScrollView style={styles.modalContent}>
           <View style={styles.detailSection}>
-            <Text style={styles.sectionTitle}>Basic Info</Text>
-            <Text style={styles.detailText}>Level: {goblin.level}</Text>
-            <Text style={styles.detailText}>Race: {goblin.race}</Text>
-            <Text style={styles.detailText}>EXP: {goblin.experience}</Text>
+            <Text style={styles.sectionTitle}>基本情報</Text>
+            <Text style={styles.detailText}>レベル: {goblin.level}</Text>
+            <Text style={styles.detailText}>種族: {goblin.race}</Text>
+            <Text style={styles.detailText}>経験値: {goblin.experience}</Text>
+            {goblin.individualValue && (
+              <Text style={styles.detailText}>個体値: {goblin.individualValue}</Text>
+            )}
           </View>
           <View style={styles.detailSection}>
-            <Text style={styles.sectionTitle}>Stats</Text>
-            <Text style={styles.detailText}>HP: {goblin.stats.hp}</Text>
-            <Text style={styles.detailText}>ATK: {goblin.stats.atk}</Text>
-            <Text style={styles.detailText}>DEF: {goblin.stats.def}</Text>
-            <Text style={styles.detailText}>SPD: {goblin.stats.spd}</Text>
+            <Text style={styles.sectionTitle}>ステータス</Text>
+            <View style={styles.statsGrid}>
+              <View style={styles.statItem}>
+                <Text style={styles.statLabel}>HP</Text>
+                <Text style={styles.statValue}>{goblin.stats.hp}</Text>
+              </View>
+              <View style={styles.statItem}>
+                <Text style={styles.statLabel}>ATK</Text>
+                <Text style={styles.statValue}>{goblin.stats.atk}</Text>
+              </View>
+              <View style={styles.statItem}>
+                <Text style={styles.statLabel}>DEF</Text>
+                <Text style={styles.statValue}>{goblin.stats.def}</Text>
+              </View>
+              <View style={styles.statItem}>
+                <Text style={styles.statLabel}>SPD</Text>
+                <Text style={styles.statValue}>{goblin.stats.spd}</Text>
+              </View>
+              <View style={styles.statItem}>
+                <Text style={styles.statLabel}>SP</Text>
+                <Text style={styles.statValue}>{goblin.stats.sp}</Text>
+              </View>
+            </View>
           </View>
+          {goblinFactors.length > 0 && (
+            <View style={styles.detailSection}>
+              <Text style={styles.sectionTitle}>因子</Text>
+              {goblinFactors.map((factor, idx) => (
+                <View key={idx} style={styles.factorItem}>
+                  <Text style={styles.factorIcon}>{factor.name.charAt(0)}</Text>
+                  <View style={styles.factorInfo}>
+                    <Text style={styles.factorName}>{factor.name}</Text>
+                    <Text style={styles.factorDesc}>{factor.description}</Text>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+          {goblin.mods && goblin.mods.length > 0 && (
+            <View style={styles.detailSection}>
+              <Text style={styles.sectionTitle}>Mod ({goblin.mods.length})</Text>
+              {goblin.mods.map((mod, idx) => (
+                <View key={idx} style={styles.modItem}>
+                  <Text style={styles.modName}>{mod.templateId}</Text>
+                  <Text style={styles.modEffect}>
+                    値: {mod.value > 0 ? '+' : ''}{mod.value}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          )}
         </ScrollView>
       </SafeAreaView>
     </Modal>
@@ -107,6 +139,7 @@ function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps)
 }
 
 export default function GoblinListScreen() {
+  const { goblins, isLoading } = useGoblinService()
   const [selectedGoblin, setSelectedGoblin] = useState<Goblin | null>(null)
   const [modalVisible, setModalVisible] = useState(false)
 
@@ -120,10 +153,31 @@ export default function GoblinListScreen() {
     setSelectedGoblin(null)
   }, [])
 
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#10B981" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    )
+  }
+
+  if (goblins.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyIcon}>G</Text>
+        <Text style={styles.emptyTitle}>ゴブリンがいません</Text>
+        <Text style={styles.emptyDescription}>
+          拠点でゴブリンを受け入れると、ここに表示されます
+        </Text>
+      </View>
+    )
+  }
+
   return (
     <View style={styles.container}>
       <FlatList
-        data={sampleGoblins}
+        data={goblins}
         keyExtractor={(item) => String(item.id)}
         renderItem={({ item }) => (
           <GoblinCard goblin={item} onPress={() => handleGoblinPress(item)} />
@@ -144,6 +198,40 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#F9FAFB',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+    color: '#6B7280',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    padding: 32,
+  },
+  emptyIcon: {
+    fontSize: 64,
+    color: '#D1D5DB',
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  emptyDescription: {
+    fontSize: 14,
+    color: '#6B7280',
+    textAlign: 'center',
   },
   listContent: {
     padding: 16,
@@ -188,7 +276,26 @@ const styles = StyleSheet.create({
   goblinLevel: {
     fontSize: 14,
     color: '#6B7280',
+    marginTop: 2,
+  },
+  factorRow: {
+    flexDirection: 'row',
     marginTop: 4,
+    alignItems: 'center',
+  },
+  factorBadge: {
+    backgroundColor: '#EEF2FF',
+    borderRadius: 4,
+    paddingHorizontal: 4,
+    paddingVertical: 2,
+    marginRight: 4,
+  },
+  factorText: {
+    fontSize: 12,
+  },
+  moreFactors: {
+    fontSize: 10,
+    color: '#6B7280',
   },
   statsContainer: {
     alignItems: 'flex-end',
@@ -248,5 +355,67 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#4B5563',
     marginBottom: 8,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  statItem: {
+    width: '33%',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  statLabel: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginBottom: 4,
+  },
+  statValue: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#1F2937',
+  },
+  factorItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+    padding: 8,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+  },
+  factorIcon: {
+    fontSize: 24,
+    marginRight: 12,
+  },
+  factorInfo: {
+    flex: 1,
+  },
+  factorName: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1F2937',
+  },
+  factorDesc: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  modItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+    padding: 8,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+  },
+  modName: {
+    fontSize: 14,
+    color: '#1F2937',
+  },
+  modEffect: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#10B981',
   },
 })

--- a/goblin_native/docs/remaining_tasks.md
+++ b/goblin_native/docs/remaining_tasks.md
@@ -1,0 +1,205 @@
+# React Native 残タスク一覧
+
+Web版(goblin_web)とReact Native版(goblin_native)の差異を解消するための残タスクです。
+
+---
+
+## 優先度1: 必須（仕様統一）
+
+### 1.1 パーティ最大人数の統一
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | Web: 6人、Native: 4人 |
+| 対象ファイル | `app/(tabs)/formation/edit.tsx` |
+| 作業内容 | `MAX_PARTY_SIZE` を6に変更、UIを6スロット表示に対応 |
+| 参照 | `goblin_web/src/presentation/components/PartyEditScreen.tsx` |
+
+### 1.2 ExpeditionEngine の移植
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | Native版はランダム生成の仮実装 |
+| 対象ファイル | 新規: `src/core/services/ExpeditionEngine.ts` |
+| 作業内容 | Web版のExpeditionEngineをReact Native用に移植 |
+| 参照 | `goblin_web/src/core/services/ExpeditionEngine.ts` |
+| 依存 | BattleSystem.tsも移植が必要 |
+
+### 1.3 遠征プレイバックの完全実装
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 固定イベントのシミュレーション表示 |
+| 対象ファイル | `app/(tabs)/formation/playback.tsx` |
+| 作業内容 | ExpeditionEngine を使用した本格的なリプレイ再生 |
+| 参照 | `goblin_web/src/presentation/components/ExpeditionPlaybackScreen.tsx` (417行) |
+
+---
+
+## 優先度2: 推奨（機能追加）
+
+### 2.1 詳細戦闘ログの実装
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | サンプルデータ表示のみ |
+| 対象ファイル | `app/(tabs)/formation/log.tsx` |
+| 作業内容 | ExpeditionRepository から replay データを取得して表示 |
+| 参照 | `goblin_web/src/presentation/components/ExpeditionLogScreen.tsx` (434行) |
+
+### 2.2 再生制御機能の追加
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 自動進行のみ |
+| 対象ファイル | `app/(tabs)/formation/playback.tsx` |
+| 作業内容 | 一時停止、スキップ、速度変更ボタンを追加 |
+| 追加UI | 再生コントロールバー |
+
+### 2.3 推定探索時間の表示
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 表示なし |
+| 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
+| 作業内容 | ダンジョン・パーティ構成から推定時間を計算して表示 |
+| 参照 | `goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx` |
+
+### 2.4 因子獲得表示
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 表示なし |
+| 対象ファイル | `app/(tabs)/formation/result.tsx` |
+| 作業内容 | 遠征で獲得した因子を結果画面に表示 |
+| 参照 | `goblin_web/src/presentation/components/ExpeditionResultScreen.tsx` |
+
+### 2.5 目標階層選択モーダル
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 帰還ポリシーに含まれる簡易実装 |
+| 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
+| 作業内容 | 目標階層を独立して選択できるモーダルを追加 |
+| 参照 | `goblin_web/src/presentation/components/FloorTargetSelectionModal.tsx` (59行) |
+
+---
+
+## 優先度3: 品質向上
+
+### 3.1 パーティHP詳細表示
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | 簡易表示 |
+| 対象ファイル | `app/(tabs)/formation/playback.tsx` |
+| 作業内容 | 各メンバーのHP/最大HPをリアルタイム更新表示 |
+
+### 3.2 緊急帰還ボタン
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | なし |
+| 対象ファイル | `app/(tabs)/formation/playback.tsx` |
+| 作業内容 | 遠征中に緊急帰還できるボタンを追加 |
+
+### 3.3 ダンジョン選択モーダル化
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | ScrollView内に統合 |
+| 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
+| 作業内容 | Web版と同様にモーダルで選択する形式に変更（任意） |
+| 参照 | `goblin_web/src/presentation/components/DungeonSelectionModal.tsx` (83行) |
+
+### 3.4 帰還ポリシー選択モーダル化
+
+| 項目 | 内容 |
+|-----|------|
+| 現状 | ScrollView内に統合 |
+| 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
+| 作業内容 | Web版と同様にモーダルで選択する形式に変更（任意） |
+| 参照 | `goblin_web/src/presentation/components/ReturnPolicySelectionModal.tsx` (78行) |
+
+---
+
+## コア移植タスク（優先度1の前提）
+
+ExpeditionEngineを動作させるために必要なコアロジックの移植：
+
+| ファイル | 行数 | 説明 |
+|---------|------|------|
+| `ExpeditionEngine.ts` | 約500行 | 遠征シミュレーションエンジン |
+| `BattleSystem.ts` | 約400行 | ターン制戦闘システム |
+| `ExperienceSystem.ts` | 約100行 | 経験値計算 |
+| `GoblinBirthService.ts` | 約200行 | ゴブリン生成ロジック |
+
+### 移植先ディレクトリ構成
+
+```
+src/core/services/
+├── ExpeditionEngine.ts      ← 移植
+├── BattleSystem.ts          ← 移植
+├── ExperienceSystem.ts      ← 移植
+└── GoblinBirthService.ts    ← 移植
+```
+
+---
+
+## 実装順序推奨
+
+```
+Step 1: コアサービス移植
+  └── BattleSystem.ts
+  └── ExpeditionEngine.ts
+  └── ExperienceSystem.ts
+
+Step 2: 遠征プレイバック完全実装
+  └── playback.tsx を ExpeditionEngine 連携に書き換え
+
+Step 3: 遠征ログ完全実装
+  └── log.tsx を replay データ表示に書き換え
+
+Step 4: パーティ人数統一
+  └── edit.tsx の MAX_PARTY_SIZE を 6 に変更
+
+Step 5: その他機能追加
+  └── 再生制御
+  └── 推定時間表示
+  └── 因子獲得表示
+```
+
+---
+
+## 完了条件チェックリスト
+
+### 優先度1
+- [ ] パーティ最大人数が Web/Native で統一されている
+- [ ] ExpeditionEngine が Native で動作する
+- [ ] 遠征プレイバックが ExpeditionEngine ベースで動作する
+
+### 優先度2
+- [ ] 遠征ログが実際の replay データを表示する
+- [ ] 再生制御（一時停止・スキップ・速度変更）が動作する
+- [ ] 推定探索時間が表示される
+- [ ] 因子獲得が結果画面に表示される
+- [ ] 目標階層選択が独立したUIで選択可能
+
+### 優先度3
+- [ ] パーティHP がリアルタイム更新表示される
+- [ ] 緊急帰還ボタンが動作する
+- [ ] ダンジョン選択がモーダル化されている（任意）
+- [ ] 帰還ポリシー選択がモーダル化されている（任意）
+
+---
+
+## 参考: Native版で既に優れている点
+
+以下はWeb版への逆移植を検討：
+
+| 機能 | Native実装 | Web版への移植検討 |
+|-----|-----------|------------------|
+| 容量プログレスバー | `base.tsx` | 推奨 |
+| パーティ名変更 | `edit.tsx` | 推奨 |
+| 拠点アップグレードUI | `base.tsx` | 推奨 |
+| 他パーティ所属判定 | `edit.tsx` | 推奨 |

--- a/goblin_native/package-lock.json
+++ b/goblin_native/package-lock.json
@@ -13,6 +13,7 @@
         "expo": "~54.0.31",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.21",
+        "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
         "firebase": "^12.8.0",
         "react": "19.1.0",
@@ -4163,7 +4164,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4384,6 +4385,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -5274,7 +5281,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -5983,6 +5990,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-16.0.10.tgz",
+      "integrity": "sha512-tUOKxE9TpfneRG3eOfbNfhN9236SJ7IiUnP8gCqU7umd9DtgDGB/5PhYVVfl+U7KskgolgNoB9v9OZ9iwXN8Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/goblin_native/package.json
+++ b/goblin_native/package.json
@@ -14,6 +14,7 @@
     "expo": "~54.0.31",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.21",
+    "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
     "firebase": "^12.8.0",
     "react": "19.1.0",

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -1,0 +1,111 @@
+/**
+ * SQLiteデータベース初期化モジュール
+ * expo-sqlite を使用したDB接続とマイグレーション管理
+ */
+import * as SQLite from 'expo-sqlite'
+import { migrateV1 } from './migrations/v1'
+
+const DB_NAME = 'goblin_kingdom.db'
+const CURRENT_SCHEMA_VERSION = 1
+
+let db: SQLite.SQLiteDatabase | null = null
+let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
+
+/**
+ * データベース接続を取得
+ * シングルトンパターンで同一インスタンスを返す
+ */
+export const getDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
+  if (db) return db
+
+  // 初期化中の場合は同じPromiseを返す（重複初期化防止）
+  if (initializationPromise) {
+    return initializationPromise
+  }
+
+  initializationPromise = initializeDatabase()
+  return initializationPromise
+}
+
+/**
+ * データベースの初期化
+ */
+const initializeDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
+  const database = await SQLite.openDatabaseAsync(DB_NAME)
+  await runMigrations(database)
+  db = database
+  return database
+}
+
+/**
+ * マイグレーション実行
+ */
+const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  const currentVersion = await getSchemaVersion(database)
+
+  if (currentVersion < 1) {
+    console.log('[DB] Running migration v1...')
+    await migrateV1(database)
+    await setSchemaVersion(database, 1)
+    console.log('[DB] Migration v1 completed')
+  }
+
+  // 将来のマイグレーション追加時はここに追加
+  // if (currentVersion < 2) { await migrateV2(database); await setSchemaVersion(database, 2); }
+}
+
+/**
+ * 現在のスキーマバージョンを取得
+ */
+const getSchemaVersion = async (database: SQLite.SQLiteDatabase): Promise<number> => {
+  try {
+    // app_metadata テーブルが存在するか確認
+    const tableExists = await database.getFirstAsync<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='app_metadata'"
+    )
+
+    if (!tableExists) {
+      return 0
+    }
+
+    const result = await database.getFirstAsync<{ value: string }>(
+      "SELECT value FROM app_metadata WHERE key = 'schema_version'"
+    )
+
+    return result ? parseInt(result.value, 10) : 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * スキーマバージョンを設定
+ */
+const setSchemaVersion = async (
+  database: SQLite.SQLiteDatabase,
+  version: number
+): Promise<void> => {
+  await database.runAsync(
+    "INSERT OR REPLACE INTO app_metadata (key, value) VALUES ('schema_version', ?)",
+    [version.toString()]
+  )
+}
+
+/**
+ * データベースをクローズ（主にテスト用）
+ */
+export const closeDatabase = async (): Promise<void> => {
+  if (db) {
+    await db.closeAsync()
+    db = null
+    initializationPromise = null
+  }
+}
+
+/**
+ * データベースを削除（主にテスト/デバッグ用）
+ */
+export const deleteDatabase = async (): Promise<void> => {
+  await closeDatabase()
+  await SQLite.deleteDatabaseAsync(DB_NAME)
+}

--- a/goblin_native/src/infrastructure/database/migrations/v1.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v1.ts
@@ -1,0 +1,22 @@
+/**
+ * 初期スキーママイグレーション (v1)
+ * 全テーブルの作成と初期データの挿入
+ */
+import type * as SQLite from 'expo-sqlite'
+import { SCHEMA } from '../schema'
+
+export const migrateV1 = async (db: SQLite.SQLiteDatabase): Promise<void> => {
+  // テーブル作成
+  await db.execAsync(SCHEMA.goblins)
+  await db.execAsync(SCHEMA.goblinsIndexes)
+  await db.execAsync(SCHEMA.pendingGoblins)
+  await db.execAsync(SCHEMA.parties)
+  await db.execAsync(SCHEMA.partiesIndex)
+  await db.execAsync(SCHEMA.expeditions)
+  await db.execAsync(SCHEMA.expeditionsIndexes)
+  await db.execAsync(SCHEMA.baseState)
+  await db.execAsync(SCHEMA.baseStateInit)
+  await db.execAsync(SCHEMA.dungeonProgress)
+  await db.execAsync(SCHEMA.appMetadata)
+  await db.execAsync(SCHEMA.appMetadataInit)
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -1,0 +1,123 @@
+/**
+ * SQLiteスキーマ定義
+ * 各テーブルのCREATE文を定義
+ */
+
+export const SCHEMA = {
+  goblins: `
+    CREATE TABLE IF NOT EXISTS goblins (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      race TEXT NOT NULL,
+      level INTEGER NOT NULL DEFAULT 1,
+      experience INTEGER NOT NULL DEFAULT 0,
+      avatar TEXT NOT NULL,
+      stats_json TEXT NOT NULL,
+      effective_stats_json TEXT,
+      factors_json TEXT,
+      variant_factor_id TEXT,
+      individual_value INTEGER DEFAULT 1,
+      mods_json TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `,
+
+  goblinsIndexes: `
+    CREATE INDEX IF NOT EXISTS idx_goblins_level ON goblins(level);
+    CREATE INDEX IF NOT EXISTS idx_goblins_race ON goblins(race)
+  `,
+
+  pendingGoblins: `
+    CREATE TABLE IF NOT EXISTS pending_goblins (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      race TEXT NOT NULL,
+      level INTEGER NOT NULL DEFAULT 1,
+      experience INTEGER NOT NULL DEFAULT 0,
+      avatar TEXT NOT NULL,
+      stats_json TEXT NOT NULL,
+      effective_stats_json TEXT,
+      factors_json TEXT,
+      variant_factor_id TEXT,
+      individual_value INTEGER DEFAULT 1,
+      mods_json TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `,
+
+  parties: `
+    CREATE TABLE IF NOT EXISTS parties (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      member_ids_json TEXT NOT NULL,
+      status TEXT DEFAULT 'idle',
+      dungeon_id TEXT,
+      target_floor INTEGER,
+      return_policy TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `,
+
+  partiesIndex: `
+    CREATE INDEX IF NOT EXISTS idx_parties_status ON parties(status)
+  `,
+
+  expeditions: `
+    CREATE TABLE IF NOT EXISTS expeditions (
+      id TEXT PRIMARY KEY,
+      party_id INTEGER NOT NULL,
+      party_name TEXT NOT NULL,
+      dungeon_id TEXT NOT NULL,
+      dungeon_name TEXT NOT NULL,
+      start_time TEXT NOT NULL,
+      return_time TEXT,
+      status TEXT NOT NULL DEFAULT 'ongoing',
+      return_policy TEXT NOT NULL,
+      replay_json TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (party_id) REFERENCES parties(id)
+    )
+  `,
+
+  expeditionsIndexes: `
+    CREATE INDEX IF NOT EXISTS idx_expeditions_party_id ON expeditions(party_id);
+    CREATE INDEX IF NOT EXISTS idx_expeditions_status ON expeditions(status);
+    CREATE INDEX IF NOT EXISTS idx_expeditions_created_at ON expeditions(created_at)
+  `,
+
+  baseState: `
+    CREATE TABLE IF NOT EXISTS base_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      capacity INTEGER NOT NULL DEFAULT 8,
+      rank INTEGER NOT NULL DEFAULT 1,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `,
+
+  baseStateInit: `
+    INSERT OR IGNORE INTO base_state (id, capacity, rank) VALUES (1, 8, 1)
+  `,
+
+  dungeonProgress: `
+    CREATE TABLE IF NOT EXISTS dungeon_progress (
+      dungeon_id TEXT PRIMARY KEY,
+      unlocked INTEGER NOT NULL DEFAULT 0,
+      cleared INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `,
+
+  appMetadata: `
+    CREATE TABLE IF NOT EXISTS app_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `,
+
+  appMetadataInit: `
+    INSERT OR IGNORE INTO app_metadata (key, value) VALUES ('schema_version', '1')
+  `,
+}

--- a/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
@@ -1,0 +1,140 @@
+/**
+ * SQLiteを使用した拠点状態リポジトリ実装
+ * シングルトンテーブルで拠点の状態を管理
+ */
+import type { BaseState } from '../../shared/types'
+import type { IBaseStateRepository } from '../../core/repositories/IBaseStateRepository'
+import { getDatabase } from '../database'
+
+interface BaseStateRow {
+  id: number
+  capacity: number
+  rank: number
+  updated_at: string
+}
+
+const DEFAULT_BASE_STATE: BaseState = {
+  capacity: 8,
+  rank: 1,
+  nextGoblinId: 1,
+}
+
+export class SQLiteBaseStateRepository implements IBaseStateRepository {
+  private cache: BaseState | null = null
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<BaseStateRow>(
+      'SELECT * FROM base_state WHERE id = 1'
+    )
+
+    if (row) {
+      this.cache = {
+        capacity: row.capacity,
+        rank: row.rank,
+        nextGoblinId: await this.getNextGoblinId(),
+      }
+    } else {
+      // 初期データがない場合は作成
+      this.cache = DEFAULT_BASE_STATE
+      await this.saveAsync(this.cache)
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 拠点状態を取得
+   */
+  getBaseState(): BaseState | null {
+    return this.cache
+  }
+
+  /**
+   * 拠点状態を保存
+   */
+  saveBaseState(state: BaseState): void {
+    this.cache = state
+
+    this.saveAsync(state).catch(err => {
+      console.error('[SQLiteBaseStateRepository] Failed to save:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * 拠点のランクを上げる
+   */
+  upgradeRank(): void {
+    if (!this.cache) return
+
+    const newState: BaseState = {
+      ...this.cache,
+      rank: this.cache.rank + 1,
+      capacity: this.cache.capacity + 4, // ランクアップごとに容量+4
+    }
+
+    this.saveBaseState(newState)
+  }
+
+  /**
+   * 次のゴブリンIDを取得して更新
+   */
+  getAndIncrementNextGoblinId(): number {
+    if (!this.cache) return 1
+
+    const nextId = this.cache.nextGoblinId ?? 1
+    this.cache.nextGoblinId = nextId + 1
+    this.saveBaseState(this.cache)
+    return nextId
+  }
+
+  // --- Private methods ---
+
+  private async saveAsync(state: BaseState): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO base_state (id, capacity, rank, updated_at)
+       VALUES (1, ?, ?, datetime('now'))`,
+      [state.capacity, state.rank]
+    )
+  }
+
+  private async getNextGoblinId(): Promise<number> {
+    const db = await getDatabase()
+
+    // goblins と pending_goblins の最大IDを取得
+    const goblinMax = await db.getFirstAsync<{ max_id: number | null }>(
+      'SELECT MAX(id) as max_id FROM goblins'
+    )
+    const pendingMax = await db.getFirstAsync<{ max_id: number | null }>(
+      'SELECT MAX(id) as max_id FROM pending_goblins'
+    )
+
+    const maxGoblin = goblinMax?.max_id ?? 0
+    const maxPending = pendingMax?.max_id ?? 0
+
+    return Math.max(maxGoblin, maxPending) + 1
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -1,0 +1,124 @@
+/**
+ * SQLiteを使用したダンジョン進行状況リポジトリ実装
+ * 内部キャッシュを使用して同期的なインターフェースを提供
+ */
+import type { DungeonProgressState } from '../../shared/types'
+import { getDatabase } from '../database'
+
+interface DungeonProgressRow {
+  dungeon_id: string
+  unlocked: number
+  cleared: number
+  updated_at: string
+}
+
+interface DungeonProgress {
+  unlocked: boolean
+  cleared: boolean
+}
+
+export interface IDungeonProgressRepository {
+  getAll(): DungeonProgressState
+  get(dungeonId: string): DungeonProgress | null
+  save(dungeonId: string, progress: DungeonProgress): void
+  unlock(dungeonId: string): void
+  markCleared(dungeonId: string): void
+}
+
+export class SQLiteDungeonProgressRepository implements IDungeonProgressRepository {
+  private cache: Map<string, DungeonProgress> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<DungeonProgressRow>('SELECT * FROM dungeon_progress')
+
+    this.cache.clear()
+    for (const row of rows) {
+      this.cache.set(row.dungeon_id, {
+        unlocked: row.unlocked === 1,
+        cleared: row.cleared === 1,
+      })
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 全ダンジョンの進行状況を取得
+   */
+  getAll(): DungeonProgressState {
+    const result: DungeonProgressState = {}
+    this.cache.forEach((progress, dungeonId) => {
+      result[dungeonId] = progress
+    })
+    return result
+  }
+
+  /**
+   * 指定ダンジョンの進行状況を取得
+   */
+  get(dungeonId: string): DungeonProgress | null {
+    return this.cache.get(dungeonId) ?? null
+  }
+
+  /**
+   * 進行状況を保存
+   */
+  save(dungeonId: string, progress: DungeonProgress): void {
+    this.cache.set(dungeonId, progress)
+
+    this.saveAsync(dungeonId, progress).catch(err => {
+      console.error('[SQLiteDungeonProgressRepository] Failed to save:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * ダンジョンを解放済みにする
+   */
+  unlock(dungeonId: string): void {
+    const current = this.cache.get(dungeonId) ?? { unlocked: false, cleared: false }
+    this.save(dungeonId, { ...current, unlocked: true })
+  }
+
+  /**
+   * ダンジョンをクリア済みにする
+   */
+  markCleared(dungeonId: string): void {
+    const current = this.cache.get(dungeonId) ?? { unlocked: true, cleared: false }
+    this.save(dungeonId, { ...current, unlocked: true, cleared: true })
+  }
+
+  // --- Private methods ---
+
+  private async saveAsync(dungeonId: string, progress: DungeonProgress): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO dungeon_progress
+       (dungeon_id, unlocked, cleared, updated_at)
+       VALUES (?, ?, ?, datetime('now'))`,
+      [dungeonId, progress.unlocked ? 1 : 0, progress.cleared ? 1 : 0]
+    )
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
@@ -1,0 +1,193 @@
+/**
+ * SQLiteを使用した遠征記録リポジトリ実装
+ * 内部キャッシュを使用して同期的なインターフェースを提供
+ */
+import type { ExpeditionRecord, ExpeditionReplay, ExpeditionRequest } from '../../shared/types'
+import { getDatabase } from '../database'
+
+interface ExpeditionRow {
+  id: string
+  party_id: number
+  party_name: string
+  dungeon_id: string
+  dungeon_name: string
+  start_time: string
+  return_time: string | null
+  status: string
+  return_policy: string
+  replay_json: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface IExpeditionRepository {
+  getAll(): ExpeditionRecord[]
+  getById(id: string): ExpeditionRecord | null
+  getByPartyId(partyId: number): ExpeditionRecord[]
+  getOngoing(): ExpeditionRecord[]
+  save(record: ExpeditionRecord): void
+  delete(id: string): void
+  complete(id: string, replay: ExpeditionReplay): void
+}
+
+export class SQLiteExpeditionRepository implements IExpeditionRepository {
+  private cache: Map<string, ExpeditionRecord> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<ExpeditionRow>(
+      'SELECT * FROM expeditions ORDER BY created_at DESC'
+    )
+
+    this.cache.clear()
+    for (const row of rows) {
+      const record = this.rowToRecord(row)
+      this.cache.set(record.id, record)
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 全遠征記録を取得
+   */
+  getAll(): ExpeditionRecord[] {
+    return Array.from(this.cache.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+  }
+
+  /**
+   * 指定IDの遠征記録を取得
+   */
+  getById(id: string): ExpeditionRecord | null {
+    return this.cache.get(id) ?? null
+  }
+
+  /**
+   * 指定パーティの遠征記録を取得
+   */
+  getByPartyId(partyId: number): ExpeditionRecord[] {
+    return Array.from(this.cache.values())
+      .filter(r => r.partyId === partyId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  }
+
+  /**
+   * 進行中の遠征記録を取得
+   */
+  getOngoing(): ExpeditionRecord[] {
+    return Array.from(this.cache.values()).filter(r => r.status === 'ongoing')
+  }
+
+  /**
+   * 遠征記録を保存
+   */
+  save(record: ExpeditionRecord): void {
+    this.cache.set(record.id, record)
+
+    this.saveAsync(record).catch(err => {
+      console.error('[SQLiteExpeditionRepository] Failed to save:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * 遠征記録を削除
+   */
+  delete(id: string): void {
+    this.cache.delete(id)
+
+    this.deleteAsync(id).catch(err => {
+      console.error('[SQLiteExpeditionRepository] Failed to delete:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * 遠征を完了状態にする
+   */
+  complete(id: string, replay: ExpeditionReplay): void {
+    const record = this.cache.get(id)
+    if (!record) return
+
+    const updated: ExpeditionRecord = {
+      ...record,
+      status: replay.summary.success ? 'completed' : 'failed',
+      returnTime: new Date(),
+      replay,
+      updatedAt: new Date(),
+    }
+
+    this.save(updated)
+  }
+
+  // --- Private methods ---
+
+  private async saveAsync(record: ExpeditionRecord): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO expeditions
+       (id, party_id, party_name, dungeon_id, dungeon_name, start_time, return_time,
+        status, return_policy, replay_json, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      [
+        record.id,
+        record.partyId,
+        record.partyName,
+        record.dungeonId,
+        record.dungeonName,
+        record.startTime.toISOString(),
+        record.returnTime?.toISOString() ?? null,
+        record.status,
+        record.returnPolicy,
+        record.replay ? JSON.stringify(record.replay) : null,
+      ]
+    )
+  }
+
+  private async deleteAsync(id: string): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync('DELETE FROM expeditions WHERE id = ?', [id])
+  }
+
+  private rowToRecord(row: ExpeditionRow): ExpeditionRecord {
+    return {
+      id: row.id,
+      userId: '', // SQLite版ではローカルユーザーのみ
+      partyId: row.party_id,
+      partyName: row.party_name,
+      dungeonId: row.dungeon_id,
+      dungeonName: row.dungeon_name,
+      startTime: new Date(row.start_time),
+      returnTime: row.return_time ? new Date(row.return_time) : new Date(),
+      status: row.status as ExpeditionRecord['status'],
+      returnPolicy: row.return_policy as ExpeditionRequest['returnPolicy'],
+      replay: row.replay_json ? JSON.parse(row.replay_json) : undefined,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    }
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -1,0 +1,180 @@
+/**
+ * SQLiteを使用したゴブリンリポジトリ実装
+ * 内部キャッシュを使用して同期的なインターフェースを提供
+ */
+import type { Goblin, GoblinStats } from '../../shared/types'
+import type { IGoblinRepository } from '../../core/repositories/IGoblinRepository'
+import { getDatabase } from '../database'
+
+interface GoblinRow {
+  id: number
+  name: string
+  race: string
+  level: number
+  experience: number
+  avatar: string
+  stats_json: string
+  effective_stats_json: string | null
+  factors_json: string | null
+  variant_factor_id: string | null
+  individual_value: number | null
+  mods_json: string | null
+  created_at: string
+  updated_at: string
+}
+
+export class SQLiteGoblinRepository implements IGoblinRepository {
+  private cache: Map<number, Goblin> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<GoblinRow>('SELECT * FROM goblins ORDER BY id')
+
+    this.cache.clear()
+    for (const row of rows) {
+      const goblin = this.rowToGoblin(row)
+      this.cache.set(goblin.id, goblin)
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 全ゴブリンを取得
+   */
+  getGoblins(): Goblin[] {
+    return Array.from(this.cache.values())
+  }
+
+  /**
+   * 指定IDのゴブリンを取得
+   */
+  getGoblin(id: number): Goblin | null {
+    return this.cache.get(id) ?? null
+  }
+
+  /**
+   * ゴブリンを保存（新規作成または更新）
+   */
+  saveGoblin(goblin: Goblin): void {
+    // キャッシュを即座に更新
+    this.cache.set(goblin.id, goblin)
+
+    // DBへの保存は非同期で実行
+    this.saveGoblinAsync(goblin).catch(err => {
+      console.error('[SQLiteGoblinRepository] Failed to save goblin:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * ゴブリンを削除
+   */
+  deleteGoblin(id: number): void {
+    this.cache.delete(id)
+
+    this.deleteGoblinAsync(id).catch(err => {
+      console.error('[SQLiteGoblinRepository] Failed to delete goblin:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * ゴブリンのステータスを更新
+   */
+  updateGoblinStats(id: number, stats: GoblinStats): void {
+    const goblin = this.cache.get(id)
+    if (!goblin) return
+
+    const updated = { ...goblin, stats }
+    this.saveGoblin(updated)
+  }
+
+  /**
+   * ゴブリンのレベルを更新
+   */
+  updateGoblinLevel(id: number, level: number): void {
+    const goblin = this.cache.get(id)
+    if (!goblin) return
+
+    const updated = { ...goblin, level }
+    this.saveGoblin(updated)
+  }
+
+  // --- Private methods ---
+
+  private async saveGoblinAsync(goblin: Goblin): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO goblins
+       (id, name, race, level, experience, avatar, stats_json,
+        effective_stats_json, factors_json, variant_factor_id,
+        individual_value, mods_json, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      [
+        goblin.id,
+        goblin.name,
+        goblin.race,
+        goblin.level,
+        goblin.experience,
+        goblin.avatar,
+        JSON.stringify(goblin.stats),
+        goblin.effectiveStats ? JSON.stringify(goblin.effectiveStats) : null,
+        goblin.factors ? JSON.stringify(goblin.factors) : null,
+        goblin.variantFactorId ?? null,
+        goblin.individualValue ?? 1,
+        goblin.mods ? JSON.stringify(goblin.mods) : null,
+      ]
+    )
+  }
+
+  private async deleteGoblinAsync(id: number): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync('DELETE FROM goblins WHERE id = ?', [id])
+  }
+
+  private rowToGoblin(row: GoblinRow): Goblin {
+    return {
+      id: row.id,
+      name: row.name,
+      race: row.race,
+      level: row.level,
+      experience: row.experience,
+      avatar: row.avatar,
+      stats: JSON.parse(row.stats_json),
+      effectiveStats: row.effective_stats_json
+        ? JSON.parse(row.effective_stats_json)
+        : undefined,
+      factors: row.factors_json
+        ? JSON.parse(row.factors_json)
+        : undefined,
+      variantFactorId: row.variant_factor_id ?? undefined,
+      individualValue: row.individual_value ?? undefined,
+      mods: row.mods_json
+        ? JSON.parse(row.mods_json)
+        : undefined,
+    }
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -1,0 +1,184 @@
+/**
+ * SQLiteを使用したパーティリポジトリ実装
+ * 内部キャッシュを使用して同期的なインターフェースを提供
+ */
+import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
+import type { IPartyRepository } from '../../core/repositories/IPartyRepository'
+import { getDatabase } from '../database'
+
+interface PartyRow {
+  id: number
+  name: string
+  member_ids_json: string
+  status: string | null
+  dungeon_id: string | null
+  target_floor: number | null
+  return_policy: string | null
+  created_at: string
+  updated_at: string
+}
+
+export class SQLitePartyRepository implements IPartyRepository {
+  private cache: Map<number, Party> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<PartyRow>('SELECT * FROM parties ORDER BY id')
+
+    this.cache.clear()
+    for (const row of rows) {
+      const party = this.rowToParty(row)
+      this.cache.set(party.id, party)
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 全パーティを取得
+   */
+  getParties(): Party[] {
+    return Array.from(this.cache.values())
+  }
+
+  /**
+   * 指定IDのパーティを取得
+   */
+  getParty(id: number): Party | null {
+    return this.cache.get(id) ?? null
+  }
+
+  /**
+   * パーティを保存（新規作成または更新）
+   */
+  saveParty(party: Party): void {
+    this.cache.set(party.id, party)
+
+    this.savePartyAsync(party).catch(err => {
+      console.error('[SQLitePartyRepository] Failed to save party:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * パーティを削除
+   */
+  deleteParty(id: number): void {
+    this.cache.delete(id)
+
+    this.deletePartyAsync(id).catch(err => {
+      console.error('[SQLitePartyRepository] Failed to delete party:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * パーティのステータスを更新
+   */
+  updatePartyStatus(id: number, status: PartyStatus): void {
+    const party = this.cache.get(id)
+    if (!party) return
+
+    const updated = { ...party, status }
+    this.saveParty(updated)
+  }
+
+  /**
+   * 指定ステータスのパーティ一覧を取得
+   */
+  getPartiesByStatus(status: PartyStatus): Party[] {
+    return Array.from(this.cache.values()).filter(p => p.status === status)
+  }
+
+  /**
+   * ダンジョン設定を更新
+   */
+  updateDungeonSettings(id: number, dungeonId: string): void {
+    const party = this.cache.get(id)
+    if (!party) return
+
+    const updated = { ...party, dungeonId }
+    this.saveParty(updated)
+  }
+
+  /**
+   * 目標階層を更新
+   */
+  updateFloorTarget(id: number, targetFloor: number | null): void {
+    const party = this.cache.get(id)
+    if (!party) return
+
+    const updated = { ...party, targetFloor }
+    this.saveParty(updated)
+  }
+
+  /**
+   * 帰還ポリシーを更新
+   */
+  updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): void {
+    const party = this.cache.get(id)
+    if (!party) return
+
+    const updated = { ...party, returnPolicy }
+    this.saveParty(updated)
+  }
+
+  // --- Private methods ---
+
+  private async savePartyAsync(party: Party): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO parties
+       (id, name, member_ids_json, status, dungeon_id, target_floor, return_policy, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      [
+        party.id,
+        party.name,
+        JSON.stringify(party.memberIds),
+        party.status ?? 'idle',
+        party.dungeonId ?? null,
+        party.targetFloor ?? null,
+        party.returnPolicy ?? null,
+      ]
+    )
+  }
+
+  private async deletePartyAsync(id: number): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync('DELETE FROM parties WHERE id = ?', [id])
+  }
+
+  private rowToParty(row: PartyRow): Party {
+    return {
+      id: row.id,
+      name: row.name,
+      memberIds: JSON.parse(row.member_ids_json),
+      status: (row.status as PartyStatus) ?? undefined,
+      dungeonId: row.dungeon_id ?? undefined,
+      targetFloor: row.target_floor ?? undefined,
+      returnPolicy: (row.return_policy as ExpeditionRequest['returnPolicy']) ?? undefined,
+    }
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
@@ -1,0 +1,168 @@
+/**
+ * SQLiteを使用した待機中ゴブリンリポジトリ実装
+ * 拠点で受け入れ待ちのゴブリンを管理
+ */
+import type { Goblin } from '../../shared/types'
+import type { IPendingGoblinRepository } from '../../core/repositories/IPendingGoblinRepository'
+import { getDatabase } from '../database'
+
+interface PendingGoblinRow {
+  id: number
+  name: string
+  race: string
+  level: number
+  experience: number
+  avatar: string
+  stats_json: string
+  effective_stats_json: string | null
+  factors_json: string | null
+  variant_factor_id: string | null
+  individual_value: number | null
+  mods_json: string | null
+  created_at: string
+}
+
+export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
+  private cache: Map<number, Goblin> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<PendingGoblinRow>(
+      'SELECT * FROM pending_goblins ORDER BY created_at DESC'
+    )
+
+    this.cache.clear()
+    for (const row of rows) {
+      const goblin = this.rowToGoblin(row)
+      this.cache.set(goblin.id, goblin)
+    }
+
+    this.initialized = true
+  }
+
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 待機中の全ゴブリンを取得
+   */
+  getPendingGoblins(): Goblin[] {
+    return Array.from(this.cache.values())
+  }
+
+  /**
+   * 待機中ゴブリンを追加
+   */
+  addPendingGoblin(goblin: Goblin): void {
+    this.cache.set(goblin.id, goblin)
+
+    this.addAsync(goblin).catch(err => {
+      console.error('[SQLitePendingGoblinRepository] Failed to add:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * 待機中ゴブリンを削除（受け入れ時）
+   */
+  removePendingGoblin(id: number): void {
+    this.cache.delete(id)
+
+    this.removeAsync(id).catch(err => {
+      console.error('[SQLitePendingGoblinRepository] Failed to remove:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * 全待機中ゴブリンをクリア
+   */
+  clearPendingGoblins(): void {
+    this.cache.clear()
+
+    this.clearAsync().catch(err => {
+      console.error('[SQLitePendingGoblinRepository] Failed to clear:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  // --- Private methods ---
+
+  private async addAsync(goblin: Goblin): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `INSERT OR REPLACE INTO pending_goblins
+       (id, name, race, level, experience, avatar, stats_json,
+        effective_stats_json, factors_json, variant_factor_id,
+        individual_value, mods_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        goblin.id,
+        goblin.name,
+        goblin.race,
+        goblin.level,
+        goblin.experience,
+        goblin.avatar,
+        JSON.stringify(goblin.stats),
+        goblin.effectiveStats ? JSON.stringify(goblin.effectiveStats) : null,
+        goblin.factors ? JSON.stringify(goblin.factors) : null,
+        goblin.variantFactorId ?? null,
+        goblin.individualValue ?? 1,
+        goblin.mods ? JSON.stringify(goblin.mods) : null,
+      ]
+    )
+  }
+
+  private async removeAsync(id: number): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync('DELETE FROM pending_goblins WHERE id = ?', [id])
+  }
+
+  private async clearAsync(): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync('DELETE FROM pending_goblins')
+  }
+
+  private rowToGoblin(row: PendingGoblinRow): Goblin {
+    return {
+      id: row.id,
+      name: row.name,
+      race: row.race,
+      level: row.level,
+      experience: row.experience,
+      avatar: row.avatar,
+      stats: JSON.parse(row.stats_json),
+      effectiveStats: row.effective_stats_json
+        ? JSON.parse(row.effective_stats_json)
+        : undefined,
+      factors: row.factors_json
+        ? JSON.parse(row.factors_json)
+        : undefined,
+      variantFactorId: row.variant_factor_id ?? undefined,
+      individualValue: row.individual_value ?? undefined,
+      mods: row.mods_json
+        ? JSON.parse(row.mods_json)
+        : undefined,
+    }
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/repositories/index.ts
+++ b/goblin_native/src/infrastructure/repositories/index.ts
@@ -1,2 +1,11 @@
-export { AsyncStorageGoblinRepositoryImpl } from './AsyncStorageGoblinRepositoryImpl'
-export { AsyncStoragePartyRepositoryImpl } from './AsyncStoragePartyRepositoryImpl'
+// SQLite Repositories
+export { SQLiteGoblinRepository } from './SQLiteGoblinRepository'
+export { SQLitePartyRepository } from './SQLitePartyRepository'
+export { SQLiteDungeonProgressRepository } from './SQLiteDungeonProgressRepository'
+export { SQLiteExpeditionRepository } from './SQLiteExpeditionRepository'
+export { SQLitePendingGoblinRepository } from './SQLitePendingGoblinRepository'
+export { SQLiteBaseStateRepository } from './SQLiteBaseStateRepository'
+
+// Repository interfaces
+export type { IDungeonProgressRepository } from './SQLiteDungeonProgressRepository'
+export type { IExpeditionRepository } from './SQLiteExpeditionRepository'

--- a/goblin_native/src/presentation/hooks/useBaseState.ts
+++ b/goblin_native/src/presentation/hooks/useBaseState.ts
@@ -1,0 +1,85 @@
+/**
+ * 拠点状態管理用カスタムフック
+ * SQLiteBaseStateRepositoryを使用して拠点の状態を管理
+ */
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { BaseState } from '@/shared/types'
+import { SQLiteBaseStateRepository } from '@/infrastructure/repositories'
+
+// シングルトンリポジトリインスタンス
+let repositoryInstance: SQLiteBaseStateRepository | null = null
+
+const getRepository = (): SQLiteBaseStateRepository => {
+  if (!repositoryInstance) {
+    repositoryInstance = new SQLiteBaseStateRepository()
+  }
+  return repositoryInstance
+}
+
+export function useBaseState() {
+  const [baseState, setBaseState] = useState<BaseState | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const repositoryRef = useRef<SQLiteBaseStateRepository | null>(null)
+
+  // リポジトリの初期化とデータ取得
+  useEffect(() => {
+    const repository = getRepository()
+    repositoryRef.current = repository
+
+    const initializeAndLoad = async () => {
+      try {
+        await repository.initialize()
+        setBaseState(repository.getBaseState())
+      } catch (error) {
+        console.error('[useBaseState] Failed to initialize:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    // データ変更時のコールバックを設定
+    repository.setOnDataChange(() => {
+      setBaseState(repository.getBaseState())
+    })
+
+    initializeAndLoad()
+  }, [])
+
+  // 拠点ランクアップ
+  const upgradeRank = useCallback(() => {
+    if (!repositoryRef.current) return
+
+    repositoryRef.current.upgradeRank()
+    setBaseState(repositoryRef.current.getBaseState())
+  }, [])
+
+  // 次のゴブリンIDを取得して更新
+  const getNextGoblinId = useCallback((): number => {
+    if (!repositoryRef.current) return 1
+
+    return repositoryRef.current.getAndIncrementNextGoblinId()
+  }, [])
+
+  // 拠点状態を更新
+  const updateBaseState = useCallback((updates: Partial<BaseState>) => {
+    if (!repositoryRef.current || !baseState) return
+
+    const newState: BaseState = {
+      ...baseState,
+      ...updates,
+    }
+
+    repositoryRef.current.saveBaseState(newState)
+    setBaseState(newState)
+  }, [baseState])
+
+  return {
+    baseState,
+    isLoading,
+    upgradeRank,
+    getNextGoblinId,
+    updateBaseState,
+    capacity: baseState?.capacity ?? 8,
+    rank: baseState?.rank ?? 1,
+  }
+}

--- a/goblin_native/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_native/src/presentation/hooks/useDungeonProgress.ts
@@ -1,14 +1,17 @@
-// TODO: SQLiteに移行予定 - 現在は暫定的にAsyncStorageを使用
-// 移行設計: docs/sqlite_migration.md を参照
-import { useEffect, useMemo, useState } from 'react'
-import AsyncStorage from '@react-native-async-storage/async-storage'
+/**
+ * ダンジョン進行状況を管理するHook
+ * SQLiteDungeonProgressRepository を使用
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { SQLiteDungeonProgressRepository } from '../../infrastructure/repositories/SQLiteDungeonProgressRepository'
 import { areasData } from '../../shared/data'
 import type { Dungeon } from '../../shared/types'
 import type { DungeonProgressState } from '../../shared/types/DungeonProgress'
 
-const STORAGE_KEY = 'dungeon_progress'
-const listeners = new Set<(progress: DungeonProgressState) => void>()
-let cachedProgress: DungeonProgressState | null = null
+type DungeonProgressRepository = SQLiteDungeonProgressRepository & {
+  initialize?: () => Promise<void>
+  setOnDataChange?: (callback: () => void) => void
+}
 
 const buildDefaultProgress = (): DungeonProgressState => {
   const defaults: DungeonProgressState = {}
@@ -21,81 +24,85 @@ const buildDefaultProgress = (): DungeonProgressState => {
   return defaults
 }
 
-const loadProgressFromStorage = async (): Promise<DungeonProgressState> => {
-  if (cachedProgress) {
-    return cachedProgress
-  }
-
-  try {
-    const saved = await AsyncStorage.getItem(STORAGE_KEY)
-    if (saved) {
-      const parsed: DungeonProgressState = { ...buildDefaultProgress(), ...JSON.parse(saved) }
-      cachedProgress = parsed
-      return parsed
-    }
-  } catch (error) {
-    console.warn('Failed to load dungeon progress', error)
-  }
-
-  const defaultProgress = buildDefaultProgress()
-  cachedProgress = defaultProgress
-  return defaultProgress
-}
-
-const persistProgress = async (progress: DungeonProgressState) => {
-  cachedProgress = progress
-  try {
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(progress))
-  } catch (error) {
-    console.warn('Failed to persist dungeon progress', error)
-  }
-  listeners.forEach(listener => listener(progress))
-}
-
 export const useDungeonProgress = () => {
-  const [progress, setProgress] = useState<DungeonProgressState>(() => cachedProgress || buildDefaultProgress())
+  const [progress, setProgress] = useState<DungeonProgressState>(() => buildDefaultProgress())
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
-    const handleUpdate = (next: DungeonProgressState) => setProgress(next)
-    listeners.add(handleUpdate)
-    return () => {
-      listeners.delete(handleUpdate)
-    }
+  const repository = useMemo<DungeonProgressRepository>(() => {
+    return new SQLiteDungeonProgressRepository()
   }, [])
 
+  const refreshProgress = useCallback(() => {
+    const storedProgress = repository.getAll()
+    const mergedProgress = { ...buildDefaultProgress(), ...storedProgress }
+    setProgress(mergedProgress)
+  }, [repository])
+
   useEffect(() => {
-    loadProgressFromStorage().then(loaded => {
-      setProgress(loaded)
-      setIsLoading(false)
-    })
-  }, [])
-
-  const updateProgress = (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
-    const next = updater(cachedProgress || buildDefaultProgress())
-    persistProgress(next)
-  }
-
-  const markDungeonCleared = (dungeon: Dungeon, cleared: boolean) => {
-    updateProgress(prev => {
-      const nextProgress: DungeonProgressState = { ...prev }
-      const current = nextProgress[dungeon.id] ?? { unlocked: dungeon.unlocked ?? false, cleared: false }
-      nextProgress[dungeon.id] = { ...current, unlocked: true, cleared: cleared || current.cleared }
-
-      if (cleared && dungeon.unlockNext) {
-        const target = nextProgress[dungeon.unlockNext] ?? { unlocked: false, cleared: false }
-        nextProgress[dungeon.unlockNext] = { ...target, unlocked: true }
+    const initRepository = async () => {
+      if (repository.initialize) {
+        await repository.initialize()
       }
 
-      return nextProgress
-    })
-  }
+      // 初期データがない場合はデフォルトを保存
+      const storedProgress = repository.getAll()
+      const defaults = buildDefaultProgress()
 
-  const dungeons: Dungeon[] = useMemo(() => areasData.map(dungeon => ({
-    ...dungeon,
-    cleared: progress[dungeon.id]?.cleared ?? dungeon.cleared ?? false,
-    unlocked: progress[dungeon.id]?.unlocked ?? dungeon.unlocked ?? false,
-  })), [progress])
+      // 新規ダンジョンの初期状態を保存
+      for (const [dungeonId, defaultState] of Object.entries(defaults)) {
+        if (!storedProgress[dungeonId]) {
+          repository.save(dungeonId, defaultState)
+        }
+      }
+
+      refreshProgress()
+      setIsLoading(false)
+    }
+    initRepository()
+  }, [repository, refreshProgress])
+
+  const updateProgress = useCallback(
+    (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
+      const currentProgress = { ...buildDefaultProgress(), ...repository.getAll() }
+      const nextProgress = updater(currentProgress)
+
+      // 変更された項目のみ保存
+      for (const [dungeonId, state] of Object.entries(nextProgress)) {
+        repository.save(dungeonId, state)
+      }
+
+      refreshProgress()
+    },
+    [repository, refreshProgress]
+  )
+
+  const markDungeonCleared = useCallback(
+    (dungeon: Dungeon, cleared: boolean) => {
+      updateProgress(prev => {
+        const nextProgress: DungeonProgressState = { ...prev }
+        const current = nextProgress[dungeon.id] ?? { unlocked: dungeon.unlocked ?? false, cleared: false }
+        nextProgress[dungeon.id] = { ...current, unlocked: true, cleared: cleared || current.cleared }
+
+        if (cleared && dungeon.unlockNext) {
+          const target = nextProgress[dungeon.unlockNext] ?? { unlocked: false, cleared: false }
+          nextProgress[dungeon.unlockNext] = { ...target, unlocked: true }
+        }
+
+        return nextProgress
+      })
+    },
+    [updateProgress]
+  )
+
+  const dungeons: Dungeon[] = useMemo(
+    () =>
+      areasData.map(dungeon => ({
+        ...dungeon,
+        cleared: progress[dungeon.id]?.cleared ?? dungeon.cleared ?? false,
+        unlocked: progress[dungeon.id]?.unlocked ?? dungeon.unlocked ?? false,
+      })),
+    [progress]
+  )
 
   return {
     dungeons,

--- a/goblin_native/src/presentation/hooks/useGoblinService.ts
+++ b/goblin_native/src/presentation/hooks/useGoblinService.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Goblin } from '../../shared/types'
-import { AsyncStorageGoblinRepositoryImpl } from '../../infrastructure/repositories/AsyncStorageGoblinRepositoryImpl'
+import { SQLiteGoblinRepository } from '../../infrastructure/repositories/SQLiteGoblinRepository'
 import type { IGoblinRepository } from '../../core/repositories'
 import { GetGoblinListUseCase } from '../../core/usecases'
 
@@ -14,7 +14,7 @@ export const useGoblinService = () => {
   const [goblins, setGoblins] = useState<Goblin[]>([])
 
   const goblinRepository = useMemo<ListenerCapableGoblinRepository>(() => {
-    return new AsyncStorageGoblinRepositoryImpl()
+    return new SQLiteGoblinRepository()
   }, [])
 
   const getGoblinListUseCase = useMemo(

--- a/goblin_native/src/presentation/hooks/usePartyService.ts
+++ b/goblin_native/src/presentation/hooks/usePartyService.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Party } from '../../shared/types'
-import { AsyncStoragePartyRepositoryImpl } from '../../infrastructure/repositories/AsyncStoragePartyRepositoryImpl'
+import { SQLitePartyRepository } from '../../infrastructure/repositories/SQLitePartyRepository'
 import type { IPartyRepository } from '../../core/repositories'
 import {
   ConfigurePartyUseCase,
@@ -21,7 +21,7 @@ export const usePartyService = () => {
   const [parties, setParties] = useState<Party[]>([])
 
   const partyRepository = useMemo<ListenerCapablePartyRepository>(() => {
-    return new AsyncStoragePartyRepositoryImpl()
+    return new SQLitePartyRepository()
   }, [])
 
   const getPartyListUseCase = useMemo(

--- a/goblin_native/src/presentation/hooks/usePendingGoblins.ts
+++ b/goblin_native/src/presentation/hooks/usePendingGoblins.ts
@@ -1,0 +1,86 @@
+/**
+ * 待機中ゴブリン管理用カスタムフック
+ * SQLitePendingGoblinRepositoryを使用して待機中のゴブリンを管理
+ */
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { Goblin } from '@/shared/types'
+import { SQLitePendingGoblinRepository } from '@/infrastructure/repositories'
+
+// シングルトンリポジトリインスタンス
+let repositoryInstance: SQLitePendingGoblinRepository | null = null
+
+const getRepository = (): SQLitePendingGoblinRepository => {
+  if (!repositoryInstance) {
+    repositoryInstance = new SQLitePendingGoblinRepository()
+  }
+  return repositoryInstance
+}
+
+export function usePendingGoblins() {
+  const [pendingGoblins, setPendingGoblins] = useState<Goblin[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const repositoryRef = useRef<SQLitePendingGoblinRepository | null>(null)
+
+  // リポジトリの初期化とデータ取得
+  useEffect(() => {
+    const repository = getRepository()
+    repositoryRef.current = repository
+
+    const initializeAndLoad = async () => {
+      try {
+        await repository.initialize()
+        setPendingGoblins(repository.getPendingGoblins())
+      } catch (error) {
+        console.error('[usePendingGoblins] Failed to initialize:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    // データ変更時のコールバックを設定
+    repository.setOnDataChange(() => {
+      setPendingGoblins(repository.getPendingGoblins())
+    })
+
+    initializeAndLoad()
+  }, [])
+
+  // 待機中ゴブリンを追加
+  const addPendingGoblin = useCallback((goblin: Goblin) => {
+    if (!repositoryRef.current) return
+
+    repositoryRef.current.addPendingGoblin(goblin)
+    setPendingGoblins(repositoryRef.current.getPendingGoblins())
+  }, [])
+
+  // 待機中ゴブリンを削除（受け入れ時）
+  const removePendingGoblin = useCallback((id: number) => {
+    if (!repositoryRef.current) return
+
+    repositoryRef.current.removePendingGoblin(id)
+    setPendingGoblins(repositoryRef.current.getPendingGoblins())
+  }, [])
+
+  // 全待機中ゴブリンをクリア
+  const clearPendingGoblins = useCallback(() => {
+    if (!repositoryRef.current) return
+
+    repositoryRef.current.clearPendingGoblins()
+    setPendingGoblins([])
+  }, [])
+
+  // 指定IDの待機中ゴブリンを取得
+  const getPendingGoblinById = useCallback((id: number): Goblin | undefined => {
+    return pendingGoblins.find(g => g.id === id)
+  }, [pendingGoblins])
+
+  return {
+    pendingGoblins,
+    isLoading,
+    addPendingGoblin,
+    removePendingGoblin,
+    clearPendingGoblins,
+    getPendingGoblinById,
+    pendingCount: pendingGoblins.length,
+  }
+}

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -40,6 +40,7 @@ export type {
 
 // Dungeon related types
 export type { Dungeon } from "./Dungeon"
+export type { DungeonProgressState } from "./DungeonProgress"
 
 // Base related types
 export type { BaseState } from "./BaseState"


### PR DESCRIPTION
## Summary
- Phase 5: 遠征機能のSQLite連携と画面実装
- Phase 6: 拠点管理画面のSQLite連携
- 残タスクドキュメント作成

## 変更内容

### 新規ファイル
**SQLite Repository**
- `SQLiteExpeditionRepository.ts` - 遠征記録の永続化
- `SQLitePendingGoblinRepository.ts` - 待機中ゴブリン管理
- `SQLiteBaseStateRepository.ts` - 拠点状態管理

**Hooks**
- `useBaseState.ts` - 拠点状態管理hook
- `usePendingGoblins.ts` - 待機中ゴブリン管理hook

**Database**
- `database/index.ts` - DB接続・初期化
- `database/schema.ts` - テーブル定義
- `database/migrations/v1.ts` - 初期マイグレーション

**ドキュメント**
- `docs/remaining_tasks.md` - Web/Native差異と残タスク一覧

### 更新ファイル
- `app/(tabs)/index.tsx` - ゴブリン一覧画面
- `app/(tabs)/base.tsx` - 拠点管理画面
- `app/(tabs)/formation/*` - 遠征関連全画面

## Test plan
- [ ] アプリ起動時にSQLiteデータベースが初期化される
- [ ] ゴブリン一覧画面でSQLiteからデータが読み込まれる
- [ ] パーティ作成・編集が正常に動作する
- [ ] 遠征プレイバック→結果→ログの遷移が正常に動作する
- [ ] 拠点管理画面でゴブリン受け入れが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)