### PR TITLE
fix: 動的インポートを静的ローダーに置換（Metro互換性対応）

### DIFF
--- a/goblin_native/package-lock.json
+++ b/goblin_native/package-lock.json
@@ -25,7 +25,7 @@
         "react-native-screens": "~4.16.0",
         "react-native-size-matters": "^0.4.2",
         "react-native-web": "^0.21.0",
-        "react-native-worklets": "^0.7.2"
+        "react-native-worklets": "^0.5.1"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -9230,113 +9230,39 @@
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.2.tgz",
-      "integrity": "sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "7.27.1",
-        "@babel/plugin-transform-class-properties": "7.27.1",
-        "@babel/plugin-transform-classes": "7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1",
-        "@babel/plugin-transform-optional-chaining": "7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "7.27.1",
-        "@babel/plugin-transform-template-literals": "7.27.1",
-        "@babel/plugin-transform-unicode-regex": "7.27.1",
-        "@babel/preset-typescript": "7.27.1",
-        "convert-source-map": "2.0.0",
-        "semver": "7.7.3"
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
       },
       "peerDependencies": {
-        "@babel/core": "*",
+        "@babel/core": "^7.0.0-0",
         "react": "*",
         "react-native": "*"
       }
     },
-    "node_modules/react-native-worklets/node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/react-native-worklets/node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
-      "integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
-        "@babel/traverse": "^7.28.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/react-native-worklets/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/react-native-worklets/node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
-      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/react-native-worklets/node_modules/@babel/preset-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-typescript": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {

--- a/goblin_native/package.json
+++ b/goblin_native/package.json
@@ -26,7 +26,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-size-matters": "^0.4.2",
     "react-native-web": "^0.21.0",
-    "react-native-worklets": "^0.7.2"
+    "react-native-worklets": "^0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -2,17 +2,17 @@ import type {
   ExpeditionRequest,
   ExpeditionReplay,
   TimelineEvent,
-  AreaConfig,
   EnemySnap,
   CombatReplay,
   RewardSummary,
   Goblin,
-  EnemyDatabase,
   Enemy,
   EnemyPattern,
   PartyState,
   ExpeditionEndReason,
 } from '../../shared/types'
+import { getAreaConfig } from '../../shared/data/expeditionArea'
+import { getEnemyDatabase } from '../../shared/data/enemy'
 import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 
@@ -51,18 +51,14 @@ export class ExpeditionEngine {
 
     const areaId = dungeonToAreaMap[request.areaId] || request.areaId
 
-    // JSONファイルからエリアデータを読み込む
-    const areaData = await import(`../../shared/data/expeditionArea/${areaId}.json`)
-    const area: AreaConfig = areaData.default || areaData
-
+    // エリアデータを取得
+    const area = getAreaConfig(areaId)
     if (!area) {
       throw new Error(`Area not found: ${request.areaId} (mapped to: ${areaId})`)
     }
 
-    // 敵データを読み込む
-    const enemyData = await import(`../../shared/data/enemy/${areaId}.json`)
-    const enemyDatabase: EnemyDatabase = enemyData.default || enemyData
-
+    // 敵データを取得
+    const enemyDatabase = getEnemyDatabase(areaId)
     if (!enemyDatabase) {
       throw new Error(`Enemy data not found: ${areaId}`)
     }

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -1,4 +1,5 @@
-import type { ExpeditionReplay, TimelineEvent, EnemyDatabase } from '../../shared/types'
+import type { ExpeditionReplay, TimelineEvent } from '../../shared/types'
+import { getEnemyDatabase } from '../../shared/data/enemy'
 import { GoblinEntity } from '../domain'
 import type { IGoblinRepository, IPartyRepository } from '../repositories'
 import type { LevelUpResult } from '../services/ExperienceSystem'
@@ -80,11 +81,10 @@ export class CompleteExpeditionUseCase {
     )
 
     if (bossEvent && bossEvent.combat.outcome === 'win') {
-      // JSONファイルから敵データを読み込んでボスの因子ドロップを取得
-      try {
-        const enemyData = await import(`../../shared/data/enemy/${replay.meta.areaId}.json`)
-        const enemyDatabase: EnemyDatabase = enemyData.default || enemyData
+      // 敵データを取得してボスの因子ドロップを取得
+      const enemyDatabase = getEnemyDatabase(replay.meta.areaId)
 
+      if (enemyDatabase) {
         // ボスパターンの敵の中からfactorDropsを持つ敵を全て取得
         const bossPattern = enemyDatabase.patterns.find(p => p.isBoss)
         const bossEnemyIds = bossPattern?.enemies ?? [bossEvent.enemy.id]
@@ -120,8 +120,7 @@ export class CompleteExpeditionUseCase {
             }
           }
         }
-      } catch {
-        // 敵データが見つからない場合はスキップ
+      } else {
         console.warn(`Enemy data not found for area: ${replay.meta.areaId}`)
       }
     }

--- a/goblin_native/src/shared/data/enemy/index.ts
+++ b/goblin_native/src/shared/data/enemy/index.ts
@@ -1,0 +1,17 @@
+import type { EnemyDatabase } from '../../types'
+
+import forestOutskirts from './forest_outskirts.json'
+import goblinVillage from './goblin_village.json'
+import orcCamp from './orc_camp.json'
+import slimeCave from './slime_cave.json'
+
+const enemyDatabases: Record<string, EnemyDatabase> = {
+  forest_outskirts: forestOutskirts as EnemyDatabase,
+  goblin_village: goblinVillage as EnemyDatabase,
+  orc_camp: orcCamp as EnemyDatabase,
+  slime_cave: slimeCave as EnemyDatabase,
+}
+
+export function getEnemyDatabase(areaId: string): EnemyDatabase | null {
+  return enemyDatabases[areaId] ?? null
+}

--- a/goblin_native/src/shared/data/expeditionArea/index.ts
+++ b/goblin_native/src/shared/data/expeditionArea/index.ts
@@ -1,0 +1,17 @@
+import type { AreaConfig } from '../../types'
+
+import forestOutskirts from './forest_outskirts.json'
+import goblinVillage from './goblin_village.json'
+import orcCamp from './orc_camp.json'
+import slimeCave from './slime_cave.json'
+
+const areaDatabases: Record<string, AreaConfig> = {
+  forest_outskirts: forestOutskirts as AreaConfig,
+  goblin_village: goblinVillage as AreaConfig,
+  orc_camp: orcCamp as AreaConfig,
+  slime_cave: slimeCave as AreaConfig,
+}
+
+export function getAreaConfig(areaId: string): AreaConfig | null {
+  return areaDatabases[areaId] ?? null
+}


### PR DESCRIPTION
## Summary
- React Native/Metroで動的インポート（import()）がサポートされていない問題を修正
- 敵データとエリアデータの読み込みを静的インポートベースのローダー関数に変更
- react-native-workletsをExpo互換バージョン(0.5.1)にダウングレード

## Changes
- `src/shared/data/enemy/index.ts`: 敵データローダー追加
- `src/shared/data/expeditionArea/index.ts`: エリアデータローダー追加
- `ExpeditionEngine.ts`: getAreaConfig/getEnemyDatabase使用に変更
- `CompleteExpeditionUseCase.ts`: getEnemyDatabase使用に変更

## Test plan
- [ ] アプリがエラーなくバンドルされることを確認
- [ ] 遠征機能が正常に動作することを確認
- [ ] ボス戦後の因子獲得が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)