### PR TITLE
fix: リポジトリをシングルトン化して画面遷移時のデータ不整合を解消

### DIFF
--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -21,14 +21,18 @@ export default function ExpeditionPlaybackScreen() {
     returnPolicy: string
   }>()
 
-  const { getPartyById, markExpedition, markIdle } = usePartyService()
-  const { goblins } = useGoblinService()
+  const { getPartyById, markExpedition, markIdle, isLoading: isPartyLoading } = usePartyService()
+  const { goblins, isLoading: isGoblinLoading } = useGoblinService()
   const { dungeons } = useDungeonProgress()
 
   const party = useMemo(() => {
-    if (!partyId) return null
-    return getPartyById(parseInt(partyId, 10))
-  }, [partyId, getPartyById])
+    if (!partyId || isPartyLoading) return null
+    try {
+      return getPartyById(parseInt(partyId, 10))
+    } catch {
+      return null
+    }
+  }, [partyId, getPartyById, isPartyLoading])
 
   const dungeon = useMemo(() => {
     const id = dungeonId || party?.dungeonId

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -24,9 +24,20 @@ interface GoblinRow {
 }
 
 export class SQLiteGoblinRepository implements IGoblinRepository {
+  private static instance: SQLiteGoblinRepository | null = null
   private cache: Map<number, Goblin> = new Map()
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLiteGoblinRepository {
+    if (!SQLiteGoblinRepository.instance) {
+      SQLiteGoblinRepository.instance = new SQLiteGoblinRepository()
+    }
+    return SQLiteGoblinRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -19,9 +19,20 @@ interface PartyRow {
 }
 
 export class SQLitePartyRepository implements IPartyRepository {
+  private static instance: SQLitePartyRepository | null = null
   private cache: Map<number, Party> = new Map()
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLitePartyRepository {
+    if (!SQLitePartyRepository.instance) {
+      SQLitePartyRepository.instance = new SQLitePartyRepository()
+    }
+    return SQLitePartyRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード

--- a/goblin_native/src/presentation/hooks/useGoblinService.ts
+++ b/goblin_native/src/presentation/hooks/useGoblinService.ts
@@ -14,7 +14,7 @@ export const useGoblinService = () => {
   const [goblins, setGoblins] = useState<Goblin[]>([])
 
   const goblinRepository = useMemo<ListenerCapableGoblinRepository>(() => {
-    return new SQLiteGoblinRepository()
+    return SQLiteGoblinRepository.getInstance()
   }, [])
 
   const getGoblinListUseCase = useMemo(

--- a/goblin_native/src/presentation/hooks/usePartyService.ts
+++ b/goblin_native/src/presentation/hooks/usePartyService.ts
@@ -22,7 +22,7 @@ export const usePartyService = () => {
   const [parties, setParties] = useState<Party[]>([])
 
   const partyRepository = useMemo<ListenerCapablePartyRepository>(() => {
-    return new SQLitePartyRepository()
+    return SQLitePartyRepository.getInstance()
   }, [])
 
   const getPartyListUseCase = useMemo(


### PR DESCRIPTION
## Summary
- SQLitePartyRepository/SQLiteGoblinRepositoryにシングルトンパターンを追加
- 画面遷移時に新しいリポジトリインスタンスが作成され、初期化完了前にgetPartyById()が呼ばれてエラーが発生していた問題を修正
- playback.tsxで初期化状態を考慮したパーティ取得に修正

## Test plan
- [ ] アプリを起動し、パーティ選択画面を表示
- [ ] パーティをタップして遠征準備画面に遷移
- [ ] 遠征を開始して playback 画面に遷移
- [ ] エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)