### PR TITLE
fix: applyBattleResultsでisDeadも更新するように修正

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -400,6 +400,7 @@ export class ExpeditionEngine {
         partyState[index].currentHP = Math.max(0, partyState[index].currentHP + delta)
         if (partyState[index].currentHP <= 0) {
           partyState[index].isKO = true
+          partyState[index].isDead = true
         }
       }
     })


### PR DESCRIPTION
## Summary
- HPが0以下になった際に`isDead`が更新されない問題を修正
- `applyBattleResults`で`isKO = true`と同時に`isDead = true`も設定するように変更
- これにより`casualties`が正しく算出され、経験値や因子処理が正常に動作

## Test plan
- [ ] 遠征を実行し、ゴブリンがKOになるケースで`casualties`に正しくIDが含まれることを確認
- [ ] 経験値分配が正しく行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)