### PR TITLE
fix: ダンジョンID→エリアIDマッピングと replay.meta.areaId の不整合を修正

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -46,8 +46,9 @@ export class ExpeditionEngine {
     // ダンジョンIDからエリアIDにマッピング
     const dungeonToAreaMap: Record<string, string> = {
       "1": "forest_outskirts",
-      "2": "mossy_cave",
-      "3": "old_mine"
+      "2": "goblin_village",
+      "3": "orc_camp",
+      "4": "slime_cave"
     }
 
     const areaId = dungeonToAreaMap[request.areaId] || request.areaId
@@ -243,7 +244,7 @@ export class ExpeditionEngine {
     return {
       meta: {
         expeditionId: `exp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-        areaId: request.areaId,
+        areaId: areaId,
         areaName: area.name,
         floors: area.floors,
         baseDurationSec: area.baseDurationSec,


### PR DESCRIPTION
## Summary
- `dungeonToAreaMap` に存在しないエリア(`mossy_cave`, `old_mine`)が含まれていた問題を修正
- `replay.meta.areaId` が `request.areaId`(元のダンジョンID)のままだった問題を修正し、マップ後の `areaId` を使用するように変更

## Test plan
- [ ] ダンジョンID "2", "3", "4" で遠征を開始し、敵データが正しく取得されることを確認
- [ ] 遠征リプレイの `meta.areaId` がマップ後のエリアID（例: `goblin_village`）になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)