### PR TITLE
fix: returnPolicy の if_two_ko と never を実装

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -416,6 +416,11 @@ export class ExpeditionEngine {
           return { shouldReturn: true, reason: "policy_return" }
         }
         break
+      case "if_two_ko":
+        if (partyState.filter(member => member.isKO).length >= 2) {
+          return { shouldReturn: true, reason: "policy_return" }
+        }
+        break
       case "last_one":
         if (aliveMembers <= 1) {
           return { shouldReturn: true, reason: "policy_return" }
@@ -430,6 +435,9 @@ export class ExpeditionEngine {
         if (currentFloor >= 3) {
           return { shouldReturn: true, reason: "policy_return" }
         }
+        break
+      case "never":
+        // 帰還条件なし - 最後まで探索（ボスクリアまたは全滅まで続行）
         break
     }
 


### PR DESCRIPTION
## Summary
- `checkReturnConditions` の switch 文に欠けていた `if_two_ko` と `never` のケースを追加
- `if_two_ko`: 2人以上がKOになったら `policy_return` で帰還
- `never`: 帰還条件なし（ボスクリアまたは全滅まで続行）

## Test plan
- [ ] `if_two_ko` ポリシーで遠征を開始し、2人KO時に帰還することを確認
- [ ] `never` ポリシーで遠征を開始し、途中帰還せずボスクリアまたは全滅まで続行することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)