### PR TITLE
feat: 戦闘ログの画面遷移化

### DIFF
--- a/goblin_native/app/(tabs)/formation/_layout.tsx
+++ b/goblin_native/app/(tabs)/formation/_layout.tsx
@@ -28,7 +28,7 @@ export default function FormationLayout() {
         name="playback"
         options={{
           title: 'Expedition',
-          presentation: 'fullScreenModal',
+          presentation: 'card',
           headerShown: false,
         }}
       />
@@ -44,6 +44,14 @@ export default function FormationLayout() {
         options={{
           title: 'Expedition Log',
           presentation: 'card',
+        }}
+      />
+      <Stack.Screen
+        name="battle-log"
+        options={{
+          title: 'Battle Log',
+          presentation: 'card',
+          headerShown: false,
         }}
       />
     </Stack>

--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useEffect } from 'react'
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { router, useLocalSearchParams } from 'expo-router'
+import type { BattleLogEntry } from '@/shared/types'
+import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
+
+export default function BattleLogScreen() {
+  const { logId } = useLocalSearchParams<{ logId?: string }>()
+
+  const battleLog = useMemo<BattleLogEntry[] | null>(() => {
+    if (!logId) return null
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return null
+    return getBattleLog(raw)
+  }, [logId])
+
+  useEffect(() => {
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return undefined
+    return () => {
+      clearBattleLog(raw)
+    }
+  }, [logId])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back()
+              return
+            }
+            router.replace('/formation/playback')
+          }}
+        >
+          <Text style={styles.navBack}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>戦闘ログ</Text>
+        <View style={styles.navSpacer} />
+      </View>
+
+      {!battleLog && (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>戦闘ログを読み込めませんでした。</Text>
+        </View>
+      )}
+
+      {battleLog && (
+        <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
+          {battleLog.map((entry, index) => {
+            if (entry.action === 'turn_start' && entry.turnState) {
+              return (
+                <View key={`turn-${entry.turn}-${index}`} style={styles.sectionCard}>
+                  <Text style={styles.sectionTitle}>Turn {entry.turn} 開始</Text>
+                  <Text style={styles.sectionLabel}>味方:</Text>
+                  {entry.turnState.allies.map(ally => (
+                    <Text key={ally.id} style={styles.sectionText}>
+                      {ally.name} {ally.currentHP}/{ally.maxHP} HP
+                    </Text>
+                  ))}
+                  <Text style={styles.sectionLabel}>敵:</Text>
+                  {entry.turnState.enemies.map((enemy, enemyIndex) => (
+                    <Text key={`${enemy.id}-${enemyIndex}`} style={styles.sectionText}>
+                      {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
+                    </Text>
+                  ))}
+                </View>
+              )
+            }
+
+            if (entry.action === 'turn_start') {
+              return null
+            }
+
+            return (
+              <View key={`log-${index}`} style={styles.logCard}>
+                <Text style={styles.logTitle}>
+                  {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
+                </Text>
+                <Text style={styles.logText}>{entry.actorName}の{entry.action}！</Text>
+                {entry.targetName && typeof entry.damage === 'number' && (
+                  <Text style={styles.logText}>
+                    {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
+                  </Text>
+                )}
+              </View>
+            )
+          })}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
+  },
+  navBack: {
+    fontSize: 14,
+    color: '#4B5563',
+  },
+  navTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#111827',
+    flex: 1,
+    textAlign: 'center',
+  },
+  navSpacer: {
+    width: 60,
+  },
+  body: {
+    flex: 1,
+  },
+  bodyContent: {
+    padding: 12,
+    gap: 10,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  sectionCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginTop: 6,
+  },
+  sectionText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+  logCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  logTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  logText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+})

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -3,8 +3,9 @@ import { View, Text, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator
 import { router, useFocusEffect } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { useExpeditionFlow, type ExpeditionHistoryDisplay } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
-import type { Party, Goblin, PartyStatus } from '@/shared/types'
+import type { Party, Goblin, ExpeditionRecord } from '@/shared/types'
 
 const MAX_PARTY_SLOTS = 6
 const INITIAL_PARTY_COUNT = 3
@@ -38,9 +39,19 @@ interface PartyCardProps {
   party: Party
   goblins: Goblin[]
   onPress: () => void
+  historyDisplays: ExpeditionHistoryDisplay[]
+  onHistoryPress: (record: ExpeditionRecord, ongoing: boolean) => void
+  onLogPress: (record: ExpeditionRecord) => void
 }
 
-function PartyCard({ party, goblins, onPress }: PartyCardProps) {
+function PartyCard({
+  party,
+  goblins,
+  onPress,
+  historyDisplays,
+  onHistoryPress,
+  onLogPress,
+}: PartyCardProps) {
   const members = useMemo(() => {
     return party.memberIds
       .map(id => goblins.find(g => g.id === id))
@@ -57,35 +68,63 @@ function PartyCard({ party, goblins, onPress }: PartyCardProps) {
   }, [members])
 
   const status = party.status ?? 'idle'
-
   return (
-    <TouchableOpacity style={styles.partyCard} onPress={onPress} activeOpacity={0.7}>
-      <View style={styles.partyHeader}>
-        <Text style={styles.partyName}>{party.name}</Text>
-        {status === 'expedition' && (
-          <View style={styles.expeditionBadge}>
-            <Text style={styles.expeditionBadgeText}>遠征中</Text>
+    <View style={styles.partyCard}>
+      <TouchableOpacity onPress={onPress} activeOpacity={0.7}>
+        <View style={styles.partyHeader}>
+          <Text style={styles.partyName}>{party.name}</Text>
+          {status === 'expedition' && (
+            <View style={styles.expeditionBadge}>
+              <Text style={styles.expeditionBadgeText}>遠征中</Text>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.membersRow}>
+          {slots.map((goblin, index) => (
+            <MemberSlot key={index} goblin={goblin} isEmpty={!goblin} />
+          ))}
+        </View>
+      </TouchableOpacity>
+
+      {historyDisplays.length > 0 && (
+        <View style={styles.historySection}>
+          <Text style={styles.historyTitle}>遠征履歴</Text>
+          <View style={styles.historyList}>
+            {historyDisplays.map(item => (
+              <View key={item.id} style={styles.historyRow}>
+                <TouchableOpacity
+                  style={styles.historyContent}
+                  onPress={() => onHistoryPress(item.record, item.ongoing)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.historyText}>{item.title}</Text>
+                  <Text style={styles.historyDungeon}>{item.subtitle}</Text>
+                </TouchableOpacity>
+                {!item.ongoing && (
+                  <TouchableOpacity style={styles.historyArrow} onPress={() => onLogPress(item.record)}>
+                    <Text style={styles.historyArrowText}>&gt;</Text>
+                  </TouchableOpacity>
+                )}
+              </View>
+            ))}
           </View>
-        )}
-      </View>
-
-      <View style={styles.membersRow}>
-        {slots.map((goblin, index) => (
-          <MemberSlot key={index} goblin={goblin} isEmpty={!goblin} />
-        ))}
-      </View>
-
-      {/* 遠征履歴セクション（将来実装） */}
-      {/* <View style={styles.historySection}>
-        <Text style={styles.historyTitle}>遠征履歴</Text>
-      </View> */}
-    </TouchableOpacity>
+        </View>
+      )}
+    </View>
   )
 }
 
 export default function FormationScreen() {
   const { parties, isLoading: partiesLoading, createParty, refreshParties } = usePartyService()
   const { goblins, isLoading: goblinsLoading, refreshGoblins } = useGoblinService()
+  const {
+    completeDueExpeditions,
+    currentTime,
+    partyHistories,
+    partyHistoryDisplays,
+    formatFullDateTimeWithSeconds,
+  } = useExpeditionFlow({ refreshParties, parties, enableAutoCompletion: true })
 
   // 画面がフォーカスされたときにデータを再取得
   useFocusEffect(
@@ -104,6 +143,7 @@ export default function FormationScreen() {
     return result
   }, [parties])
 
+
   const handlePartyPress = useCallback((party: Party | null, index: number) => {
     if (!party) {
       // パーティがない場合は新規作成して遷移
@@ -120,11 +160,18 @@ export default function FormationScreen() {
 
     const status = party.status ?? 'idle'
     if (status === 'expedition') {
-      // 遠征中のパーティはプレイバック画面へ
-      router.push({
-        pathname: '/formation/playback',
-        params: { partyId: party.id.toString() },
-      })
+      const latestHistory = partyHistories[party.id]?.[0]
+      if (latestHistory) {
+        router.push({
+          pathname: '/formation/playback',
+          params: { expeditionId: latestHistory.id, partyId: party.id.toString() },
+        })
+      } else {
+        router.push({
+          pathname: '/formation/playback',
+          params: { partyId: party.id.toString() },
+        })
+      }
     } else {
       // 待機中のパーティは遠征準備画面へ
       router.push({
@@ -132,7 +179,28 @@ export default function FormationScreen() {
         params: { partyId: party.id.toString() },
       })
     }
-  }, [createParty])
+  }, [createParty, partyHistories])
+
+  const handleHistoryPress = useCallback((record: ExpeditionRecord, ongoing: boolean) => {
+    if (ongoing) {
+      router.push({
+        pathname: '/formation/playback',
+        params: { expeditionId: record.id, partyId: record.partyId.toString() },
+      })
+    } else {
+      router.push({
+        pathname: '/formation/result',
+        params: { expeditionId: record.id, partyId: record.partyId.toString() },
+      })
+    }
+  }, [])
+
+  const handleLogPress = useCallback((record: ExpeditionRecord) => {
+    router.push({
+      pathname: '/formation/playback',
+      params: { expeditionId: record.id, partyId: record.partyId.toString() },
+    })
+  }, [])
 
   if (partiesLoading || goblinsLoading) {
     return (
@@ -143,42 +211,53 @@ export default function FormationScreen() {
     )
   }
 
-  return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
-      <Text style={styles.screenTitle}>パーティ選択</Text>
+  const currentTimeLabel = formatFullDateTimeWithSeconds(currentTime)
 
-      {displayParties.map((party, index) => {
-        if (party) {
-          return (
-            <PartyCard
-              key={party.id}
-              party={party}
-              goblins={goblins}
-              onPress={() => handlePartyPress(party, index)}
-            />
-          )
-        } else {
-          // 空のパーティ枠
-          return (
-            <TouchableOpacity
-              key={`empty-${index}`}
-              style={styles.partyCard}
-              onPress={() => handlePartyPress(null, index)}
-              activeOpacity={0.7}
-            >
-              <View style={styles.partyHeader}>
-                <Text style={styles.partyName}>PT{index + 1}</Text>
-              </View>
-              <View style={styles.membersRow}>
-                {Array.from({ length: MAX_PARTY_SLOTS }).map((_, slotIndex) => (
-                  <MemberSlot key={slotIndex} isEmpty />
-                ))}
-              </View>
-            </TouchableOpacity>
-          )
-        }
-      })}
-    </ScrollView>
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
+        <Text style={styles.screenTitle}>パーティ選択</Text>
+
+        {displayParties.map((party, index) => {
+          if (party) {
+            return (
+              <PartyCard
+                key={party.id}
+                party={party}
+                goblins={goblins}
+                onPress={() => handlePartyPress(party, index)}
+                historyDisplays={partyHistoryDisplays[party.id] ?? []}
+                onHistoryPress={handleHistoryPress}
+                onLogPress={handleLogPress}
+              />
+            )
+          } else {
+            // 空のパーティ枠
+            return (
+              <TouchableOpacity
+                key={`empty-${index}`}
+                style={styles.partyCard}
+                onPress={() => handlePartyPress(null, index)}
+                activeOpacity={0.7}
+              >
+                <View style={styles.partyHeader}>
+                  <Text style={styles.partyName}>PT{index + 1}</Text>
+                </View>
+                <View style={styles.membersRow}>
+                  {Array.from({ length: MAX_PARTY_SLOTS }).map((_, slotIndex) => (
+                    <MemberSlot key={slotIndex} isEmpty />
+                  ))}
+                </View>
+              </TouchableOpacity>
+            )
+          }
+        })}
+      </ScrollView>
+
+      <View style={styles.currentTimeBadge} pointerEvents="none">
+        <Text style={styles.currentTimeText}>{currentTimeLabel}</Text>
+      </View>
+    </View>
   )
 }
 
@@ -187,8 +266,12 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#F3F4F6',
   },
+  scrollView: {
+    flex: 1,
+  },
   contentContainer: {
     padding: 16,
+    paddingBottom: 48,
   },
   loadingContainer: {
     flex: 1,
@@ -217,6 +300,63 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
+  },
+  currentTimeBadge: {
+    position: 'absolute',
+    left: 12,
+    bottom: 8,
+    backgroundColor: 'rgba(17, 24, 39, 0.8)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  currentTimeText: {
+    fontSize: 11,
+    color: '#F9FAFB',
+  },
+  historySection: {
+    marginTop: 12,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+  },
+  historyTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginBottom: 8,
+  },
+  historyList: {
+    gap: 8,
+  },
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  historyContent: {
+    flex: 1,
+  },
+  historyText: {
+    fontSize: 12,
+    color: '#374151',
+  },
+  historyDungeon: {
+    fontSize: 11,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  historyArrow: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  historyArrowText: {
+    fontSize: 16,
+    color: '#6B7280',
+    fontWeight: '600',
   },
   partyHeader: {
     flexDirection: 'row',

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
-import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator, Modal } from 'react-native'
+import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
@@ -9,6 +9,7 @@ import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
 import { CompleteExpeditionUseCase } from '@/core/usecases'
 import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord } from '@/shared/types'
 import type { BattleLogEntry } from '@/shared/types'
+import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 
 interface LogEntry {
   id: string
@@ -69,7 +70,6 @@ export default function ExpeditionPlaybackScreen() {
   const [currentTime, setCurrentTime] = useState(0)
   const [replay, setReplay] = useState<ExpeditionReplay | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [selectedBattleLog, setSelectedBattleLog] = useState<BattleLogEntry[] | null>(null)
 
   const progressAnim = useRef(new Animated.Value(0)).current
   const playbackTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -87,6 +87,12 @@ export default function ExpeditionPlaybackScreen() {
     const minutes = Math.floor(seconds / 60)
     const secs = Math.floor(seconds % 60)
     return `${minutes}:${secs.toString().padStart(2, '0')}`
+  }, [])
+
+  const openBattleLog = useCallback((detail: BattleLogEntry[]) => {
+    const logId = storeBattleLog(detail)
+    const path = `/formation/battle-log?logId=${encodeURIComponent(logId)}`
+    router.push(path)
   }, [])
 
   const getReturnReasonText = useCallback((reason: TimelineEvent extends { reason: infer R } ? R : never) => {
@@ -399,77 +405,32 @@ export default function ExpeditionPlaybackScreen() {
 
       <View style={styles.eventLog}>
         <ScrollView style={styles.logScroll}>
-          {eventLog.map(entry => (
-            <Text key={entry.id} style={styles.logText}>
-              {entry.text.replace('[詳細]', '')}
-              {entry.detail && (
-                <Text style={styles.logDetail} onPress={() => setSelectedBattleLog(entry.detail!)}>
-                  [詳細]
-                </Text>
-              )}
-            </Text>
-          ))}
+          {eventLog.map(entry => {
+            const baseText = entry.text.replace('[詳細]', '')
+            if (entry.detail) {
+              return (
+                <TouchableOpacity
+                  key={entry.id}
+                  style={styles.logRow}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
+                  onPress={() => openBattleLog(entry.detail!)}
+                >
+                  <Text style={styles.logText}>{baseText}</Text>
+                  <Text style={styles.logDetail}>詳細</Text>
+                </TouchableOpacity>
+              )
+            }
+
+            return (
+              <View key={entry.id} style={styles.logRow}>
+                <Text style={styles.logText}>{baseText}</Text>
+              </View>
+            )
+          })}
         </ScrollView>
       </View>
-
-      <Modal
-        visible={Boolean(selectedBattleLog)}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setSelectedBattleLog(null)}
-      >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.modalCard}>
-            <View style={styles.modalHeader}>
-              <Text style={styles.modalTitle}>戦闘ログ</Text>
-              <TouchableOpacity onPress={() => setSelectedBattleLog(null)}>
-                <Text style={styles.modalClose}>×</Text>
-              </TouchableOpacity>
-            </View>
-            <ScrollView style={styles.modalBody}>
-              {selectedBattleLog?.map((entry, index) => {
-                if (entry.action === 'turn_start' && entry.turnState) {
-                  return (
-                    <View key={`turn-${entry.turn}-${index}`} style={styles.modalSection}>
-                      <Text style={styles.modalSectionTitle}>Turn {entry.turn} 開始</Text>
-                      <Text style={styles.modalLabel}>味方:</Text>
-                      {entry.turnState.allies.map(ally => (
-                        <Text key={ally.id} style={styles.modalText}>
-                          {ally.name} {ally.currentHP}/{ally.maxHP} HP
-                        </Text>
-                      ))}
-                      <Text style={styles.modalLabel}>敵:</Text>
-                      {entry.turnState.enemies.map((enemy, enemyIndex) => (
-                        <Text key={`${enemy.id}-${enemyIndex}`} style={styles.modalText}>
-                          {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
-                        </Text>
-                      ))}
-                    </View>
-                  )
-                }
-
-                if (entry.action === 'turn_start') {
-                  return null
-                }
-
-                return (
-                  <View key={`log-${index}`} style={styles.modalLogCard}>
-                    <Text style={styles.modalLogTitle}>
-                      {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
-                    </Text>
-                    <Text style={styles.modalText}>{entry.actorName}の{entry.action}！</Text>
-                    {entry.targetName && typeof entry.damage === 'number' && (
-                      <Text style={styles.modalText}>
-                        {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
-                      </Text>
-                    )}
-                  </View>
-                )
-              })}
-            </ScrollView>
-          </View>
-        </View>
-      </Modal>
     </SafeAreaView>
   )
 }
@@ -592,86 +553,21 @@ const styles = StyleSheet.create({
   logScroll: {
     flex: 1,
   },
+  logRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 6,
+    gap: 6,
+  },
   logText: {
     fontSize: 12,
     color: '#374151',
     fontFamily: 'Courier',
-    marginBottom: 6,
+    flex: 1,
   },
   logDetail: {
     color: '#2563EB',
     fontWeight: '600',
-  },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.4)',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  modalCard: {
-    backgroundColor: '#F9FAFB',
-    borderRadius: 12,
-    overflow: 'hidden',
-    maxHeight: '85%',
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: '#1F2937',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  modalTitle: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: '#F9FAFB',
-  },
-  modalClose: {
-    fontSize: 20,
-    color: '#F9FAFB',
-    paddingHorizontal: 8,
-  },
-  modalBody: {
-    padding: 12,
-  },
-  modalSection: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    padding: 12,
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  modalSectionTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
-  },
-  modalLabel: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#6B7280',
-    marginTop: 6,
-  },
-  modalText: {
-    fontSize: 12,
-    color: '#374151',
-    marginTop: 2,
-  },
-  modalLogCard: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    padding: 12,
-    marginBottom: 10,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  modalLogTitle: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 6,
   },
 })

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -1,272 +1,475 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
-import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native'
+import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator, Modal } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
-import type { TimelineEvent, Goblin } from '@/shared/types'
+import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
+import { CompleteExpeditionUseCase } from '@/core/usecases'
+import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord } from '@/shared/types'
+import type { BattleLogEntry } from '@/shared/types'
 
-interface DisplayEvent {
-  type: string
-  message: string
-  color: string
-  icon: string
+interface LogEntry {
+  id: string
+  text: string
+  detail?: BattleLogEntry[]
 }
 
 export default function ExpeditionPlaybackScreen() {
-  const { partyId, dungeonId, returnPolicy } = useLocalSearchParams<{
-    partyId: string
-    dungeonId: string
-    returnPolicy: string
+  const { partyId, expeditionId } = useLocalSearchParams<{
+    partyId?: string
+    expeditionId?: string
   }>()
 
-  const { getPartyById, markExpedition, markIdle, isLoading: isPartyLoading } = usePartyService()
-  const { goblins, isLoading: isGoblinLoading } = useGoblinService()
+  const { getPartyById, partyRepository, isLoading: isPartyLoading } = usePartyService()
+  const { goblins, goblinRepository, isLoading: isGoblinLoading } = useGoblinService()
   const { dungeons } = useDungeonProgress()
+  const {
+    expeditionRecords,
+    getExpeditionById,
+    getPartyExpeditionHistory,
+    completeExpeditionRecord,
+    isLoading: isExpeditionLoading,
+  } = useExpeditionService()
+
+  const expeditionRecord = useMemo<ExpeditionRecord | null>(() => {
+    if (expeditionId) {
+      return getExpeditionById(expeditionId)
+    }
+    const numericPartyId = partyId ? Number.parseInt(partyId, 10) : NaN
+    if (Number.isNaN(numericPartyId)) return null
+    const history = getPartyExpeditionHistory(numericPartyId, 1)
+    return history[0] ?? null
+  }, [expeditionId, partyId, getExpeditionById, getPartyExpeditionHistory, expeditionRecords])
+
+  const resolvedPartyId = useMemo(() => {
+    if (expeditionRecord) return expeditionRecord.partyId
+    const numericPartyId = partyId ? Number.parseInt(partyId, 10) : NaN
+    return Number.isNaN(numericPartyId) ? null : numericPartyId
+  }, [expeditionRecord, partyId])
 
   const party = useMemo(() => {
-    if (!partyId || isPartyLoading) return null
+    if (!resolvedPartyId || isPartyLoading) return null
     try {
-      return getPartyById(parseInt(partyId, 10))
+      return getPartyById(resolvedPartyId)
     } catch {
       return null
     }
-  }, [partyId, getPartyById, isPartyLoading])
+  }, [resolvedPartyId, getPartyById, isPartyLoading])
 
   const dungeon = useMemo(() => {
-    const id = dungeonId || party?.dungeonId
+    const id = expeditionRecord?.dungeonId || party?.dungeonId
     return dungeons.find(d => d.id === id)
-  }, [dungeons, dungeonId, party?.dungeonId])
+  }, [dungeons, expeditionRecord?.dungeonId, party?.dungeonId])
 
-  const partyMembers = useMemo(() => {
-    if (!party) return []
-    return party.memberIds
-      .map(id => goblins.find(g => g.id === id))
-      .filter((g): g is Goblin => g !== undefined)
-  }, [party, goblins])
-
-  const [events, setEvents] = useState<DisplayEvent[]>([])
-  const [currentEventIndex, setCurrentEventIndex] = useState(0)
-  const [isComplete, setIsComplete] = useState(false)
-  const [expeditionResult, setExpeditionResult] = useState<{
-    success: boolean
-    xpGained: number
-    maxFloor: number
-  } | null>(null)
+  const [eventLog, setEventLog] = useState<LogEntry[]>([])
+  const [partyHp, setPartyHp] = useState<number[]>([])
+  const [currentFloor, setCurrentFloor] = useState(1)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [replay, setReplay] = useState<ExpeditionReplay | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [selectedBattleLog, setSelectedBattleLog] = useState<BattleLogEntry[] | null>(null)
 
   const progressAnim = useRef(new Animated.Value(0)).current
+  const playbackTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const startTimestampRef = useRef<number>(0)
+  const baseTimeRef = useRef<number>(0)
+  const processedEventIndexRef = useRef(0)
+  const hasCompletedRef = useRef(false)
+  const logIdRef = useRef(0)
 
-  // 遠征イベントをシミュレート
-  useEffect(() => {
-    if (!dungeon || !party || partyMembers.length === 0) return
+  const completeExpeditionUseCase = useMemo(() => {
+    return new CompleteExpeditionUseCase(goblinRepository, partyRepository)
+  }, [goblinRepository, partyRepository])
 
-    // パーティを遠征状態に設定
-    markExpedition(party.id)
+  const formatTime = useCallback((seconds: number): string => {
+    const minutes = Math.floor(seconds / 60)
+    const secs = Math.floor(seconds % 60)
+    return `${minutes}:${secs.toString().padStart(2, '0')}`
+  }, [])
 
-    const floors = dungeon.floors
-    const generatedEvents: DisplayEvent[] = []
+  const getReturnReasonText = useCallback((reason: TimelineEvent extends { reason: infer R } ? R : never) => {
+    if (reason === 'completed') return '探索完了'
+    if (reason === 'defeated') return '全滅により撤退'
+    if (reason === 'policy_return') return '帰還'
+    if (reason === 'abort') return '緊急帰還'
+    return '探索完了'
+  }, [])
 
-    // 開始イベント
-    generatedEvents.push({
-      type: 'move_start',
-      message: `${dungeon.name}への遠征を開始...`,
-      color: '#6B7280',
-      icon: '>',
-    })
+  const buildLogEntries = useCallback((event: TimelineEvent): LogEntry[] => {
+    const createEntry = (text: string, detail?: BattleLogEntry[]) => {
+      logIdRef.current += 1
+      return { id: `${logIdRef.current}`, text, detail }
+    }
+    switch (event.type) {
+      case 'move_start':
+        return [createEntry(`${event.floor}階の探索を開始`)]
+      case 'floor_up':
+        return [createEntry(`${event.from}階から${event.to}階へ移動`)]
+      case 'exploring':
+        return [createEntry('探索中...')]
+      case 'battle':
+      case 'boss': {
+        const label = event.type === 'boss' ? 'ボス' : '戦闘'
+        const result = event.combat.outcome === 'win' ? '勝利' : '敗北'
+        const entries: LogEntry[] = [
+          createEntry(
+            `${label} ${event.enemy.name} Lv${event.enemy.lvl} ×${event.enemy.count}体と遭遇 → ${result}[詳細]`,
+            event.combat.detailedLog,
+          ),
+        ]
+        if (event.xp > 0) {
+          entries.push(createEntry(`${event.xp}XP獲得`))
+        }
+        return entries
+      }
+      case 'return':
+        return [createEntry(getReturnReasonText(event.reason))]
+      default:
+        return [createEntry('イベント発生')]
+    }
+  }, [getReturnReasonText])
 
-    // 各階層のイベントを生成
-    for (let floor = 1; floor <= floors; floor++) {
-      generatedEvents.push({
-        type: 'floor_arrive',
-        message: `${floor}階に到着`,
-        color: '#3B82F6',
-        icon: 'F',
-      })
+  const applyEvent = useCallback((event: TimelineEvent, eventTime: number) => {
+    const entries = buildLogEntries(event)
+    setEventLog(prev => [
+      ...prev,
+      ...entries.map(entry => ({
+        ...entry,
+        text: `[${formatTime(eventTime)}] ${entry.text}`,
+      })),
+    ])
 
-      // ランダムなイベント
-      const eventRoll = Math.random()
-      if (eventRoll < 0.7) {
-        // 戦闘
-        generatedEvents.push({
-          type: 'encounter',
-          message: `敵と遭遇！`,
-          color: '#F59E0B',
-          icon: '!',
-        })
-        generatedEvents.push({
-          type: 'battle',
-          message: '戦闘中...',
-          color: '#EF4444',
-          icon: 'X',
-        })
-        generatedEvents.push({
-          type: 'victory',
-          message: `勝利！経験値を獲得`,
-          color: '#10B981',
-          icon: 'V',
-        })
-      } else if (eventRoll < 0.9) {
-        // 探索
-        generatedEvents.push({
-          type: 'exploring',
-          message: '探索中...',
-          color: '#8B5CF6',
-          icon: '?',
+    if (event.type === 'floor_up') {
+      setCurrentFloor(event.to)
+    }
+    if (event.type === 'move_start') {
+      setCurrentFloor(event.floor)
+    }
+    if (event.type === 'battle' || event.type === 'boss') {
+      if (event.combat.allyHPDelta) {
+        setPartyHp(prev => {
+          const updated = [...prev]
+          event.combat.allyHPDelta.forEach((delta, idx) => {
+            updated[idx] = Math.max(0, (updated[idx] ?? 0) + delta)
+          })
+          return updated
         })
       }
     }
+  }, [buildLogEntries, formatTime])
 
-    // ボス戦
-    generatedEvents.push({
-      type: 'boss',
-      message: `ボス出現！`,
-      color: '#DC2626',
-      icon: 'B',
-    })
-    generatedEvents.push({
-      type: 'battle',
-      message: '激闘中...',
-      color: '#EF4444',
-      icon: 'X',
-    })
+  const playbackEvents = useMemo(() => {
+    if (!replay) return []
+    const events = replay.events.map(event => ({ ...event }))
+    let maxAt = 0
+    for (const event of events) {
+      if (event.at > maxAt) maxAt = event.at
+    }
+    if (events.length > 0) {
+      const last = events[events.length - 1]
+      if (last.type === 'return' && last.at < maxAt) {
+        last.at = maxAt
+      }
+    }
+    return events
+  }, [replay])
 
-    // 結果（80%の確率で成功）
-    const success = Math.random() < 0.8
-    if (success) {
-      generatedEvents.push({
-        type: 'complete',
-        message: 'ダンジョン踏破！',
-        color: '#10B981',
-        icon: '*',
-      })
-    } else {
-      generatedEvents.push({
-        type: 'return',
-        message: '撤退...',
-        color: '#EF4444',
-        icon: '<',
-      })
+  const playbackDuration = useMemo(() => {
+    if (!replay) return 0
+    const maxAt = playbackEvents.reduce((max, event) => Math.max(max, event.at), 0)
+    return Math.max(replay.durationSec, maxAt)
+  }, [replay, playbackEvents])
+
+  const initialTime = useMemo(() => {
+    if (!replay || !expeditionRecord) return 0
+    const elapsedSec = (Date.now() - expeditionRecord.startTime.getTime()) / 1000
+    return Math.min(Math.max(0, elapsedSec), playbackDuration)
+  }, [replay, expeditionRecord, playbackDuration])
+
+  const completePlayback = useCallback(async () => {
+    if (!expeditionRecord || !replay || hasCompletedRef.current) return
+    hasCompletedRef.current = true
+
+    if (expeditionRecord.status !== 'ongoing') {
+      return
     }
 
-    setEvents(generatedEvents)
-    setExpeditionResult({
-      success,
-      xpGained: floors * 50 + (success ? 100 : 0),
-      maxFloor: success ? floors : Math.floor(floors * 0.7),
-    })
+    try {
+      await completeExpeditionUseCase.execute(expeditionRecord.partyId, replay)
+      completeExpeditionRecord(expeditionRecord.id, replay)
+    } catch (error) {
+      console.warn('[Playback] Failed to complete expedition', error)
+    }
+  }, [expeditionRecord, replay, completeExpeditionUseCase, completeExpeditionRecord])
 
-    // プログレスアニメーション
-    const duration = generatedEvents.length * 800
+  useEffect(() => {
+    if (isPartyLoading || isGoblinLoading || isExpeditionLoading) return
+    if (!expeditionRecord) {
+      setErrorMessage('遠征データが見つかりません')
+      return
+    }
+    if (!expeditionRecord.replay) {
+      setErrorMessage(null)
+      setReplay(null)
+      return
+    }
+
+    setErrorMessage(null)
+    setReplay(expeditionRecord.replay)
+  }, [expeditionRecord, isPartyLoading, isGoblinLoading, isExpeditionLoading])
+
+  useEffect(() => {
+    if (!replay) return
+    if (playbackTimerRef.current) {
+      clearInterval(playbackTimerRef.current)
+    }
+
+    const initialPartyHp = replay.meta.party.map(memberId => {
+      const goblin = goblins.find(g => g.id === parseInt(memberId, 10))
+      return goblin?.stats.hp ?? 100
+    })
+    let tempHp = [...initialPartyHp]
+    let tempFloor = 1
+    const preloadedLogs: LogEntry[] = []
+    let nextIndex = 0
+
+    while (nextIndex < playbackEvents.length && playbackEvents[nextIndex].at <= initialTime) {
+      const event = playbackEvents[nextIndex]
+      const entries = buildLogEntries(event)
+      preloadedLogs.push(
+        ...entries.map(entry => ({
+          ...entry,
+          text: `[${formatTime(event.at)}] ${entry.text}`,
+        }))
+      )
+      if (event.type === 'floor_up') {
+        tempFloor = event.to
+      }
+      if (event.type === 'move_start') {
+        tempFloor = event.floor
+      }
+      if (event.type === 'battle' || event.type === 'boss') {
+        if (event.combat.allyHPDelta) {
+          event.combat.allyHPDelta.forEach((delta, idx) => {
+            tempHp[idx] = Math.max(0, (tempHp[idx] ?? 0) + delta)
+          })
+        }
+      }
+      nextIndex += 1
+    }
+
+    setEventLog(preloadedLogs)
+    setPartyHp(tempHp)
+    setCurrentFloor(tempFloor)
+    processedEventIndexRef.current = nextIndex
+    hasCompletedRef.current = false
+    baseTimeRef.current = initialTime
+    startTimestampRef.current = Date.now()
+    setCurrentTime(initialTime)
+
+    const progress = playbackDuration > 0 ? initialTime / playbackDuration : 1
+    progressAnim.setValue(progress)
+
+    if (initialTime >= playbackDuration) {
+      void completePlayback()
+      return
+    }
+
+    const remainingMs = (playbackDuration - initialTime) * 1000
     Animated.timing(progressAnim, {
       toValue: 1,
-      duration,
+      duration: remainingMs,
       useNativeDriver: false,
     }).start()
 
-    // イベント進行
-    let eventIndex = 0
-    const interval = setInterval(() => {
-      if (eventIndex < generatedEvents.length - 1) {
-        eventIndex++
-        setCurrentEventIndex(eventIndex)
-      } else {
-        setIsComplete(true)
-        markIdle(party.id)
-        clearInterval(interval)
+    playbackTimerRef.current = setInterval(() => {
+      const elapsedSec = (Date.now() - startTimestampRef.current) / 1000
+      const timeNow = Math.min(baseTimeRef.current + elapsedSec, playbackDuration)
+      setCurrentTime(timeNow)
+
+      while (
+        processedEventIndexRef.current < playbackEvents.length &&
+        playbackEvents[processedEventIndexRef.current].at <= timeNow
+      ) {
+        const event = playbackEvents[processedEventIndexRef.current]
+        applyEvent(event, event.at)
+        processedEventIndexRef.current += 1
       }
-    }, 800)
+
+      if (timeNow >= playbackDuration) {
+        if (playbackTimerRef.current) {
+          clearInterval(playbackTimerRef.current)
+        }
+        completePlayback()
+      }
+    }, 400)
 
     return () => {
-      clearInterval(interval)
-      if (party) {
-        markIdle(party.id)
+      if (playbackTimerRef.current) {
+        clearInterval(playbackTimerRef.current)
       }
     }
-  }, [dungeon, party, partyMembers.length])
+  }, [
+    replay,
+    buildLogEntries,
+    formatTime,
+    completePlayback,
+    progressAnim,
+    initialTime,
+    goblins,
+    applyEvent,
+    playbackEvents,
+    playbackDuration,
+  ])
 
-  const handleViewResults = useCallback(() => {
-    router.replace({
-      pathname: '/formation/result',
-      params: {
-        partyId,
-        dungeonId: dungeonId || party?.dungeonId || '',
-        success: expeditionResult?.success ? 'true' : 'false',
-        xpGained: String(expeditionResult?.xpGained || 0),
-        maxFloor: String(expeditionResult?.maxFloor || 0),
-      },
-    })
-  }, [partyId, dungeonId, party?.dungeonId, expeditionResult])
+  useEffect(() => {
+    return () => {
+      if (playbackTimerRef.current) {
+        clearInterval(playbackTimerRef.current)
+      }
+    }
+  }, [])
 
-  if (!party || !dungeon) {
+  if (!expeditionRecord || !dungeon || !replay) {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color="#3B82F6" />
-          <Text style={styles.loadingText}>読み込み中...</Text>
+          <Text style={styles.loadingText}>{errorMessage ?? '読み込み中...'}</Text>
         </View>
       </SafeAreaView>
     )
   }
 
-  const currentEvent = events[currentEventIndex]
+  const progressText = `${formatTime(currentTime)} / ${formatTime(playbackDuration)}`
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>遠征中</Text>
-        <Text style={styles.subtitle}>{party.name} → {dungeon.name}</Text>
+      <View style={styles.navBar}>
+        <TouchableOpacity onPress={() => router.back()}>
+          <Text style={styles.navBack}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>{dungeon.name} - ログ閲覧</Text>
+        <View style={styles.navSpacer} />
       </View>
 
-      <View style={styles.partyInfo}>
-        {partyMembers.map(member => (
-          <View key={member.id} style={styles.memberBadge}>
-            <Text style={styles.memberIcon}>G</Text>
-            <Text style={styles.memberName}>{member.name}</Text>
-          </View>
-        ))}
-      </View>
-
-      <View style={styles.progressContainer}>
-        <Animated.View
-          style={[
-            styles.progressBar,
-            {
-              width: progressAnim.interpolate({
-                inputRange: [0, 1],
-                outputRange: ['0%', '100%'],
-              }),
-            },
-          ]}
-        />
-      </View>
-
-      {currentEvent && (
-        <View style={styles.eventContainer}>
-          <View style={[styles.eventIcon, { backgroundColor: currentEvent.color }]}>
-            <Text style={styles.eventIconText}>{currentEvent.icon}</Text>
-          </View>
-          <Text style={styles.eventMessage}>{currentEvent.message}</Text>
+      <View style={styles.statusBar}>
+        <View style={styles.statusRow}>
+          <Text style={styles.statusTitle}>{dungeon.name} - {currentFloor}階</Text>
+          <Text style={styles.statusTimer}>{progressText}</Text>
         </View>
-      )}
+        <View style={styles.progressContainer}>
+          <Animated.View
+            style={[
+              styles.progressBar,
+              {
+                width: progressAnim.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ['0%', '100%'],
+                }),
+              },
+            ]}
+          />
+        </View>
+      </View>
+
+      <View style={styles.partyGrid}>
+        {replay.meta.party.map((memberId, index) => {
+          const goblin = goblins.find(g => g.id === parseInt(memberId, 10))
+          const maxHp = goblin?.stats.hp ?? 100
+          const currentHp = partyHp[index] ?? maxHp
+          return (
+            <View key={memberId} style={styles.partyCard}>
+              <Text style={styles.partyNameText}>{goblin?.name || `ID:${memberId}`}</Text>
+              <View style={styles.hpBar}>
+                <View
+                  style={[
+                    styles.hpBarFill,
+                    { width: `${Math.min(100, (currentHp / maxHp) * 100)}%` },
+                  ]}
+                />
+              </View>
+              <Text style={styles.hpText}>HP: {currentHp}/{maxHp}</Text>
+            </View>
+          )
+        })}
+      </View>
 
       <View style={styles.eventLog}>
-        <Text style={styles.logTitle}>イベントログ</Text>
         <ScrollView style={styles.logScroll}>
-          {events.slice(0, currentEventIndex + 1).reverse().map((event, index) => (
-            <View key={index} style={styles.logItem}>
-              <View style={[styles.logDot, { backgroundColor: event.color }]} />
-              <Text style={styles.logText}>{event.message}</Text>
-            </View>
+          {eventLog.map(entry => (
+            <Text key={entry.id} style={styles.logText}>
+              {entry.text.replace('[詳細]', '')}
+              {entry.detail && (
+                <Text style={styles.logDetail} onPress={() => setSelectedBattleLog(entry.detail!)}>
+                  [詳細]
+                </Text>
+              )}
+            </Text>
           ))}
         </ScrollView>
       </View>
 
-      {isComplete && (
-        <TouchableOpacity style={styles.resultButton} onPress={handleViewResults}>
-          <Text style={styles.resultButtonText}>結果を見る</Text>
-        </TouchableOpacity>
-      )}
+      <Modal
+        visible={Boolean(selectedBattleLog)}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSelectedBattleLog(null)}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalCard}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>戦闘ログ</Text>
+              <TouchableOpacity onPress={() => setSelectedBattleLog(null)}>
+                <Text style={styles.modalClose}>×</Text>
+              </TouchableOpacity>
+            </View>
+            <ScrollView style={styles.modalBody}>
+              {selectedBattleLog?.map((entry, index) => {
+                if (entry.action === 'turn_start' && entry.turnState) {
+                  return (
+                    <View key={`turn-${entry.turn}-${index}`} style={styles.modalSection}>
+                      <Text style={styles.modalSectionTitle}>Turn {entry.turn} 開始</Text>
+                      <Text style={styles.modalLabel}>味方:</Text>
+                      {entry.turnState.allies.map(ally => (
+                        <Text key={ally.id} style={styles.modalText}>
+                          {ally.name} {ally.currentHP}/{ally.maxHP} HP
+                        </Text>
+                      ))}
+                      <Text style={styles.modalLabel}>敵:</Text>
+                      {entry.turnState.enemies.map((enemy, enemyIndex) => (
+                        <Text key={`${enemy.id}-${enemyIndex}`} style={styles.modalText}>
+                          {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
+                        </Text>
+                      ))}
+                    </View>
+                  )
+                }
+
+                if (entry.action === 'turn_start') {
+                  return null
+                }
+
+                return (
+                  <View key={`log-${index}`} style={styles.modalLogCard}>
+                    <Text style={styles.modalLogTitle}>
+                      {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
+                    </Text>
+                    <Text style={styles.modalText}>{entry.actorName}の{entry.action}！</Text>
+                    {entry.targetName && typeof entry.damage === 'number' && (
+                      <Text style={styles.modalText}>
+                        {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
+                      </Text>
+                    )}
+                  </View>
+                )
+              })}
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   )
 }
@@ -274,7 +477,7 @@ export default function ExpeditionPlaybackScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1F2937',
+    backgroundColor: '#F3F4F6',
   },
   loadingContainer: {
     flex: 1,
@@ -286,121 +489,189 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#9CA3AF',
   },
-  header: {
-    padding: 20,
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#9CA3AF',
-    marginTop: 4,
-  },
-  partyInfo: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    paddingHorizontal: 20,
-    marginBottom: 16,
-    gap: 8,
-  },
-  memberBadge: {
+  navBar: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#374151',
+    justifyContent: 'space-between',
     paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-    gap: 4,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
   },
-  memberIcon: {
+  navBack: {
     fontSize: 14,
-    fontWeight: 'bold',
-    color: '#10B981',
+    color: '#374151',
   },
-  memberName: {
+  navTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#111827',
+    flex: 1,
+    textAlign: 'center',
+  },
+  navSpacer: {
+    width: 60,
+  },
+  statusBar: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#1F2937',
+  },
+  statusRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  statusTitle: {
     fontSize: 12,
-    color: '#FFFFFF',
+    fontWeight: '600',
+    color: '#F9FAFB',
+  },
+  statusTimer: {
+    fontSize: 12,
+    color: '#D1D5DB',
+  },
+  partyGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+  },
+  partyCard: {
+    width: '48%',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  partyNameText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  hpBar: {
+    height: 4,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  hpBarFill: {
+    height: '100%',
+    backgroundColor: '#374151',
+  },
+  hpText: {
+    marginTop: 6,
+    fontSize: 11,
+    color: '#6B7280',
   },
   progressContainer: {
-    height: 8,
+    height: 6,
     backgroundColor: '#374151',
-    marginHorizontal: 20,
-    borderRadius: 4,
+    borderRadius: 3,
     overflow: 'hidden',
   },
   progressBar: {
     height: '100%',
-    backgroundColor: '#3B82F6',
-    borderRadius: 4,
-  },
-  eventContainer: {
-    alignItems: 'center',
-    padding: 40,
-  },
-  eventIcon: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 20,
-  },
-  eventIconText: {
-    fontSize: 36,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-  },
-  eventMessage: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#FFFFFF',
-    textAlign: 'center',
+    backgroundColor: '#9CA3AF',
+    borderRadius: 3,
   },
   eventLog: {
     flex: 1,
-    backgroundColor: '#111827',
-    margin: 20,
-    borderRadius: 12,
-    padding: 16,
-  },
-  logTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    color: '#9CA3AF',
-    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+    margin: 12,
+    borderRadius: 8,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
   },
   logScroll: {
     flex: 1,
   },
-  logItem: {
+  logText: {
+    fontSize: 12,
+    color: '#374151',
+    fontFamily: 'Courier',
+    marginBottom: 6,
+  },
+  logDetail: {
+    color: '#2563EB',
+    fontWeight: '600',
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  modalCard: {
+    backgroundColor: '#F9FAFB',
+    borderRadius: 12,
+    overflow: 'hidden',
+    maxHeight: '85%',
+  },
+  modalHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 8,
+    justifyContent: 'space-between',
+    backgroundColor: '#1F2937',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
   },
-  logDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    marginRight: 12,
+  modalTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#F9FAFB',
   },
-  logText: {
+  modalClose: {
+    fontSize: 20,
+    color: '#F9FAFB',
+    paddingHorizontal: 8,
+  },
+  modalBody: {
+    padding: 12,
+  },
+  modalSection: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  modalSectionTitle: {
     fontSize: 14,
-    color: '#D1D5DB',
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
   },
-  resultButton: {
-    backgroundColor: '#10B981',
-    margin: 20,
-    padding: 16,
-    borderRadius: 12,
-    alignItems: 'center',
+  modalLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginTop: 6,
   },
-  resultButtonText: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
+  modalText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+  modalLogCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  modalLogTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
   },
 })

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -4,6 +4,7 @@ import { router, useLocalSearchParams, Stack, useFocusEffect } from 'expo-router
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
+import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import type { ExpeditionRequest, Goblin, Dungeon } from '@/shared/types'
 
@@ -46,9 +47,18 @@ function MemberSlot({ goblin, isEmpty }: MemberSlotProps) {
 
 export default function ExpeditionPreparationScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
-  const { parties, isLoading: partiesLoading, getPartyById, setDungeon, setReturnPolicy, setTargetFloor, refreshParties } = usePartyService()
+  const {
+    parties,
+    isLoading: partiesLoading,
+    getPartyById,
+    setDungeon,
+    setReturnPolicy,
+    setTargetFloor,
+    refreshParties,
+  } = usePartyService()
   const { goblins, isLoading: goblinsLoading, refreshGoblins } = useGoblinService()
   const { dungeons, isLoading: dungeonsLoading } = useDungeonProgress()
+  const { startExpedition } = useExpeditionFlow()
   const [retryCount, setRetryCount] = useState(0)
 
   const party = useMemo(() => {
@@ -139,15 +149,35 @@ export default function ExpeditionPreparationScreen() {
       return
     }
 
-    router.push({
-      pathname: '/formation/playback',
-      params: {
-        partyId,
-        dungeonId: selectedDungeonId,
-        returnPolicy: selectedReturnPolicy,
-      },
-    })
-  }, [partyId, selectedDungeonId, selectedReturnPolicy, partyMembers.length])
+    if (!party || !selectedDungeon) {
+      Alert.alert('ダンジョン情報が取得できません', 'ダンジョン情報の取得に失敗しました')
+      return
+    }
+
+    const doStartExpedition = async () => {
+      try {
+        await startExpedition({
+          party,
+          dungeon: selectedDungeon,
+          returnPolicy: selectedReturnPolicy,
+        })
+
+        router.replace('/formation')
+      } catch (error) {
+        console.error('[Preparation] Failed to start expedition', error)
+        Alert.alert('遠征に失敗しました', '遠征開始時にエラーが発生しました')
+      }
+    }
+
+    void doStartExpedition()
+  }, [
+    party,
+    selectedDungeon,
+    selectedDungeonId,
+    selectedReturnPolicy,
+    partyMembers.length,
+    startExpedition,
+  ])
 
   const canStartExpedition = selectedDungeonId && partyMembers.length > 0
 

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -1,128 +1,180 @@
 import { useMemo, useCallback } from 'react'
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Animated } from 'react-native'
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Image, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
+import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
+import { getGoblinImage } from '@/shared/utils/goblinImages'
+import { areasData } from '@/shared/data'
 import type { Goblin } from '@/shared/types'
 
 export default function ExpeditionResultScreen() {
-  const { partyId, dungeonId, success, xpGained, maxFloor } = useLocalSearchParams<{
+  const { partyId, dungeonId, success, xpGained, maxFloor, expeditionId } = useLocalSearchParams<{
     partyId: string
     dungeonId: string
     success: string
     xpGained: string
     maxFloor: string
+    expeditionId?: string
   }>()
 
   const { getPartyById } = usePartyService()
   const { goblins } = useGoblinService()
   const { dungeons } = useDungeonProgress()
+  const { getExpeditionById, isLoading: isExpeditionLoading } = useExpeditionService()
+
+  const expeditionRecord = useMemo(() => {
+    if (!expeditionId) return null
+    return getExpeditionById(expeditionId)
+  }, [expeditionId, getExpeditionById])
+
+  const replay = expeditionRecord?.replay ?? null
+  const resolvedPartyId = expeditionRecord?.partyId ?? (partyId ? parseInt(partyId, 10) : null)
 
   const party = useMemo(() => {
-    if (!partyId) return null
-    return getPartyById(parseInt(partyId, 10))
-  }, [partyId, getPartyById])
+    if (!resolvedPartyId) return null
+    return getPartyById(resolvedPartyId)
+  }, [resolvedPartyId, getPartyById])
 
   const dungeon = useMemo(() => {
-    const id = dungeonId || party?.dungeonId
+    const id = expeditionRecord?.dungeonId || dungeonId || party?.dungeonId
     return dungeons.find(d => d.id === id)
-  }, [dungeons, dungeonId, party?.dungeonId])
+  }, [dungeons, expeditionRecord?.dungeonId, dungeonId, party?.dungeonId])
 
-  const partyMembers = useMemo(() => {
-    if (!party) return []
-    return party.memberIds
-      .map(id => goblins.find(g => g.id === id))
-      .filter((g): g is Goblin => g !== undefined)
-  }, [party, goblins])
+  const isSuccess = replay?.summary.success ?? success === 'true'
+  const expGained = replay?.summary.xpGained ?? parseInt(xpGained || '0', 10)
+  const goldGained = replay?.summary.goldGained ?? 0
+  const floorsCleared = replay?.summary.maxFloorReached ?? parseInt(maxFloor || '0', 10)
 
-  const isSuccess = success === 'true'
-  const expGained = parseInt(xpGained || '0', 10)
-  const floorsCleared = parseInt(maxFloor || '0', 10)
+  const getPartyMember = useCallback((memberId: string) => {
+    return goblins.find(g => g.id === parseInt(memberId, 10))
+  }, [goblins])
 
-  const handleViewLog = useCallback(() => {
-    router.push({
-      pathname: '/formation/log',
-      params: { partyId },
-    })
-  }, [partyId])
+  const isInjured = (memberId: string) => replay?.summary.injuries.includes(memberId) ?? false
+  const isDead = (memberId: string) => replay?.summary.casualties.includes(memberId) ?? false
+
+  const getResultText = () => {
+    if (!replay) {
+      return isSuccess ? 'ダンジョンを踏破しました。' : '帰還しました。'
+    }
+    if (replay.summary.casualties.length === replay.meta.party.length) {
+      return '全滅しました。'
+    }
+    const area = areasData.find(a => a.id === replay.meta.areaId)
+    if (replay.summary.success && replay.summary.maxFloorReached === area?.floors) {
+      return 'ダンジョンを踏破しました。'
+    }
+    if (replay.summary.success) {
+      return '目標階層を突破しました。'
+    }
+    return '帰還しました。'
+  }
+
+  const getPartyMemberHp = (memberId: string) => {
+    const goblin = getPartyMember(memberId)
+    if (!goblin) return { current: 0, max: 0 }
+
+    if (isDead(memberId)) {
+      return { current: 0, max: goblin.stats.hp }
+    }
+
+    if (isInjured(memberId)) {
+      return { current: Math.floor(goblin.stats.hp * 0.5), max: goblin.stats.hp }
+    }
+
+    return { current: goblin.stats.hp, max: goblin.stats.hp }
+  }
 
   const handleBackToList = useCallback(() => {
     router.replace('/formation')
   }, [])
 
+  const area = replay ? areasData.find(a => a.id === replay.meta.areaId) : null
+  const unlockNext = area?.unlockNext
+  const nextAreaName = unlockNext
+    ? areasData.find(a => a.id === unlockNext)?.name || unlockNext
+    : null
+
+  if (expeditionId && (isExpeditionLoading || !expeditionRecord)) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3B82F6" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  if (expeditionId && expeditionRecord && !expeditionRecord.replay) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.loadingText}>遠征結果が見つかりません</Text>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity onPress={() => router.back()}>
+          <Text style={styles.navBack}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>遠征結果</Text>
+        <View style={styles.navSpacer} />
+      </View>
+
       <ScrollView style={styles.scrollView}>
-        <View style={styles.header}>
-          <View style={[styles.resultBadge, isSuccess ? styles.successBadge : styles.failureBadge]}>
-            <Text style={styles.resultText}>{isSuccess ? '踏破成功' : '撤退'}</Text>
-          </View>
-          <Text style={styles.title}>遠征完了</Text>
-          {party && dungeon && (
-            <Text style={styles.subtitle}>{party.name} → {dungeon.name}</Text>
-          )}
+        <View style={styles.headerSection}>
+          <Text style={styles.headerTitle}>
+            {dungeon?.name || '遠征'}: {getResultText()}
+          </Text>
         </View>
 
-        <View style={styles.statsGrid}>
-          <View style={styles.statCard}>
-            <Text style={[styles.statValue, isSuccess ? styles.successValue : styles.failureValue]}>
-              {floorsCleared}
-            </Text>
-            <Text style={styles.statLabel}>到達階層</Text>
-          </View>
-          <View style={styles.statCard}>
-            <Text style={[styles.statValue, styles.expValue]}>{expGained}</Text>
-            <Text style={styles.statLabel}>獲得経験値</Text>
-          </View>
-        </View>
-
-        {/* パーティメンバー */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>参加メンバー</Text>
-          <View style={styles.memberList}>
-            {partyMembers.map(member => (
-              <View key={member.id} style={styles.memberCard}>
+          {(replay?.meta.party ?? party?.memberIds.map(id => id.toString()) ?? []).map(memberId => {
+            const goblin = getPartyMember(memberId)
+            const hp = getPartyMemberHp(memberId)
+            const dead = isDead(memberId)
+            return (
+              <View key={memberId} style={styles.memberRow}>
                 <View style={styles.memberAvatar}>
-                  <Text style={styles.memberAvatarText}>G</Text>
+                  {goblin ? (
+                    <Image
+                      source={getGoblinImage(goblin.avatar)}
+                      style={[styles.memberAvatarImage, dead && styles.memberAvatarDead]}
+                    />
+                  ) : (
+                    <Text style={styles.memberAvatarFallback}>?</Text>
+                  )}
                 </View>
                 <View style={styles.memberInfo}>
-                  <Text style={styles.memberName}>{member.name}</Text>
-                  <Text style={styles.memberLevel}>Lv.{member.level}</Text>
-                </View>
-                <View style={styles.expBadge}>
-                  <Text style={styles.expBadgeText}>+{Math.floor(expGained / Math.max(partyMembers.length, 1))} EXP</Text>
+                  <Text style={styles.memberName}>{goblin?.name || `ID:${memberId}`}</Text>
+                  <Text style={styles.memberHp}>({hp.current}/{hp.max})</Text>
                 </View>
               </View>
-            ))}
-          </View>
+            )
+          })}
         </View>
 
-        {/* 結果サマリー */}
-        <View style={styles.summarySection}>
-          <View style={styles.summaryRow}>
-            <Text style={styles.summaryLabel}>ダンジョン</Text>
-            <Text style={styles.summaryValue}>{dungeon?.name || '不明'}</Text>
-          </View>
-          <View style={styles.summaryRow}>
-            <Text style={styles.summaryLabel}>総階層</Text>
-            <Text style={styles.summaryValue}>{dungeon?.floors || 0}階</Text>
-          </View>
-          <View style={styles.summaryRow}>
-            <Text style={styles.summaryLabel}>結果</Text>
-            <Text style={[styles.summaryValue, isSuccess ? styles.successText : styles.failureText]}>
-              {isSuccess ? '完全踏破' : `${floorsCleared}階で撤退`}
-            </Text>
-          </View>
+        <View style={styles.section}>
+          <Text style={styles.summaryText}>経験値 {expGained.toLocaleString()} XP</Text>
+          <Text style={styles.summaryText}>{goldGained.toLocaleString()} Gold を獲得</Text>
         </View>
 
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.logButton} onPress={handleViewLog}>
-            <Text style={styles.logButtonText}>詳細ログを見る</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.doneButton} onPress={handleBackToList}>
-            <Text style={styles.doneButtonText}>完了</Text>
+        {nextAreaName && isSuccess && (
+          <View style={styles.section}>
+            <Text style={styles.summaryText}>次のエリア「{nextAreaName}」が解放されました</Text>
+          </View>
+        )}
+
+        <View style={styles.bottomSection}>
+          <TouchableOpacity style={styles.menuButton} onPress={handleBackToList}>
+            <Text style={styles.menuButtonText}>メニューに戻る</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -133,181 +185,117 @@ export default function ExpeditionResultScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1F2937',
+    backgroundColor: '#F3F4F6',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6B7280',
   },
   scrollView: {
     flex: 1,
   },
-  header: {
-    alignItems: 'center',
-    padding: 24,
-  },
-  resultBadge: {
-    paddingHorizontal: 32,
-    paddingVertical: 12,
-    borderRadius: 24,
-    marginBottom: 16,
-  },
-  successBadge: {
-    backgroundColor: '#10B981',
-  },
-  failureBadge: {
-    backgroundColor: '#EF4444',
-  },
-  resultText: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-  },
-  subtitle: {
-    fontSize: 16,
-    color: '#9CA3AF',
-    marginTop: 8,
-  },
-  statsGrid: {
+  navBar: {
     flexDirection: 'row',
-    padding: 16,
-    gap: 12,
-  },
-  statCard: {
-    flex: 1,
-    backgroundColor: '#374151',
-    borderRadius: 16,
-    padding: 20,
     alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
   },
-  statValue: {
-    fontSize: 48,
-    fontWeight: 'bold',
-  },
-  successValue: {
-    color: '#10B981',
-  },
-  failureValue: {
-    color: '#F59E0B',
-  },
-  expValue: {
-    color: '#3B82F6',
-  },
-  statLabel: {
+  navBack: {
     fontSize: 14,
-    color: '#9CA3AF',
-    marginTop: 8,
+    color: '#374151',
+  },
+  navTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  navSpacer: {
+    width: 60,
+  },
+  headerSection: {
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
   },
   section: {
     padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
   },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-    marginBottom: 12,
-  },
-  memberList: {
-    gap: 8,
-  },
-  memberCard: {
+  memberRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#374151',
-    borderRadius: 12,
-    padding: 12,
+    marginBottom: 12,
   },
   memberAvatar: {
     width: 40,
     height: 40,
-    borderRadius: 20,
-    backgroundColor: '#10B981',
+    borderRadius: 6,
+    backgroundColor: '#E5E7EB',
+    overflow: 'hidden',
     alignItems: 'center',
     justifyContent: 'center',
+    marginRight: 12,
   },
-  memberAvatarText: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
+  memberAvatarImage: {
+    width: '100%',
+    height: '100%',
+  },
+  memberAvatarDead: {
+    opacity: 0.5,
+  },
+  memberAvatarFallback: {
+    color: '#6B7280',
+    fontWeight: '600',
   },
   memberInfo: {
     flex: 1,
-    marginLeft: 12,
   },
   memberName: {
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: '600',
-    color: '#FFFFFF',
+    color: '#111827',
   },
-  memberLevel: {
+  memberHp: {
     fontSize: 12,
-    color: '#9CA3AF',
+    color: '#6B7280',
     marginTop: 2,
   },
-  expBadge: {
-    backgroundColor: '#3B82F6',
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 12,
-  },
-  expBadgeText: {
-    fontSize: 12,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-  },
-  summarySection: {
-    backgroundColor: '#111827',
-    margin: 16,
-    borderRadius: 12,
-    padding: 16,
-  },
-  summaryRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#374151',
-  },
-  summaryLabel: {
+  summaryText: {
     fontSize: 14,
-    color: '#9CA3AF',
+    color: '#111827',
+    marginBottom: 6,
   },
-  summaryValue: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#FFFFFF',
-  },
-  successText: {
-    color: '#10B981',
-  },
-  failureText: {
-    color: '#F59E0B',
-  },
-  buttonContainer: {
+  bottomSection: {
     padding: 16,
-    gap: 12,
+    backgroundColor: '#F3F4F6',
   },
-  logButton: {
-    backgroundColor: '#374151',
-    borderRadius: 12,
-    padding: 16,
+  menuButton: {
+    backgroundColor: '#1F2937',
+    borderRadius: 8,
+    paddingVertical: 14,
     alignItems: 'center',
   },
-  logButtonText: {
-    fontSize: 16,
+  menuButtonText: {
+    fontSize: 15,
     fontWeight: '600',
-    color: '#FFFFFF',
-  },
-  doneButton: {
-    backgroundColor: '#10B981',
-    borderRadius: 12,
-    padding: 16,
-    alignItems: 'center',
-  },
-  doneButtonText: {
-    fontSize: 16,
-    fontWeight: 'bold',
     color: '#FFFFFF',
   },
 })

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -66,9 +66,10 @@ export class ExpeditionEngine {
     }
 
     // 表示上の規定時間をそのまま使い、終端にイベントを揃える
-    // DEBUG環境変数がtrueの場合は1秒に短縮
+    // DEBUG環境変数がtrueの場合は1秒に短縮（明示指定がある場合は尊重）
     const isDebug = typeof __DEV__ !== 'undefined' ? __DEV__ : false
-    const adjustedDuration = isDebug ? 1 : Math.ceil(area.baseDurationSec)
+    const requestedDuration = request.durationSec ?? area.baseDurationSec
+    const adjustedDuration = isDebug && request.durationSec == null ? 1 : Math.ceil(requestedDuration)
 
     const events: TimelineEvent[] = []
     let currentFloor = 1
@@ -247,7 +248,7 @@ export class ExpeditionEngine {
         areaId: areaId,
         areaName: area.name,
         floors: area.floors,
-        baseDurationSec: area.baseDurationSec,
+        baseDurationSec: adjustedDuration,
         party: party.map(g => g.id.toString()),
         returnPolicy: request.returnPolicy,
         seed: this.seed

--- a/goblin_native/src/presentation/contexts/battleLogStore.ts
+++ b/goblin_native/src/presentation/contexts/battleLogStore.ts
@@ -1,0 +1,19 @@
+import type { BattleLogEntry } from '@/shared/types'
+
+const battleLogStore = new Map<string, BattleLogEntry[]>()
+let logCounter = 0
+
+export const storeBattleLog = (log: BattleLogEntry[]): string => {
+  logCounter += 1
+  const id = `${Date.now()}-${logCounter}`
+  battleLogStore.set(id, log)
+  return id
+}
+
+export const getBattleLog = (id: string): BattleLogEntry[] | null => {
+  return battleLogStore.get(id) ?? null
+}
+
+export const clearBattleLog = (id: string): void => {
+  battleLogStore.delete(id)
+}

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -1,43 +1,79 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
   Dungeon,
   ExpeditionReplay,
   ExpeditionRequest,
-  PartyStatus,
+  ExpeditionRecord,
+  Party,
 } from '../../shared/types'
-import type { StartExpeditionUseCase } from '../../core/usecases'
+import { StartExpeditionUseCase, CompleteExpeditionUseCase } from '../../core/usecases'
+import { ExpeditionEngine } from '../../core/services'
+import { usePartyService } from './usePartyService'
+import { useGoblinService } from './useGoblinService'
+import { useExpeditionService } from './useExpeditionService'
 
 interface UseExpeditionFlowParams {
-  startExpeditionUseCase: StartExpeditionUseCase
-  expeditionRepository: unknown
-  setPartyExpeditionStatus: (partyId: number, status: PartyStatus) => void
-  clearExpedition: (partyId: number) => void
-  getPartyById: (partyId: number) => { id: number; name: string }
-  markPartyAsOnExpedition: (partyId: number) => void
-  markPartyAsIdle: (partyId: number) => void
+  refreshParties?: () => Promise<void> | void
+  parties?: Party[]
+  enableAutoCompletion?: boolean
+}
+
+interface StartExpeditionInput {
+  party: Party
+  dungeon: Dungeon
+  returnPolicy: ExpeditionRequest['returnPolicy']
 }
 
 interface StartExpeditionResult {
   replay: ExpeditionReplay
-  partyId: number
+  record: ExpeditionRecord
+}
+
+export interface ExpeditionHistoryDisplay {
+  id: string
+  title: string
+  subtitle: string
+  ongoing: boolean
+  record: ExpeditionRecord
 }
 
 export const useExpeditionFlow = ({
-  startExpeditionUseCase,
-  setPartyExpeditionStatus,
-  clearExpedition,
-  getPartyById,
-  markPartyAsOnExpedition,
-  markPartyAsIdle,
-}: UseExpeditionFlowParams) => {
+  refreshParties,
+  parties,
+  enableAutoCompletion = false,
+}: UseExpeditionFlowParams = {}) => {
   const [isProcessing, setIsProcessing] = useState(false)
+  const [currentTime, setCurrentTime] = useState(new Date())
+  const processedExpeditionsRef = useRef<Set<string>>(new Set())
+
+  const { partyRepository } = usePartyService()
+  const { goblinRepository } = useGoblinService()
+  const {
+    expeditionRecords,
+    getPartyExpeditionHistory,
+    saveExpeditionRecord,
+    completeExpeditionRecord,
+  } = useExpeditionService()
+
+  const startExpeditionUseCase = useMemo(() => {
+    return new StartExpeditionUseCase(
+      partyRepository,
+      goblinRepository,
+      new ExpeditionEngine(),
+    )
+  }, [partyRepository, goblinRepository])
+
+  const completeExpeditionUseCase = useMemo(() => {
+    return new CompleteExpeditionUseCase(goblinRepository, partyRepository)
+  }, [goblinRepository, partyRepository])
 
   const estimateExplorationTime = useCallback((
     dungeon: Dungeon,
     returnPolicy: ExpeditionRequest['returnPolicy'],
   ): number => {
-    const baseTime = dungeon.exploration_time_sec_first ?? dungeon.exploration_time_sec
-
+    const baseTime = dungeon.cleared
+      ? dungeon.exploration_time_sec
+      : dungeon.exploration_time_sec_first
     const multiplierMap: Record<ExpeditionRequest['returnPolicy'], number> = {
       never: 1.0,
       until_floor2: 0.4,
@@ -46,49 +82,199 @@ export const useExpeditionFlow = ({
       if_two_ko: 0.75,
       last_one: 0.9,
     }
-
     const multiplier = multiplierMap[returnPolicy] ?? 1.0
     return Math.floor(baseTime * multiplier)
   }, [])
 
+  const formatTime = useCallback((date: Date) => {
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+    return `${hours}:${minutes}`
+  }, [])
+
+  const formatTimeWithSeconds = useCallback((date: Date) => {
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+    const seconds = String(date.getSeconds()).padStart(2, '0')
+    return `${hours}:${minutes}:${seconds}`
+  }, [])
+
+  const formatFullDateTime = useCallback((date: Date) => {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}/${month}/${day} ${formatTime(date)}`
+  }, [formatTime])
+
+  const formatFullDateTimeWithSeconds = useCallback((date: Date) => {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}/${month}/${day} ${formatTimeWithSeconds(date)}`
+  }, [formatTimeWithSeconds])
+
+  const getRemainingMinutes = useCallback((returnTime: Date, now: Date) => {
+    const diff = returnTime.getTime() - now.getTime()
+    return Math.max(0, Math.floor(diff / (1000 * 60)))
+  }, [])
+
+  const isExpeditionOngoing = useCallback((record: ExpeditionRecord, now: Date) => {
+    return record.returnTime ? record.returnTime > now : record.status === 'ongoing'
+  }, [])
+
   const startExpedition = useCallback(
-    async (request: ExpeditionRequest, _dungeon: Dungeon): Promise<StartExpeditionResult> => {
-      const partyId = Number.parseInt(request.partyId, 10)
-      if (Number.isNaN(partyId)) {
-        throw new Error('Invalid party ID')
-      }
-
-      getPartyById(partyId)
-
+    async ({ party, dungeon, returnPolicy }: StartExpeditionInput): Promise<StartExpeditionResult> => {
       setIsProcessing(true)
       try {
+        const durationSec = estimateExplorationTime(dungeon, returnPolicy)
+        const request: ExpeditionRequest = {
+          partyId: party.id.toString(),
+          areaId: dungeon.id,
+          returnPolicy,
+          clientVersion: 'native',
+          durationSec,
+        }
+
         const replay = await startExpeditionUseCase.execute(request)
+        const startTime = new Date()
+        const returnTime = new Date(startTime.getTime() + replay.durationSec * 1000)
+        const expeditionId = `exp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+        const record: ExpeditionRecord = {
+          id: expeditionId,
+          userId: '',
+          partyId: party.id,
+          partyName: party.name,
+          dungeonId: dungeon.id,
+          dungeonName: dungeon.name,
+          startTime,
+          returnTime,
+          status: 'ongoing',
+          returnPolicy,
+          replay,
+          createdAt: startTime,
+          updatedAt: startTime,
+        }
 
-        setPartyExpeditionStatus(partyId, 'expedition')
-        markPartyAsOnExpedition(partyId)
+        saveExpeditionRecord(record)
 
-        return { replay, partyId }
+        return { replay, record }
       } finally {
         setIsProcessing(false)
       }
     },
-    [
-      getPartyById,
-      markPartyAsOnExpedition,
-      setPartyExpeditionStatus,
-      startExpeditionUseCase,
-    ],
+    [estimateExplorationTime, saveExpeditionRecord, startExpeditionUseCase],
   )
 
-  const completeExpedition = useCallback((partyId: number) => {
-    clearExpedition(partyId)
-    markPartyAsIdle(partyId)
-  }, [clearExpedition, markPartyAsIdle])
+  const completeDueExpeditions = useCallback(async (): Promise<void> => {
+    const now = new Date()
+    const dueExpeditions = expeditionRecords.filter(record =>
+      record.status === 'ongoing' &&
+      record.returnTime &&
+      record.returnTime <= now &&
+      record.replay
+    )
+
+    for (const record of dueExpeditions) {
+      if (processedExpeditionsRef.current.has(record.id)) continue
+      try {
+        await completeExpeditionUseCase.execute(record.partyId, record.replay!)
+        completeExpeditionRecord(record.id, record.replay!)
+        processedExpeditionsRef.current.add(record.id)
+        if (refreshParties) {
+          await refreshParties()
+        }
+      } catch (error) {
+        console.warn('[useExpeditionFlow] Failed to complete expedition', error)
+      }
+    }
+  }, [
+    currentTime,
+    expeditionRecords,
+    completeExpeditionUseCase,
+    completeExpeditionRecord,
+    refreshParties,
+  ])
+
+  const partyHistories = useMemo(() => {
+    return (parties ?? []).reduce<Record<number, ExpeditionRecord[]>>((acc, party) => {
+      const history = getPartyExpeditionHistory(party.id, 2)
+      if (history.length > 0) {
+        acc[party.id] = history
+      }
+      return acc
+    }, {})
+  }, [parties, expeditionRecords, getPartyExpeditionHistory])
+
+  const partyHistoryDisplays = useMemo(() => {
+    const displays: Record<number, ExpeditionHistoryDisplay[]> = {}
+    Object.entries(partyHistories).forEach(([partyId, history]) => {
+      const items = history.map(record => {
+        const ongoing = isExpeditionOngoing(record, currentTime)
+        const floorReached = record.replay?.summary.maxFloorReached ?? 0
+        const remainingMinutes = ongoing && record.returnTime
+          ? getRemainingMinutes(record.returnTime, currentTime)
+          : 0
+        const title = ongoing && record.returnTime
+          ? `[${floorReached}F]: 帰還予定 ${formatTime(record.returnTime)} 残り${remainingMinutes}分`
+          : `[${floorReached}F]: ${formatFullDateTime(record.startTime)}`
+        return {
+          id: record.id,
+          title,
+          subtitle: record.dungeonName,
+          ongoing,
+          record,
+        }
+      })
+      if (items.length > 0) {
+        displays[Number(partyId)] = items
+      }
+    })
+    return displays
+  }, [
+    partyHistories,
+    currentTime,
+    formatFullDateTime,
+    formatTime,
+    getRemainingMinutes,
+    isExpeditionOngoing,
+  ])
+
+  const hasOngoingExpeditions = useMemo(() => {
+    return Object.values(partyHistories).some(history =>
+      history.some(record =>
+        record.status === 'ongoing' &&
+        record.returnTime &&
+        record.returnTime > currentTime
+      )
+    )
+  }, [partyHistories, currentTime])
+
+  useEffect(() => {
+    if (!enableAutoCompletion) return
+    const interval = setInterval(() => {
+      setCurrentTime(new Date())
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [enableAutoCompletion])
+
+  useEffect(() => {
+    if (!enableAutoCompletion) return
+    void completeDueExpeditions()
+  }, [enableAutoCompletion, completeDueExpeditions])
 
   return {
     isProcessing,
     startExpedition,
-    completeExpedition,
     estimateExplorationTime,
+    completeDueExpeditions,
+    currentTime,
+    partyHistories,
+    partyHistoryDisplays,
+    hasOngoingExpeditions,
+    formatTime,
+    formatFullDateTime,
+    formatFullDateTimeWithSeconds,
+    getRemainingMinutes,
+    isExpeditionOngoing,
   }
 }

--- a/goblin_native/src/presentation/hooks/useExpeditionService.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionService.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ExpeditionRecord, ExpeditionReplay } from '@/shared/types'
+import { SQLiteExpeditionRepository } from '@/infrastructure/repositories'
+
+let repositoryInstance: SQLiteExpeditionRepository | null = null
+let dataChangeSubscribers: Set<() => void> = new Set()
+let dataChangeListenerBound = false
+
+const getRepository = (): SQLiteExpeditionRepository => {
+  if (!repositoryInstance) {
+    repositoryInstance = new SQLiteExpeditionRepository()
+  }
+  return repositoryInstance
+}
+
+export const useExpeditionService = () => {
+  const [expeditionRecords, setExpeditionRecords] = useState<ExpeditionRecord[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const repositoryRef = useRef<SQLiteExpeditionRepository | null>(null)
+
+  const bindDataChangeListener = useCallback((repository: SQLiteExpeditionRepository) => {
+    if (dataChangeListenerBound) return
+    repository.setOnDataChange(() => {
+      dataChangeSubscribers.forEach(callback => callback())
+    })
+    dataChangeListenerBound = true
+  }, [])
+
+  const refreshExpeditions = useCallback(() => {
+    if (!repositoryRef.current) return
+    setExpeditionRecords(repositoryRef.current.getAll())
+  }, [])
+
+  useEffect(() => {
+    const repository = getRepository()
+    repositoryRef.current = repository
+
+    const initializeAndLoad = async () => {
+      try {
+        await repository.initialize()
+        setExpeditionRecords(repository.getAll())
+      } catch (error) {
+        console.error('[useExpeditionService] Failed to initialize:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    bindDataChangeListener(repository)
+    const handleDataChange = () => {
+      setExpeditionRecords(repository.getAll())
+    }
+    dataChangeSubscribers.add(handleDataChange)
+
+    initializeAndLoad()
+
+    return () => {
+      dataChangeSubscribers.delete(handleDataChange)
+    }
+  }, [bindDataChangeListener])
+
+  const getExpeditionById = useCallback((id: string): ExpeditionRecord | null => {
+    if (!repositoryRef.current) return null
+    return repositoryRef.current.getById(id)
+  }, [])
+
+  const getPartyExpeditionHistory = useCallback((partyId: number, limit = 2): ExpeditionRecord[] => {
+    if (!repositoryRef.current) return []
+    const records = repositoryRef.current.getByPartyId(partyId)
+    return records.slice(0, limit)
+  }, [])
+
+  const saveExpeditionRecord = useCallback((record: ExpeditionRecord) => {
+    if (!repositoryRef.current) return
+    repositoryRef.current.save(record)
+  }, [])
+
+  const updateExpeditionReplay = useCallback((id: string, replay: ExpeditionReplay) => {
+    if (!repositoryRef.current) return
+    const record = repositoryRef.current.getById(id)
+    if (!record) return
+    repositoryRef.current.save({
+      ...record,
+      replay,
+      updatedAt: new Date(),
+    })
+  }, [])
+
+  const completeExpeditionRecord = useCallback((id: string, replay: ExpeditionReplay) => {
+    if (!repositoryRef.current) return
+    repositoryRef.current.complete(id, replay)
+  }, [])
+
+  return {
+    expeditionRepository: repositoryRef.current,
+    expeditionRecords,
+    isLoading,
+    refreshExpeditions,
+    getExpeditionById,
+    getPartyExpeditionHistory,
+    saveExpeditionRecord,
+    updateExpeditionReplay,
+    completeExpeditionRecord,
+  }
+}

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -6,6 +6,7 @@ export interface ExpeditionRequest {
   areaId: string
   returnPolicy: "until_floor2" | "until_floor3" | "if_any_ko" | "if_two_ko" | "last_one" | "never"
   clientVersion: string
+  durationSec?: number
 }
 
 /**

--- a/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
@@ -252,183 +252,193 @@ export const ExpeditionLogScreen = ({
 
   return (
     <div className="flex flex-col h-full">
-      {/* ヘッダー */}
-      <div className="p-3 text-white bg-gray-800 shadow-lg">
-        <div className="flex justify-between items-center">
-          <div className="text-sm font-bold">
-            {expeditionReplay.meta.areaName} - {currentFloor}階
-          </div>
-          <div className="text-xs">
-            {formatTime(currentTime)} / {formatTime(expeditionReplay.durationSec)}
-          </div>
-        </div>
-
-        {/* プログレスバー */}
-        <div className="overflow-hidden mt-2 h-2 bg-gray-700 rounded-full">
-          <div
-            className="h-full bg-gray-400 transition-all duration-100 ease-linear"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-      </div>
-
-      {/* パーティ状態 */}
-      <div className="p-3 bg-gray-100 border-b-2 border-gray-300">
-        <div className="grid grid-cols-3 gap-2">
-          {expeditionReplay.meta.party.map((memberId, idx) => {
-            const goblin = goblins.find(g => g.id === parseInt(memberId))
-            const maxHp = goblin?.stats.hp || 100
-            const currentHp = partyHp[idx]
-            const hpPercent = (currentHp / maxHp) * 100
-            const isKO = currentHp <= 0
-
-            return (
-              <div
-                key={memberId}
-                className={`bg-white rounded-lg p-2 border ${isKO ? 'border-gray-500 opacity-50' : 'border-gray-300'}`}
-              >
-                <div className="flex gap-1 items-center mb-1">
-                  <div className="flex overflow-hidden justify-center items-center w-6 h-6 bg-gray-200 rounded-full">
-                    <img src={goblin?.avatar} alt={goblin?.name} className="object-cover w-full h-full" />
-                  </div>
-                  <div className="flex-1 text-xs font-medium truncate">
-                    {goblin?.name || `ID:${memberId}`}
-                  </div>
-                </div>
-                <div className="overflow-hidden h-1 bg-gray-200 rounded-full">
-                  <div
-                    className={`h-full transition-all duration-300 ${isKO ? 'bg-gray-400' : hpPercent > 50 ? 'bg-gray-700' : hpPercent > 25 ? 'bg-gray-500' : 'bg-gray-400'}`}
-                    style={{ width: `${hpPercent}%` }}
-                  />
-                </div>
-                <div className="mt-1 text-xs text-gray-600">
-                  HP: {currentHp}/{maxHp}
-                </div>
+      {/* ログ一覧 / 戦闘詳細 */}
+      <div className="relative flex-1 overflow-hidden bg-white">
+        <div
+          className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-out ${
+            selectedBattleLog ? '-translate-x-full' : 'translate-x-0'
+          }`}
+        >
+          <div className="p-3 text-white bg-gray-800 shadow-lg">
+            <div className="flex justify-between items-center">
+              <div className="text-sm font-bold">
+                {expeditionReplay.meta.areaName} - {currentFloor}階
               </div>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* イベントログ */}
-      <div className="overflow-hidden flex-1 bg-white">
-        <div
-          ref={logContainerRef}
-          className="overflow-y-auto p-4 space-y-1 h-full"
-        >
-          {eventLog.map((log, idx) => (
-            <div
-              key={idx}
-              className={`text-sm text-gray-700 font-mono ${
-                log.battleLog && log.battleLog.length > 0
-                  ? 'cursor-pointer hover:bg-gray-100 py-1 rounded'
-                  : ''
-              }`}
-              onClick={() => {
-                if (log.battleLog && log.battleLog.length > 0) {
-                  setSelectedBattleLog(log.battleLog)
-                }
-              }}
-            >
-              {log.message}
-              {log.battleLog && log.battleLog.length > 0 && (
-                <span className="ml-2 text-xs text-gray-500">[詳細]</span>
-              )}
+              <div className="text-xs">
+                {formatTime(currentTime)} / {formatTime(expeditionReplay.durationSec)}
+              </div>
             </div>
-          ))}
-        </div>
-      </div>
 
-      {/* 戦闘詳細ログモーダル */}
-      {selectedBattleLog && (
-        <div
-          className="flex fixed inset-0 z-50 justify-center items-center bg-black bg-opacity-50"
-          onClick={() => setSelectedBattleLog(null)}
-        >
-          <div
-            className="bg-white max-w-[414px] w-full h-full overflow-hidden flex flex-col"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex justify-between items-center p-4 text-white bg-gray-800">
-              <h3 className="font-bold">戦闘ログ</h3>
-              <button
-                onClick={() => setSelectedBattleLog(null)}
-                className="text-white hover:text-gray-300"
-              >
-                ×
-              </button>
+            <div className="overflow-hidden mt-2 h-2 bg-gray-700 rounded-full">
+              <div
+                className="h-full bg-gray-400 transition-all duration-100 ease-linear"
+                style={{ width: `${progress}%` }}
+              />
             </div>
-            <div className="overflow-y-auto overflow-x-hidden flex-1 p-4 space-y-2" style={{ WebkitOverflowScrolling: 'touch' }}>
-              {selectedBattleLog.map((entry, idx) => {
-                // ターン開始ログの場合
-                if (entry.action === 'turn_start' && entry.turnState) {
-                  return (
-                    <div key={idx} className="p-3 bg-gray-100 rounded border border-gray-300">
-                      <div className="mb-2 font-bold text-gray-700">
-                        Turn {entry.turn} 開始
-                      </div>
-                      <div className="space-y-2">
-                        <div>
-                          <div className="mb-1 text-xs font-semibold text-gray-700">味方:</div>
-                          <div className="space-y-1">
-                            {entry.turnState.allies.map((ally, i) => (
-                              <div key={i} className="flex justify-between items-center text-xs">
-                                <span className="text-gray-700">{ally.name}</span>
-                                <span className={`font-mono ${ally.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
-                                  {ally.currentHP}/{ally.maxHP} HP
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                        <div>
-                          <div className="mb-1 text-xs font-semibold text-gray-600">敵:</div>
-                          <div className="space-y-1">
-                            {entry.turnState.enemies.map((enemy, i) => (
-                              <div key={i} className="flex justify-between items-center text-xs">
-                                <span className="text-gray-700">{enemy.name}</span>
-                                <span className={`font-mono ${enemy.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
-                                  {enemy.currentHP}/{enemy.maxHP} HP
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )
-                }
+          </div>
 
-                // 通常の戦闘ログ
+          <div className="p-3 bg-gray-100 border-b border-gray-300">
+            <div className="grid grid-cols-3 gap-2">
+              {expeditionReplay.meta.party.map((memberId, idx) => {
+                const goblin = goblins.find(g => g.id === parseInt(memberId))
+                const maxHp = goblin?.stats.hp || 100
+                const currentHp = partyHp[idx]
+                const hpPercent = (currentHp / maxHp) * 100
+                const isKO = currentHp <= 0
+
                 return (
                   <div
-                    key={idx}
-                    className={`text-sm p-2 rounded ${
-                      entry.isAlly ? 'bg-gray-100' : 'bg-gray-200'
-                    }`}
+                    key={memberId}
+                    className={`bg-white rounded-lg p-2 border ${isKO ? 'border-gray-500 opacity-50' : 'border-gray-300'}`}
                   >
-                    <div className="font-mono text-xs">
-                      <span className={entry.isAlly ? 'text-gray-800 font-semibold' : 'text-gray-700 font-semibold'}>
-                        {entry.actorName}の攻撃
-                      </span>
-                      <span className="text-gray-500">
-                        ({entry.actorHP}HP)
-                      </span>
+                    <div className="flex gap-1 items-center mb-1">
+                      <div className="flex overflow-hidden justify-center items-center w-6 h-6 bg-gray-200 rounded-full">
+                        <img src={goblin?.avatar} alt={goblin?.name} className="object-cover w-full h-full" />
+                      </div>
+                      <div className="flex-1 text-xs font-medium truncate">
+                        {goblin?.name || `ID:${memberId}`}
+                      </div>
                     </div>
-                    <div className="mt-1 text-xs text-gray-700">
-                      {entry.actorName}の{entry.action}!
+                    <div className="overflow-hidden h-1 bg-gray-200 rounded-full">
+                      <div
+                        className={`h-full transition-all duration-300 ${isKO ? 'bg-gray-400' : hpPercent > 50 ? 'bg-gray-700' : hpPercent > 25 ? 'bg-gray-500' : 'bg-gray-400'}`}
+                        style={{ width: `${hpPercent}%` }}
+                      />
                     </div>
-                    <div className="mt-1 text-xs text-gray-700">
-                      {entry.targetName}に{entry.damage}ダメージ{entry.targetDefeated ? 'を与えて倒した！' : ''}
-                      {entry.healing && `${entry.healing}回復`}
+                    <div className="mt-1 text-xs text-gray-600">
+                      HP: {currentHp}/{maxHp}
                     </div>
                   </div>
                 )
               })}
             </div>
           </div>
+
+          <div className="overflow-hidden flex-1 bg-white">
+            <div
+              ref={logContainerRef}
+              className="overflow-y-auto p-4 space-y-1 h-full"
+            >
+              {eventLog.map((log, idx) => (
+                <div
+                  key={idx}
+                  className={`flex justify-between items-center text-sm text-gray-700 font-mono ${
+                    log.battleLog && log.battleLog.length > 0
+                      ? 'cursor-pointer hover:bg-gray-100 py-1 rounded'
+                      : ''
+                  }`}
+                  onClick={() => {
+                    if (log.battleLog && log.battleLog.length > 0) {
+                      setSelectedBattleLog(log.battleLog)
+                    }
+                  }}
+                >
+                  <div className="min-w-0">
+                    <div className="truncate">{log.message}</div>
+                    {log.battleLog && log.battleLog.length > 0 && (
+                      <div className="text-xs text-gray-500">詳細を見る</div>
+                    )}
+                  </div>
+                  {log.battleLog && log.battleLog.length > 0 && (
+                    <span className="ml-2 text-xs text-gray-400">›</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
-      )}
+
+        <div
+          className={`absolute inset-0 flex flex-col bg-white transition-transform duration-300 ease-out ${
+            selectedBattleLog ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
+          <div className="px-3 py-3 bg-white border-b border-gray-200">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setSelectedBattleLog(null)}
+                className="flex items-center gap-1 text-[15px] text-gray-600 hover:text-gray-800"
+              >
+                <span className="text-lg leading-none">‹</span>
+                戻る
+              </button>
+              <div className="text-[15px] font-semibold text-gray-900">
+                戦闘ログ
+              </div>
+              <div className="text-xs text-gray-400">
+                {formatTime(currentTime)}
+              </div>
+            </div>
+          </div>
+          <div className="overflow-y-auto overflow-x-hidden flex-1 p-4 space-y-2" style={{ WebkitOverflowScrolling: 'touch' }}>
+            {selectedBattleLog?.map((entry, idx) => {
+              if (entry.action === 'turn_start' && entry.turnState) {
+                return (
+                  <div key={idx} className="p-3 bg-gray-100 rounded border border-gray-300">
+                    <div className="mb-2 font-bold text-gray-700">
+                      Turn {entry.turn} 開始
+                    </div>
+                    <div className="space-y-2">
+                      <div>
+                        <div className="mb-1 text-xs font-semibold text-gray-700">味方:</div>
+                        <div className="space-y-1">
+                          {entry.turnState.allies.map((ally, i) => (
+                            <div key={i} className="flex justify-between items-center text-xs">
+                              <span className="text-gray-700">{ally.name}</span>
+                              <span className={`font-mono ${ally.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
+                                {ally.currentHP}/{ally.maxHP} HP
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="mb-1 text-xs font-semibold text-gray-600">敵:</div>
+                        <div className="space-y-1">
+                          {entry.turnState.enemies.map((enemy, i) => (
+                            <div key={i} className="flex justify-between items-center text-xs">
+                              <span className="text-gray-700">{enemy.name}</span>
+                              <span className={`font-mono ${enemy.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
+                                {enemy.currentHP}/{enemy.maxHP} HP
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              }
+
+              return (
+                <div
+                  key={idx}
+                  className={`text-sm p-2 rounded ${
+                    entry.isAlly ? 'bg-gray-100' : 'bg-gray-200'
+                  }`}
+                >
+                  <div className="font-mono text-xs">
+                    <span className={entry.isAlly ? 'text-gray-800 font-semibold' : 'text-gray-700 font-semibold'}>
+                      {entry.actorName}の攻撃
+                    </span>
+                    <span className="text-gray-500">
+                      ({entry.actorHP}HP)
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs text-gray-700">
+                    {entry.actorName}の{entry.action}!
+                  </div>
+                  <div className="mt-1 text-xs text-gray-700">
+                    {entry.targetName}に{entry.damage}ダメージ{entry.targetDefeated ? 'を与えて倒した！' : ''}
+                    {entry.healing && `${entry.healing}回復`}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
- ネイティブの戦闘ログ詳細をモーダルから画面遷移へ変更
- 戦闘ログ受け渡し用の一時ストアを追加
- Web側のログ詳細表示を画面内遷移で調整

## テスト
- 未実施（必要なら実機で確認します）