### PR TITLE
feat: 戦闘ログの画面遷移化

### DIFF
--- a/goblin_native/app/(tabs)/formation/_layout.tsx
+++ b/goblin_native/app/(tabs)/formation/_layout.tsx
@@ -28,7 +28,7 @@ export default function FormationLayout() {
         name="playback"
         options={{
           title: 'Expedition',
-          presentation: 'fullScreenModal',
+          presentation: 'card',
           headerShown: false,
         }}
       />
@@ -44,6 +44,14 @@ export default function FormationLayout() {
         options={{
           title: 'Expedition Log',
           presentation: 'card',
+        }}
+      />
+      <Stack.Screen
+        name="battle-log"
+        options={{
+          title: 'Battle Log',
+          presentation: 'card',
+          headerShown: false,
         }}
       />
     </Stack>

--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useEffect } from 'react'
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { router, useLocalSearchParams } from 'expo-router'
+import type { BattleLogEntry } from '@/shared/types'
+import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
+
+export default function BattleLogScreen() {
+  const { logId } = useLocalSearchParams<{ logId?: string }>()
+
+  const battleLog = useMemo<BattleLogEntry[] | null>(() => {
+    if (!logId) return null
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return null
+    return getBattleLog(raw)
+  }, [logId])
+
+  useEffect(() => {
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return undefined
+    return () => {
+      clearBattleLog(raw)
+    }
+  }, [logId])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back()
+              return
+            }
+            router.replace('/formation/playback')
+          }}
+        >
+          <Text style={styles.navBack}>← 戻る</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>戦闘ログ</Text>
+        <View style={styles.navSpacer} />
+      </View>
+
+      {!battleLog && (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>戦闘ログを読み込めませんでした。</Text>
+        </View>
+      )}
+
+      {battleLog && (
+        <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
+          {battleLog.map((entry, index) => {
+            if (entry.action === 'turn_start' && entry.turnState) {
+              return (
+                <View key={`turn-${entry.turn}-${index}`} style={styles.sectionCard}>
+                  <Text style={styles.sectionTitle}>Turn {entry.turn} 開始</Text>
+                  <Text style={styles.sectionLabel}>味方:</Text>
+                  {entry.turnState.allies.map(ally => (
+                    <Text key={ally.id} style={styles.sectionText}>
+                      {ally.name} {ally.currentHP}/{ally.maxHP} HP
+                    </Text>
+                  ))}
+                  <Text style={styles.sectionLabel}>敵:</Text>
+                  {entry.turnState.enemies.map((enemy, enemyIndex) => (
+                    <Text key={`${enemy.id}-${enemyIndex}`} style={styles.sectionText}>
+                      {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
+                    </Text>
+                  ))}
+                </View>
+              )
+            }
+
+            if (entry.action === 'turn_start') {
+              return null
+            }
+
+            return (
+              <View key={`log-${index}`} style={styles.logCard}>
+                <Text style={styles.logTitle}>
+                  {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
+                </Text>
+                <Text style={styles.logText}>{entry.actorName}の{entry.action}！</Text>
+                {entry.targetName && typeof entry.damage === 'number' && (
+                  <Text style={styles.logText}>
+                    {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
+                  </Text>
+                )}
+              </View>
+            )
+          })}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
+  },
+  navBack: {
+    fontSize: 14,
+    color: '#4B5563',
+  },
+  navTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#111827',
+    flex: 1,
+    textAlign: 'center',
+  },
+  navSpacer: {
+    width: 60,
+  },
+  body: {
+    flex: 1,
+  },
+  bodyContent: {
+    padding: 12,
+    gap: 10,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  sectionCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginTop: 6,
+  },
+  sectionText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+  logCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  logTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  logText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+})

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
-import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator, Modal } from 'react-native'
+import { View, Text, StyleSheet, Animated, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
@@ -9,6 +9,7 @@ import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
 import { CompleteExpeditionUseCase } from '@/core/usecases'
 import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord } from '@/shared/types'
 import type { BattleLogEntry } from '@/shared/types'
+import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 
 interface LogEntry {
   id: string
@@ -69,7 +70,6 @@ export default function ExpeditionPlaybackScreen() {
   const [currentTime, setCurrentTime] = useState(0)
   const [replay, setReplay] = useState<ExpeditionReplay | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [selectedBattleLog, setSelectedBattleLog] = useState<BattleLogEntry[] | null>(null)
 
   const progressAnim = useRef(new Animated.Value(0)).current
   const playbackTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -87,6 +87,12 @@ export default function ExpeditionPlaybackScreen() {
     const minutes = Math.floor(seconds / 60)
     const secs = Math.floor(seconds % 60)
     return `${minutes}:${secs.toString().padStart(2, '0')}`
+  }, [])
+
+  const openBattleLog = useCallback((detail: BattleLogEntry[]) => {
+    const logId = storeBattleLog(detail)
+    const path = `/formation/battle-log?logId=${encodeURIComponent(logId)}`
+    router.push(path)
   }, [])
 
   const getReturnReasonText = useCallback((reason: TimelineEvent extends { reason: infer R } ? R : never) => {
@@ -399,77 +405,32 @@ export default function ExpeditionPlaybackScreen() {
 
       <View style={styles.eventLog}>
         <ScrollView style={styles.logScroll}>
-          {eventLog.map(entry => (
-            <Text key={entry.id} style={styles.logText}>
-              {entry.text.replace('[詳細]', '')}
-              {entry.detail && (
-                <Text style={styles.logDetail} onPress={() => setSelectedBattleLog(entry.detail!)}>
-                  [詳細]
-                </Text>
-              )}
-            </Text>
-          ))}
+          {eventLog.map(entry => {
+            const baseText = entry.text.replace('[詳細]', '')
+            if (entry.detail) {
+              return (
+                <TouchableOpacity
+                  key={entry.id}
+                  style={styles.logRow}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
+                  onPress={() => openBattleLog(entry.detail!)}
+                >
+                  <Text style={styles.logText}>{baseText}</Text>
+                  <Text style={styles.logDetail}>詳細</Text>
+                </TouchableOpacity>
+              )
+            }
+
+            return (
+              <View key={entry.id} style={styles.logRow}>
+                <Text style={styles.logText}>{baseText}</Text>
+              </View>
+            )
+          })}
         </ScrollView>
       </View>
-
-      <Modal
-        visible={Boolean(selectedBattleLog)}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setSelectedBattleLog(null)}
-      >
-        <View style={styles.modalBackdrop}>
-          <View style={styles.modalCard}>
-            <View style={styles.modalHeader}>
-              <Text style={styles.modalTitle}>戦闘ログ</Text>
-              <TouchableOpacity onPress={() => setSelectedBattleLog(null)}>
-                <Text style={styles.modalClose}>×</Text>
-              </TouchableOpacity>
-            </View>
-            <ScrollView style={styles.modalBody}>
-              {selectedBattleLog?.map((entry, index) => {
-                if (entry.action === 'turn_start' && entry.turnState) {
-                  return (
-                    <View key={`turn-${entry.turn}-${index}`} style={styles.modalSection}>
-                      <Text style={styles.modalSectionTitle}>Turn {entry.turn} 開始</Text>
-                      <Text style={styles.modalLabel}>味方:</Text>
-                      {entry.turnState.allies.map(ally => (
-                        <Text key={ally.id} style={styles.modalText}>
-                          {ally.name} {ally.currentHP}/{ally.maxHP} HP
-                        </Text>
-                      ))}
-                      <Text style={styles.modalLabel}>敵:</Text>
-                      {entry.turnState.enemies.map((enemy, enemyIndex) => (
-                        <Text key={`${enemy.id}-${enemyIndex}`} style={styles.modalText}>
-                          {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
-                        </Text>
-                      ))}
-                    </View>
-                  )
-                }
-
-                if (entry.action === 'turn_start') {
-                  return null
-                }
-
-                return (
-                  <View key={`log-${index}`} style={styles.modalLogCard}>
-                    <Text style={styles.modalLogTitle}>
-                      {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
-                    </Text>
-                    <Text style={styles.modalText}>{entry.actorName}の{entry.action}！</Text>
-                    {entry.targetName && typeof entry.damage === 'number' && (
-                      <Text style={styles.modalText}>
-                        {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
-                      </Text>
-                    )}
-                  </View>
-                )
-              })}
-            </ScrollView>
-          </View>
-        </View>
-      </Modal>
     </SafeAreaView>
   )
 }
@@ -592,86 +553,21 @@ const styles = StyleSheet.create({
   logScroll: {
     flex: 1,
   },
+  logRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 6,
+    gap: 6,
+  },
   logText: {
     fontSize: 12,
     color: '#374151',
     fontFamily: 'Courier',
-    marginBottom: 6,
+    flex: 1,
   },
   logDetail: {
     color: '#2563EB',
     fontWeight: '600',
-  },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.4)',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  modalCard: {
-    backgroundColor: '#F9FAFB',
-    borderRadius: 12,
-    overflow: 'hidden',
-    maxHeight: '85%',
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: '#1F2937',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  modalTitle: {
-    fontSize: 16,
-    fontWeight: '700',
-    color: '#F9FAFB',
-  },
-  modalClose: {
-    fontSize: 20,
-    color: '#F9FAFB',
-    paddingHorizontal: 8,
-  },
-  modalBody: {
-    padding: 12,
-  },
-  modalSection: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    padding: 12,
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  modalSectionTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
-  },
-  modalLabel: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#6B7280',
-    marginTop: 6,
-  },
-  modalText: {
-    fontSize: 12,
-    color: '#374151',
-    marginTop: 2,
-  },
-  modalLogCard: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 10,
-    padding: 12,
-    marginBottom: 10,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  modalLogTitle: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 6,
   },
 })

--- a/goblin_native/src/presentation/contexts/battleLogStore.ts
+++ b/goblin_native/src/presentation/contexts/battleLogStore.ts
@@ -1,0 +1,19 @@
+import type { BattleLogEntry } from '@/shared/types'
+
+const battleLogStore = new Map<string, BattleLogEntry[]>()
+let logCounter = 0
+
+export const storeBattleLog = (log: BattleLogEntry[]): string => {
+  logCounter += 1
+  const id = `${Date.now()}-${logCounter}`
+  battleLogStore.set(id, log)
+  return id
+}
+
+export const getBattleLog = (id: string): BattleLogEntry[] | null => {
+  return battleLogStore.get(id) ?? null
+}
+
+export const clearBattleLog = (id: string): void => {
+  battleLogStore.delete(id)
+}

--- a/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
@@ -252,183 +252,193 @@ export const ExpeditionLogScreen = ({
 
   return (
     <div className="flex flex-col h-full">
-      {/* ヘッダー */}
-      <div className="p-3 text-white bg-gray-800 shadow-lg">
-        <div className="flex justify-between items-center">
-          <div className="text-sm font-bold">
-            {expeditionReplay.meta.areaName} - {currentFloor}階
-          </div>
-          <div className="text-xs">
-            {formatTime(currentTime)} / {formatTime(expeditionReplay.durationSec)}
-          </div>
-        </div>
-
-        {/* プログレスバー */}
-        <div className="overflow-hidden mt-2 h-2 bg-gray-700 rounded-full">
-          <div
-            className="h-full bg-gray-400 transition-all duration-100 ease-linear"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-      </div>
-
-      {/* パーティ状態 */}
-      <div className="p-3 bg-gray-100 border-b-2 border-gray-300">
-        <div className="grid grid-cols-3 gap-2">
-          {expeditionReplay.meta.party.map((memberId, idx) => {
-            const goblin = goblins.find(g => g.id === parseInt(memberId))
-            const maxHp = goblin?.stats.hp || 100
-            const currentHp = partyHp[idx]
-            const hpPercent = (currentHp / maxHp) * 100
-            const isKO = currentHp <= 0
-
-            return (
-              <div
-                key={memberId}
-                className={`bg-white rounded-lg p-2 border ${isKO ? 'border-gray-500 opacity-50' : 'border-gray-300'}`}
-              >
-                <div className="flex gap-1 items-center mb-1">
-                  <div className="flex overflow-hidden justify-center items-center w-6 h-6 bg-gray-200 rounded-full">
-                    <img src={goblin?.avatar} alt={goblin?.name} className="object-cover w-full h-full" />
-                  </div>
-                  <div className="flex-1 text-xs font-medium truncate">
-                    {goblin?.name || `ID:${memberId}`}
-                  </div>
-                </div>
-                <div className="overflow-hidden h-1 bg-gray-200 rounded-full">
-                  <div
-                    className={`h-full transition-all duration-300 ${isKO ? 'bg-gray-400' : hpPercent > 50 ? 'bg-gray-700' : hpPercent > 25 ? 'bg-gray-500' : 'bg-gray-400'}`}
-                    style={{ width: `${hpPercent}%` }}
-                  />
-                </div>
-                <div className="mt-1 text-xs text-gray-600">
-                  HP: {currentHp}/{maxHp}
-                </div>
+      {/* ログ一覧 / 戦闘詳細 */}
+      <div className="relative flex-1 overflow-hidden bg-white">
+        <div
+          className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-out ${
+            selectedBattleLog ? '-translate-x-full' : 'translate-x-0'
+          }`}
+        >
+          <div className="p-3 text-white bg-gray-800 shadow-lg">
+            <div className="flex justify-between items-center">
+              <div className="text-sm font-bold">
+                {expeditionReplay.meta.areaName} - {currentFloor}階
               </div>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* イベントログ */}
-      <div className="overflow-hidden flex-1 bg-white">
-        <div
-          ref={logContainerRef}
-          className="overflow-y-auto p-4 space-y-1 h-full"
-        >
-          {eventLog.map((log, idx) => (
-            <div
-              key={idx}
-              className={`text-sm text-gray-700 font-mono ${
-                log.battleLog && log.battleLog.length > 0
-                  ? 'cursor-pointer hover:bg-gray-100 py-1 rounded'
-                  : ''
-              }`}
-              onClick={() => {
-                if (log.battleLog && log.battleLog.length > 0) {
-                  setSelectedBattleLog(log.battleLog)
-                }
-              }}
-            >
-              {log.message}
-              {log.battleLog && log.battleLog.length > 0 && (
-                <span className="ml-2 text-xs text-gray-500">[詳細]</span>
-              )}
+              <div className="text-xs">
+                {formatTime(currentTime)} / {formatTime(expeditionReplay.durationSec)}
+              </div>
             </div>
-          ))}
-        </div>
-      </div>
 
-      {/* 戦闘詳細ログモーダル */}
-      {selectedBattleLog && (
-        <div
-          className="flex fixed inset-0 z-50 justify-center items-center bg-black bg-opacity-50"
-          onClick={() => setSelectedBattleLog(null)}
-        >
-          <div
-            className="bg-white max-w-[414px] w-full h-full overflow-hidden flex flex-col"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex justify-between items-center p-4 text-white bg-gray-800">
-              <h3 className="font-bold">戦闘ログ</h3>
-              <button
-                onClick={() => setSelectedBattleLog(null)}
-                className="text-white hover:text-gray-300"
-              >
-                ×
-              </button>
+            <div className="overflow-hidden mt-2 h-2 bg-gray-700 rounded-full">
+              <div
+                className="h-full bg-gray-400 transition-all duration-100 ease-linear"
+                style={{ width: `${progress}%` }}
+              />
             </div>
-            <div className="overflow-y-auto overflow-x-hidden flex-1 p-4 space-y-2" style={{ WebkitOverflowScrolling: 'touch' }}>
-              {selectedBattleLog.map((entry, idx) => {
-                // ターン開始ログの場合
-                if (entry.action === 'turn_start' && entry.turnState) {
-                  return (
-                    <div key={idx} className="p-3 bg-gray-100 rounded border border-gray-300">
-                      <div className="mb-2 font-bold text-gray-700">
-                        Turn {entry.turn} 開始
-                      </div>
-                      <div className="space-y-2">
-                        <div>
-                          <div className="mb-1 text-xs font-semibold text-gray-700">味方:</div>
-                          <div className="space-y-1">
-                            {entry.turnState.allies.map((ally, i) => (
-                              <div key={i} className="flex justify-between items-center text-xs">
-                                <span className="text-gray-700">{ally.name}</span>
-                                <span className={`font-mono ${ally.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
-                                  {ally.currentHP}/{ally.maxHP} HP
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                        <div>
-                          <div className="mb-1 text-xs font-semibold text-gray-600">敵:</div>
-                          <div className="space-y-1">
-                            {entry.turnState.enemies.map((enemy, i) => (
-                              <div key={i} className="flex justify-between items-center text-xs">
-                                <span className="text-gray-700">{enemy.name}</span>
-                                <span className={`font-mono ${enemy.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
-                                  {enemy.currentHP}/{enemy.maxHP} HP
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )
-                }
+          </div>
 
-                // 通常の戦闘ログ
+          <div className="p-3 bg-gray-100 border-b border-gray-300">
+            <div className="grid grid-cols-3 gap-2">
+              {expeditionReplay.meta.party.map((memberId, idx) => {
+                const goblin = goblins.find(g => g.id === parseInt(memberId))
+                const maxHp = goblin?.stats.hp || 100
+                const currentHp = partyHp[idx]
+                const hpPercent = (currentHp / maxHp) * 100
+                const isKO = currentHp <= 0
+
                 return (
                   <div
-                    key={idx}
-                    className={`text-sm p-2 rounded ${
-                      entry.isAlly ? 'bg-gray-100' : 'bg-gray-200'
-                    }`}
+                    key={memberId}
+                    className={`bg-white rounded-lg p-2 border ${isKO ? 'border-gray-500 opacity-50' : 'border-gray-300'}`}
                   >
-                    <div className="font-mono text-xs">
-                      <span className={entry.isAlly ? 'text-gray-800 font-semibold' : 'text-gray-700 font-semibold'}>
-                        {entry.actorName}の攻撃
-                      </span>
-                      <span className="text-gray-500">
-                        ({entry.actorHP}HP)
-                      </span>
+                    <div className="flex gap-1 items-center mb-1">
+                      <div className="flex overflow-hidden justify-center items-center w-6 h-6 bg-gray-200 rounded-full">
+                        <img src={goblin?.avatar} alt={goblin?.name} className="object-cover w-full h-full" />
+                      </div>
+                      <div className="flex-1 text-xs font-medium truncate">
+                        {goblin?.name || `ID:${memberId}`}
+                      </div>
                     </div>
-                    <div className="mt-1 text-xs text-gray-700">
-                      {entry.actorName}の{entry.action}!
+                    <div className="overflow-hidden h-1 bg-gray-200 rounded-full">
+                      <div
+                        className={`h-full transition-all duration-300 ${isKO ? 'bg-gray-400' : hpPercent > 50 ? 'bg-gray-700' : hpPercent > 25 ? 'bg-gray-500' : 'bg-gray-400'}`}
+                        style={{ width: `${hpPercent}%` }}
+                      />
                     </div>
-                    <div className="mt-1 text-xs text-gray-700">
-                      {entry.targetName}に{entry.damage}ダメージ{entry.targetDefeated ? 'を与えて倒した！' : ''}
-                      {entry.healing && `${entry.healing}回復`}
+                    <div className="mt-1 text-xs text-gray-600">
+                      HP: {currentHp}/{maxHp}
                     </div>
                   </div>
                 )
               })}
             </div>
           </div>
+
+          <div className="overflow-hidden flex-1 bg-white">
+            <div
+              ref={logContainerRef}
+              className="overflow-y-auto p-4 space-y-1 h-full"
+            >
+              {eventLog.map((log, idx) => (
+                <div
+                  key={idx}
+                  className={`flex justify-between items-center text-sm text-gray-700 font-mono ${
+                    log.battleLog && log.battleLog.length > 0
+                      ? 'cursor-pointer hover:bg-gray-100 py-1 rounded'
+                      : ''
+                  }`}
+                  onClick={() => {
+                    if (log.battleLog && log.battleLog.length > 0) {
+                      setSelectedBattleLog(log.battleLog)
+                    }
+                  }}
+                >
+                  <div className="min-w-0">
+                    <div className="truncate">{log.message}</div>
+                    {log.battleLog && log.battleLog.length > 0 && (
+                      <div className="text-xs text-gray-500">詳細を見る</div>
+                    )}
+                  </div>
+                  {log.battleLog && log.battleLog.length > 0 && (
+                    <span className="ml-2 text-xs text-gray-400">›</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
-      )}
+
+        <div
+          className={`absolute inset-0 flex flex-col bg-white transition-transform duration-300 ease-out ${
+            selectedBattleLog ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
+          <div className="px-3 py-3 bg-white border-b border-gray-200">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setSelectedBattleLog(null)}
+                className="flex items-center gap-1 text-[15px] text-gray-600 hover:text-gray-800"
+              >
+                <span className="text-lg leading-none">‹</span>
+                戻る
+              </button>
+              <div className="text-[15px] font-semibold text-gray-900">
+                戦闘ログ
+              </div>
+              <div className="text-xs text-gray-400">
+                {formatTime(currentTime)}
+              </div>
+            </div>
+          </div>
+          <div className="overflow-y-auto overflow-x-hidden flex-1 p-4 space-y-2" style={{ WebkitOverflowScrolling: 'touch' }}>
+            {selectedBattleLog?.map((entry, idx) => {
+              if (entry.action === 'turn_start' && entry.turnState) {
+                return (
+                  <div key={idx} className="p-3 bg-gray-100 rounded border border-gray-300">
+                    <div className="mb-2 font-bold text-gray-700">
+                      Turn {entry.turn} 開始
+                    </div>
+                    <div className="space-y-2">
+                      <div>
+                        <div className="mb-1 text-xs font-semibold text-gray-700">味方:</div>
+                        <div className="space-y-1">
+                          {entry.turnState.allies.map((ally, i) => (
+                            <div key={i} className="flex justify-between items-center text-xs">
+                              <span className="text-gray-700">{ally.name}</span>
+                              <span className={`font-mono ${ally.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
+                                {ally.currentHP}/{ally.maxHP} HP
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="mb-1 text-xs font-semibold text-gray-600">敵:</div>
+                        <div className="space-y-1">
+                          {entry.turnState.enemies.map((enemy, i) => (
+                            <div key={i} className="flex justify-between items-center text-xs">
+                              <span className="text-gray-700">{enemy.name}</span>
+                              <span className={`font-mono ${enemy.currentHP <= 0 ? 'text-gray-500' : 'text-gray-600'}`}>
+                                {enemy.currentHP}/{enemy.maxHP} HP
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              }
+
+              return (
+                <div
+                  key={idx}
+                  className={`text-sm p-2 rounded ${
+                    entry.isAlly ? 'bg-gray-100' : 'bg-gray-200'
+                  }`}
+                >
+                  <div className="font-mono text-xs">
+                    <span className={entry.isAlly ? 'text-gray-800 font-semibold' : 'text-gray-700 font-semibold'}>
+                      {entry.actorName}の攻撃
+                    </span>
+                    <span className="text-gray-500">
+                      ({entry.actorHP}HP)
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs text-gray-700">
+                    {entry.actorName}の{entry.action}!
+                  </div>
+                  <div className="mt-1 text-xs text-gray-700">
+                    {entry.targetName}に{entry.damage}ダメージ{entry.targetDefeated ? 'を与えて倒した！' : ''}
+                    {entry.healing && `${entry.healing}回復`}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
- ネイティブの戦闘ログ詳細をモーダルから画面遷移へ変更
- 戦闘ログ受け渡し用の一時ストアを追加
- Web側のログ詳細表示を画面内遷移で調整

## テスト
- 未実施（必要なら実機で確認します）