### PR TITLE
feat: improve goblin detail and expedition preparation UI

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -4,12 +4,12 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useFocusEffect } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { useBaseState } from '@/presentation/hooks/useBaseState'
 import { useExpeditionFlow, type ExpeditionHistoryDisplay } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import type { Party, Goblin, ExpeditionRecord } from '@/shared/types'
 
 const MAX_PARTY_SLOTS = 6
-const INITIAL_PARTY_COUNT = 3
 
 interface MemberSlotProps {
   goblin?: Goblin
@@ -126,6 +126,7 @@ export default function FormationScreen() {
   const { width } = useWindowDimensions()
   const { parties, isLoading: partiesLoading, createParty, refreshParties } = usePartyService()
   const { goblins, isLoading: goblinsLoading, refreshGoblins } = useGoblinService()
+  const { rank, isLoading: baseLoading } = useBaseState()
   const {
     completeDueExpeditions,
     currentTime,
@@ -156,13 +157,15 @@ export default function FormationScreen() {
   )
 
   // 初期パーティ枠を確保（最低3つ）
+  const maxPartyCount = Math.max(1, rank)
   const displayParties = useMemo(() => {
-    const result: (Party | null)[] = [...parties]
-    while (result.length < INITIAL_PARTY_COUNT) {
+    const sortedParties = [...parties].sort((a, b) => a.id - b.id).slice(0, maxPartyCount)
+    const result: (Party | null)[] = [...sortedParties]
+    while (result.length < maxPartyCount) {
       result.push(null)
     }
     return result
-  }, [parties])
+  }, [maxPartyCount, parties])
 
 
   const handlePartyPress = useCallback((party: Party | null, index: number) => {
@@ -223,7 +226,7 @@ export default function FormationScreen() {
     })
   }, [])
 
-  if (partiesLoading || goblinsLoading) {
+  if (partiesLoading || goblinsLoading || baseLoading) {
     return (
       <SafeAreaView style={styles.loadingContainer} edges={['left', 'right', 'bottom']}>
         <ActivityIndicator size="large" color="#3B82F6" />
@@ -395,7 +398,7 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   partyName: {
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: 'bold',
     color: '#1F2937',
   },

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
-import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator, Alert, Image, useWindowDimensions } from 'react-native'
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator, Alert, Image, useWindowDimensions, Modal, Pressable } from 'react-native'
 import { router, useLocalSearchParams, Stack, useFocusEffect } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
@@ -61,7 +61,7 @@ export default function ExpeditionPreparationScreen() {
   } = usePartyService()
   const { goblins, isLoading: goblinsLoading, refreshGoblins } = useGoblinService()
   const { dungeons, isLoading: dungeonsLoading } = useDungeonProgress()
-  const { startExpedition } = useExpeditionFlow()
+  const { startExpedition, estimateExplorationTime } = useExpeditionFlow()
   const [retryCount, setRetryCount] = useState(0)
 
   const party = useMemo(() => {
@@ -95,6 +95,8 @@ export default function ExpeditionPreparationScreen() {
   const [selectedDungeonId, setSelectedDungeonId] = useState<string | undefined>(party?.dungeonId)
   const [selectedReturnPolicy, setSelectedReturnPolicy] = useState<ReturnPolicy>(party?.returnPolicy ?? 'never')
   const [selectedTargetFloor, setSelectedTargetFloor] = useState<number | null>(party?.targetFloor ?? null)
+  const [isDungeonModalVisible, setIsDungeonModalVisible] = useState(false)
+  const [isReturnPolicyModalVisible, setIsReturnPolicyModalVisible] = useState(false)
 
   const partyMembers = useMemo(() => {
     if (!party) return []
@@ -119,6 +121,11 @@ export default function ExpeditionPreparationScreen() {
   const selectedDungeon = useMemo(() => {
     return dungeons.find(d => d.id === selectedDungeonId)
   }, [dungeons, selectedDungeonId])
+
+  const estimatedExplorationTime = useMemo(() => {
+    if (!selectedDungeon) return null
+    return estimateExplorationTime(selectedDungeon, selectedReturnPolicy)
+  }, [estimateExplorationTime, selectedDungeon, selectedReturnPolicy])
 
   const handleEditParty = useCallback(() => {
     router.push({
@@ -266,37 +273,21 @@ export default function ExpeditionPreparationScreen() {
             {/* 遠征先 */}
             <View style={styles.settingItem}>
               <Text style={styles.settingLabel}>遠征先</Text>
-              <View style={styles.settingValue}>
+              <TouchableOpacity
+                style={styles.settingValue}
+                onPress={() => setIsDungeonModalVisible(true)}
+                disabled={unlockedDungeons.length === 0}
+              >
                 {selectedDungeon ? (
-                  <Text style={styles.settingValueText}>{selectedDungeon.name}</Text>
+                  <>
+                    <Text style={styles.settingValueText}>{selectedDungeon.name}</Text>
+                    <Text style={styles.settingValueDescription}>{selectedDungeon.description}</Text>
+                  </>
                 ) : (
                   <Text style={styles.settingValuePlaceholder}>遠征先が未設定です</Text>
                 )}
-              </View>
+              </TouchableOpacity>
             </View>
-
-            {/* ダンジョン選択リスト */}
-            {unlockedDungeons.length > 0 && (
-              <View style={styles.dungeonList}>
-                {unlockedDungeons.map(dungeon => (
-                  <TouchableOpacity
-                    key={dungeon.id}
-                    style={[
-                      styles.dungeonOption,
-                      selectedDungeonId === dungeon.id && styles.dungeonSelected,
-                    ]}
-                    onPress={() => handleSelectDungeon(dungeon)}
-                  >
-                    <Text style={[
-                      styles.dungeonName,
-                      selectedDungeonId === dungeon.id && styles.dungeonNameSelected,
-                    ]}>
-                      {dungeon.name}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            )}
 
             {/* 目標階数 */}
             <View style={styles.settingItem}>
@@ -311,36 +302,110 @@ export default function ExpeditionPreparationScreen() {
             {/* 帰還条件 */}
             <View style={styles.settingItem}>
               <Text style={styles.settingLabel}>帰還条件</Text>
-              <View style={styles.settingValue}>
+              <TouchableOpacity
+                style={styles.settingValue}
+                onPress={() => setIsReturnPolicyModalVisible(true)}
+              >
                 <Text style={styles.settingValueText}>
                   {RETURN_POLICIES.find(p => p.value === selectedReturnPolicy)?.label ?? '帰還しない'}
                 </Text>
-              </View>
+              </TouchableOpacity>
             </View>
 
-            {/* 帰還条件選択リスト */}
-            <View style={styles.policyList}>
+            {/* 推定探索時間 */}
+            <View style={styles.settingItem}>
+              <Text style={styles.settingLabel}>推定探索時間</Text>
+              <View style={styles.settingValue}>
+                {estimatedExplorationTime !== null ? (
+                  <Text style={styles.settingValueText}>{estimatedExplorationTime}秒</Text>
+                ) : (
+                  <Text style={styles.settingValuePlaceholder}>遠征先が未設定です</Text>
+                )}
+              </View>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+      <Modal
+        transparent
+        visible={isDungeonModalVisible}
+        animationType="fade"
+        onRequestClose={() => setIsDungeonModalVisible(false)}
+      >
+        <Pressable style={styles.modalOverlay} onPress={() => setIsDungeonModalVisible(false)}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>遠征先を選択</Text>
+            <ScrollView style={styles.modalList} contentContainerStyle={styles.modalListContent}>
+              {unlockedDungeons.length === 0 ? (
+                <Text style={styles.modalEmptyText}>選択できるダンジョンがありません</Text>
+              ) : (
+                unlockedDungeons.map(dungeon => (
+                  <TouchableOpacity
+                    key={dungeon.id}
+                    style={[
+                      styles.modalOption,
+                      selectedDungeonId === dungeon.id && styles.modalOptionSelected,
+                    ]}
+                    onPress={() => {
+                      handleSelectDungeon(dungeon)
+                      setIsDungeonModalVisible(false)
+                    }}
+                  >
+                    <Text style={[
+                      styles.modalOptionTitle,
+                      selectedDungeonId === dungeon.id && styles.modalOptionTitleSelected,
+                    ]}>
+                      {dungeon.name}
+                    </Text>
+                    <Text style={styles.modalOptionDescription}>{dungeon.description}</Text>
+                  </TouchableOpacity>
+                ))
+              )}
+            </ScrollView>
+            <TouchableOpacity style={styles.modalCloseButton} onPress={() => setIsDungeonModalVisible(false)}>
+              <Text style={styles.modalCloseButtonText}>閉じる</Text>
+            </TouchableOpacity>
+          </View>
+        </Pressable>
+      </Modal>
+
+      <Modal
+        transparent
+        visible={isReturnPolicyModalVisible}
+        animationType="fade"
+        onRequestClose={() => setIsReturnPolicyModalVisible(false)}
+      >
+        <Pressable style={styles.modalOverlay} onPress={() => setIsReturnPolicyModalVisible(false)}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>帰還条件を選択</Text>
+            <ScrollView style={styles.modalList} contentContainerStyle={styles.modalListContent}>
               {RETURN_POLICIES.map(policy => (
                 <TouchableOpacity
                   key={policy.value}
                   style={[
-                    styles.policyOption,
-                    selectedReturnPolicy === policy.value && styles.policySelected,
+                    styles.modalOption,
+                    selectedReturnPolicy === policy.value && styles.modalOptionSelected,
                   ]}
-                  onPress={() => handleSelectReturnPolicy(policy.value)}
+                  onPress={() => {
+                    handleSelectReturnPolicy(policy.value)
+                    setIsReturnPolicyModalVisible(false)
+                  }}
                 >
                   <Text style={[
-                    styles.policyName,
-                    selectedReturnPolicy === policy.value && styles.policyNameSelected,
+                    styles.modalOptionTitle,
+                    selectedReturnPolicy === policy.value && styles.modalOptionTitleSelected,
                   ]}>
                     {policy.label}
                   </Text>
                 </TouchableOpacity>
               ))}
-            </View>
+            </ScrollView>
+            <TouchableOpacity style={styles.modalCloseButton} onPress={() => setIsReturnPolicyModalVisible(false)}>
+              <Text style={styles.modalCloseButtonText}>閉じる</Text>
+            </TouchableOpacity>
           </View>
-        </View>
-      </ScrollView>
+        </Pressable>
+      </Modal>
     </>
   )
 }
@@ -500,56 +565,77 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#1F2937',
   },
+  settingValueDescription: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 4,
+  },
   settingValuePlaceholder: {
     fontSize: 14,
     color: '#9CA3AF',
   },
-  dungeonList: {
-    marginBottom: 16,
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
   },
-  dungeonOption: {
+  modalContent: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    maxHeight: '70%',
+  },
+  modalTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1F2937',
+    marginBottom: 12,
+  },
+  modalList: {
+    marginBottom: 12,
+  },
+  modalListContent: {
+    gap: 8,
+  },
+  modalOption: {
     paddingVertical: 10,
     paddingHorizontal: 12,
     borderRadius: 8,
-    marginBottom: 6,
     backgroundColor: '#F9FAFB',
     borderWidth: 1,
     borderColor: '#E5E7EB',
   },
-  dungeonSelected: {
+  modalOptionSelected: {
     backgroundColor: '#DBEAFE',
     borderColor: '#3B82F6',
   },
-  dungeonName: {
+  modalOptionTitle: {
     fontSize: 14,
     color: '#374151',
-  },
-  dungeonNameSelected: {
-    color: '#1D4ED8',
     fontWeight: '600',
+    marginBottom: 4,
   },
-  policyList: {
-    marginTop: 8,
+  modalOptionTitleSelected: {
+    color: '#1D4ED8',
   },
-  policyOption: {
+  modalOptionDescription: {
+    fontSize: 12,
+    color: '#6B7280',
+  },
+  modalEmptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  modalCloseButton: {
     paddingVertical: 10,
-    paddingHorizontal: 12,
+    alignItems: 'center',
     borderRadius: 8,
-    marginBottom: 6,
-    backgroundColor: '#F9FAFB',
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
+    backgroundColor: '#E5E7EB',
   },
-  policySelected: {
-    backgroundColor: '#DBEAFE',
-    borderColor: '#3B82F6',
-  },
-  policyName: {
+  modalCloseButtonText: {
     fontSize: 14,
-    color: '#374151',
-  },
-  policyNameSelected: {
-    color: '#1D4ED8',
     fontWeight: '600',
+    color: '#374151',
   },
 })

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useEffect } from 'react'
 import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Image, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -22,7 +22,7 @@ export default function ExpeditionResultScreen() {
 
   const { getPartyById } = usePartyService()
   const { goblins } = useGoblinService()
-  const { dungeons } = useDungeonProgress()
+  const { dungeons, markDungeonCleared } = useDungeonProgress()
   const { expeditionRecords, getExpeditionById, isLoading: isExpeditionLoading } = useExpeditionService()
 
   const expeditionRecord = useMemo(() => {
@@ -86,6 +86,14 @@ export default function ExpeditionResultScreen() {
 
     return { current: goblin.stats.hp, max: goblin.stats.hp }
   }
+
+  useEffect(() => {
+    if (!replay || !dungeon) return
+    const cleared = replay.summary.success && replay.summary.maxFloorReached >= dungeon.floors
+    if (cleared && !dungeon.cleared) {
+      markDungeonCleared(dungeon, true)
+    }
+  }, [dungeon, markDungeonCleared, replay])
 
   const handleBackToList = useCallback(() => {
     router.replace('/formation')

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -1,11 +1,14 @@
-import { useState, useCallback } from 'react'
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView, ActivityIndicator, Image } from 'react-native'
+import { useState, useCallback, useMemo } from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView, ActivityIndicator, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import type { Goblin } from '@/shared/types'
 import { getFactor } from '@/shared/data/factors'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
+import { ModStatCalculator } from '@/core/services/ModStatCalculator'
+import { getExpForNextLevel, getExpProgress } from '@/core/services/ExperienceSystem'
+import { getModTemplate } from '@/shared/data/modPoolLoader'
 
 interface GoblinCardProps {
   goblin: Goblin
@@ -45,6 +48,23 @@ function GoblinCard({ goblin, onPress }: GoblinCardProps) {
   )
 }
 
+const STAT_LABELS: Record<string, string> = {
+  hp_percent: 'HP',
+  hp_flat: 'HP',
+  atk_percent: 'ATK',
+  atk_flat: 'ATK',
+  def_percent: 'DEF',
+  def_flat: 'DEF',
+  spd_percent: 'SPD',
+  sp_percent: 'SP',
+  sp_flat: 'SP',
+  damage_reduction: '被ダメ軽減',
+}
+
+function getStatLabel(stat: string): string {
+  return STAT_LABELS[stat] || stat
+}
+
 interface GoblinDetailModalProps {
   goblin: Goblin | null
   visible: boolean
@@ -52,7 +72,31 @@ interface GoblinDetailModalProps {
 }
 
 function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps) {
+  const { deleteGoblin } = useGoblinService()
+
   if (!goblin) return null
+
+  const effectiveStats = useMemo(() => ModStatCalculator.calculate(goblin), [goblin])
+  const expForNext = getExpForNextLevel(goblin.level)
+  const expProgress = getExpProgress(goblin.level, goblin.experience)
+
+  const handleBanish = () => {
+    Alert.alert(
+      '追放確認',
+      `${goblin.name}を追放しますか？`,
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: '追放する',
+          style: 'destructive',
+          onPress: () => {
+            deleteGoblin(goblin.id)
+            onClose()
+          },
+        },
+      ],
+    )
+  }
 
   return (
     <Modal
@@ -63,46 +107,58 @@ function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps)
     >
       <SafeAreaView style={styles.modalContainer}>
         <View style={styles.modalHeader}>
-          <Text style={styles.modalTitle}>{goblin.name}</Text>
           <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-            <Text style={styles.closeButtonText}>X</Text>
+            <Text style={styles.closeButtonText}>←</Text>
           </TouchableOpacity>
+          <Text style={styles.modalTitle}>ゴブリン詳細</Text>
+          <View style={styles.headerSpacer} />
         </View>
         <ScrollView style={styles.modalContent}>
-          <View style={styles.detailSection}>
-            <Text style={styles.sectionTitle}>基本情報</Text>
-            <Text style={styles.detailText}>レベル: {goblin.level}</Text>
-            <Text style={styles.detailText}>種族: {goblin.race}</Text>
-            <Text style={styles.detailText}>経験値: {goblin.experience}</Text>
-            {goblin.individualValue && (
-              <Text style={styles.detailText}>個体値: {goblin.individualValue}</Text>
-            )}
-          </View>
-          <View style={styles.detailSection}>
-            <Text style={styles.sectionTitle}>ステータス</Text>
-            <View style={styles.statsGrid}>
-              <View style={styles.statItem}>
-                <Text style={styles.statLabel}>HP</Text>
-                <Text style={styles.statValue}>{goblin.stats.hp}</Text>
+          <View style={styles.profileCard}>
+            <View style={styles.profileRow}>
+              <View style={styles.profileAvatar}>
+                <Image source={getGoblinImage(goblin.avatar)} style={styles.profileAvatarImage} />
               </View>
-              <View style={styles.statItem}>
-                <Text style={styles.statLabel}>ATK</Text>
-                <Text style={styles.statValue}>{goblin.stats.atk}</Text>
-              </View>
-              <View style={styles.statItem}>
-                <Text style={styles.statLabel}>DEF</Text>
-                <Text style={styles.statValue}>{goblin.stats.def}</Text>
-              </View>
-              <View style={styles.statItem}>
-                <Text style={styles.statLabel}>SPD</Text>
-                <Text style={styles.statValue}>{goblin.stats.spd}</Text>
-              </View>
-              <View style={styles.statItem}>
-                <Text style={styles.statLabel}>SP</Text>
-                <Text style={styles.statValue}>{goblin.stats.sp}</Text>
+              <View style={styles.profileInfo}>
+                <Text style={styles.profileName}>{goblin.name}</Text>
+                <Text style={styles.profileRace}>{goblin.race}</Text>
+                <Text style={styles.profileLevel}>Lv.{goblin.level}</Text>
               </View>
             </View>
           </View>
+
+          <View style={styles.detailSection}>
+            <Text style={styles.sectionTitle}>ステータス</Text>
+            <View style={styles.statList}>
+              {([
+                { key: 'hp', label: 'HP' },
+                { key: 'atk', label: 'ATK' },
+                { key: 'def', label: 'DEF' },
+                { key: 'spd', label: 'SPD' },
+                { key: 'sp', label: 'SP' },
+              ] as const).map(item => (
+                <View key={item.key} style={styles.statRow}>
+                  <Text style={styles.statRowLabel}>{item.label}</Text>
+                  <Text style={styles.statRowValue}>{effectiveStats[item.key]}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.detailSection}>
+            <Text style={styles.sectionTitle}>経験値</Text>
+            <View style={styles.expCard}>
+              <View style={styles.expRow}>
+                <Text style={styles.expLabel}>EXP</Text>
+                <Text style={styles.expValue}>{goblin.experience} / {expForNext}</Text>
+              </View>
+              <View style={styles.expBarTrack}>
+                <View style={[styles.expBarFill, { width: `${Math.max(0, Math.min(1, expProgress)) * 100}%` }]} />
+              </View>
+              <Text style={styles.expHint}>次のレベルまで: {Math.max(0, expForNext - goblin.experience)}</Text>
+            </View>
+          </View>
+
           {goblin.factors && goblin.factors.length > 0 && (
             <View style={styles.detailSection}>
               <Text style={styles.sectionTitle}>因子</Text>
@@ -118,25 +174,48 @@ function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps)
                     <View style={styles.factorInfo}>
                       <Text style={styles.factorName}>{factor.name}</Text>
                       <Text style={styles.factorDesc}>{factor.description}</Text>
+                      {factor.effects && factor.effects.length > 0 && (
+                        <View style={styles.factorEffectRow}>
+                          {factor.effects
+                            .filter(effect => effect.type === 'stat_bonus')
+                            .map((effect, effectIndex) => (
+                              <View key={`${factorId}-${effectIndex}`} style={styles.factorEffectBadge}>
+                                <Text style={styles.factorEffectText}>
+                                  {effect.target.toUpperCase()} +{effect.value}
+                                </Text>
+                              </View>
+                            ))}
+                        </View>
+                      )}
                     </View>
                   </View>
                 )
               })}
             </View>
           )}
+
           {goblin.mods && goblin.mods.length > 0 && (
             <View style={styles.detailSection}>
-              <Text style={styles.sectionTitle}>Mod ({goblin.mods.length})</Text>
-              {goblin.mods.map((mod, idx) => (
-                <View key={idx} style={styles.modItem}>
-                  <Text style={styles.modName}>{mod.templateId}</Text>
-                  <Text style={styles.modEffect}>
-                    値: {mod.value > 0 ? '+' : ''}{mod.value}
-                  </Text>
-                </View>
-              ))}
+              <Text style={styles.sectionTitle}>Mod</Text>
+              {goblin.mods.map((mod, idx) => {
+                const template = getModTemplate(mod.templateId)
+                if (!template) return null
+                const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
+                const label = getStatLabel(template.stat)
+                const valueText = `${mod.value > 0 ? '+' : ''}${mod.value}${isPercent ? '%' : ''}`
+                return (
+                  <View key={idx} style={styles.modItem}>
+                    <Text style={styles.modName}>{label}</Text>
+                    <Text style={styles.modEffect}>{valueText}</Text>
+                  </View>
+                )
+              })}
             </View>
           )}
+
+          <TouchableOpacity style={styles.banishButton} onPress={handleBanish}>
+            <Text style={styles.banishButtonText}>このゴブリンを追放する</Text>
+          </TouchableOpacity>
         </ScrollView>
       </SafeAreaView>
     </Modal>
@@ -320,32 +399,81 @@ const styles = StyleSheet.create({
     borderBottomColor: '#E5E7EB',
   },
   modalTitle: {
-    fontSize: 24,
-    fontWeight: 'bold',
+    fontSize: 18,
+    fontWeight: '700',
     color: '#1F2937',
   },
   closeButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: '#E5E7EB',
-    alignItems: 'center',
-    justifyContent: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
   },
   closeButtonText: {
-    fontSize: 16,
-    fontWeight: 'bold',
+    fontSize: 18,
+    fontWeight: '600',
     color: '#6B7280',
+  },
+  headerSpacer: {
+    width: 32,
   },
   modalContent: {
     flex: 1,
     padding: 16,
+  },
+  profileCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  profileAvatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    borderWidth: 2,
+    borderColor: '#9CA3AF',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    marginRight: 16,
+    backgroundColor: '#F3F4F6',
+  },
+  profileAvatarImage: {
+    width: 52,
+    height: 52,
+    resizeMode: 'contain',
+  },
+  profileInfo: {
+    flex: 1,
+  },
+  profileName: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1F2937',
+    marginBottom: 4,
+  },
+  profileRace: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginBottom: 2,
+  },
+  profileLevel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1F2937',
   },
   detailSection: {
     backgroundColor: '#FFFFFF',
     borderRadius: 12,
     padding: 16,
     marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
   },
   sectionTitle: {
     fontSize: 16,
@@ -353,37 +481,76 @@ const styles = StyleSheet.create({
     color: '#1F2937',
     marginBottom: 12,
   },
-  detailText: {
+  statList: {
+    gap: 10,
+  },
+  statRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+  },
+  statRowLabel: {
     fontSize: 14,
-    color: '#4B5563',
+    fontWeight: '600',
+    color: '#374151',
+  },
+  statRowValue: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#374151',
+  },
+  expCard: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+    padding: 12,
+  },
+  expRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     marginBottom: 8,
   },
-  statsGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+  expLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#374151',
   },
-  statItem: {
-    width: '33%',
-    alignItems: 'center',
-    marginBottom: 12,
+  expValue: {
+    fontSize: 13,
+    color: '#6B7280',
   },
-  statLabel: {
+  expBarTrack: {
+    height: 8,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  expBarFill: {
+    height: '100%',
+    backgroundColor: '#4B5563',
+  },
+  expHint: {
+    marginTop: 6,
     fontSize: 12,
     color: '#6B7280',
-    marginBottom: 4,
-  },
-  statValue: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#1F2937',
+    textAlign: 'right',
   },
   factorItem: {
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 12,
-    padding: 8,
-    backgroundColor: '#F3F4F6',
-    borderRadius: 8,
+    padding: 12,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
   },
   factorIconContainer: {
     width: 32,
@@ -405,14 +572,33 @@ const styles = StyleSheet.create({
     color: '#6B7280',
     marginTop: 2,
   },
+  factorEffectRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 8,
+  },
+  factorEffectBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    backgroundColor: '#DCFCE7',
+  },
+  factorEffectText: {
+    fontSize: 11,
+    color: '#166534',
+    fontWeight: '600',
+  },
   modItem: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 8,
-    padding: 8,
+    padding: 12,
     backgroundColor: '#F3F4F6',
-    borderRadius: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#DBEAFE',
   },
   modName: {
     fontSize: 14,
@@ -421,6 +607,19 @@ const styles = StyleSheet.create({
   modEffect: {
     fontSize: 14,
     fontWeight: '600',
-    color: '#10B981',
+    color: '#1F2937',
+  },
+  banishButton: {
+    marginTop: 4,
+    marginBottom: 24,
+    backgroundColor: '#374151',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  banishButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 14,
   },
 })

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -14,6 +14,7 @@ import { useGoblinService } from './useGoblinService'
 import { useExpeditionService } from './useExpeditionService'
 import { usePendingGoblins } from './usePendingGoblins'
 import { useBaseState } from './useBaseState'
+import { useDungeonProgress } from './useDungeonProgress'
 
 interface UseExpeditionFlowParams {
   refreshParties?: () => Promise<void> | void
@@ -53,6 +54,7 @@ export const useExpeditionFlow = ({
   const { goblinRepository, goblins } = useGoblinService()
   const { pendingGoblins, addPendingGoblin, isLoading: isPendingLoading } = usePendingGoblins()
   const { rank, getNextGoblinId, isLoading: isBaseLoading } = useBaseState()
+  const { markDungeonCleared } = useDungeonProgress()
   const {
     expeditionRecords,
     getPartyExpeditionHistory,
@@ -72,7 +74,7 @@ export const useExpeditionFlow = ({
     return new CompleteExpeditionUseCase(goblinRepository, partyRepository)
   }, [goblinRepository, partyRepository])
 
-  const addPendingGoblinOnClear = useCallback((record: ExpeditionRecord) => {
+  const handleDungeonClear = useCallback((record: ExpeditionRecord) => {
     if (!record.replay || isPendingLoading || isBaseLoading) return
 
     const dungeon = areasData.find(area => area.id === record.dungeonId)
@@ -81,6 +83,8 @@ export const useExpeditionFlow = ({
     const cleared = record.replay.summary.success &&
       record.replay.summary.maxFloorReached >= dungeon.floors
     if (!cleared) return
+
+    markDungeonCleared(dungeon, true)
 
     const maxPending = rank * 5
     if (pendingGoblins.length >= maxPending) return
@@ -96,6 +100,7 @@ export const useExpeditionFlow = ({
     goblins,
     isBaseLoading,
     isPendingLoading,
+    markDungeonCleared,
     pendingGoblins.length,
     rank,
   ])
@@ -211,7 +216,7 @@ export const useExpeditionFlow = ({
       if (processedExpeditionsRef.current.has(record.id)) continue
       try {
         await completeExpeditionUseCase.execute(record.partyId, record.replay!)
-        addPendingGoblinOnClear(record)
+        handleDungeonClear(record)
         completeExpeditionRecord(record.id, record.replay!)
         processedExpeditionsRef.current.add(record.id)
         if (refreshParties) {
@@ -226,7 +231,7 @@ export const useExpeditionFlow = ({
     expeditionRecords,
     completeExpeditionUseCase,
     completeExpeditionRecord,
-    addPendingGoblinOnClear,
+    handleDungeonClear,
     refreshParties,
   ])
 

--- a/goblin_web/src/presentation/components/BaseManagementScreen.tsx
+++ b/goblin_web/src/presentation/components/BaseManagementScreen.tsx
@@ -9,6 +9,7 @@ import { JsonBaseStateRepositoryImpl } from '../../infrastructure/repositories/J
 import { getModTemplate } from '../../shared/data/modPoolLoader'
 import { ModStatCalculator } from '../../core/services/ModStatCalculator'
 import { FactorBadgeList } from './FactorBadge'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 const STAT_LABELS: Record<ModStat, string> = {
   hp_percent: 'HP',
@@ -246,7 +247,7 @@ export const BaseManagementScreen = () => {
                       </div>
                     </div>
                     <div className="w-10 h-10 flex items-center justify-center flex-shrink-0">
-                      <img src={goblin.avatar} alt={goblin.name} className="w-full h-full object-contain" />
+                      <img src={getGoblinAvatar(goblin)} alt={goblin.name} className="w-full h-full object-contain" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="font-semibold text-gray-800 text-sm truncate">{goblin.name}</div>

--- a/goblin_web/src/presentation/components/DungeonConfirmModal.tsx
+++ b/goblin_web/src/presentation/components/DungeonConfirmModal.tsx
@@ -1,4 +1,5 @@
 import type { Dungeon, Party, Goblin } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface DungeonConfirmModalProps {
   dungeon: Dungeon
@@ -32,7 +33,7 @@ export const DungeonConfirmModal = ({ dungeon, party, goblins, onConfirm, onCanc
             {members.map(member => (
               <div key={member.id} className="flex items-center gap-1 text-xs bg-white rounded px-2 py-1 border border-gray-300">
                 <div className="w-6 h-6 bg-gray-100 rounded-full flex items-center justify-center border border-gray-400 overflow-hidden">
-                  <img src={member.avatar} alt={member.name} className="w-full h-full object-cover" />
+                  <img src={getGoblinAvatar(member)} alt={member.name} className="w-full h-full object-cover" />
                 </div>
                 <span className="text-gray-600">{member.name}</span>
               </div>

--- a/goblin_web/src/presentation/components/ExpeditionConfirmModal.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionConfirmModal.tsx
@@ -1,4 +1,5 @@
 import type { Dungeon, Goblin } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionConfirmModalProps {
   dungeon: Dungeon
@@ -38,7 +39,7 @@ export const ExpeditionConfirmModal = ({
                 {members.map(member => (
                   <div key={member.id} className="flex items-center gap-1 text-xs bg-white rounded px-2 py-1 border border-gray-200">
                     <div className="w-5 h-5 rounded-full overflow-hidden">
-                      <img src={member.avatar} alt={member.name} className="w-full h-full object-cover" />
+                      <img src={getGoblinAvatar(member)} alt={member.name} className="w-full h-full object-cover" />
                     </div>
                     <span className="text-gray-700">{member.name}</span>
                   </div>

--- a/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionLogScreen.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { ExpeditionReplay, TimelineEvent, Goblin, BattleLogEntry } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionLogScreenProps {
   expeditionReplay: ExpeditionReplay
@@ -293,7 +294,7 @@ export const ExpeditionLogScreen = ({
                   >
                     <div className="flex gap-1 items-center mb-1">
                       <div className="flex overflow-hidden justify-center items-center w-6 h-6 bg-gray-200 rounded-full">
-                        <img src={goblin?.avatar} alt={goblin?.name} className="object-cover w-full h-full" />
+                        <img src={getGoblinAvatar(goblin)} alt={goblin?.name} className="object-cover w-full h-full" />
                       </div>
                       <div className="flex-1 text-xs font-medium truncate">
                         {goblin?.name || `ID:${memberId}`}

--- a/goblin_web/src/presentation/components/ExpeditionPlaybackScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionPlaybackScreen.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { ExpeditionReplay, TimelineEvent, Goblin } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionPlaybackScreenProps {
   expeditionReplay: ExpeditionReplay
@@ -314,7 +315,7 @@ export const ExpeditionPlaybackScreen = ({
               >
                 <div className="flex items-center gap-1 mb-1">
                   <div className="w-6 h-6 bg-gray-200 rounded-full flex items-center justify-center overflow-hidden">
-                    <img src={goblin?.avatar} alt={goblin?.name} className="w-full h-full object-cover" />
+                    <img src={getGoblinAvatar(goblin)} alt={goblin?.name} className="w-full h-full object-cover" />
                   </div>
                   <div className="text-xs font-medium truncate flex-1">
                     {goblin?.name || `ID:${memberId}`}

--- a/goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx
@@ -4,6 +4,7 @@ import { DungeonSelectionModal } from './DungeonSelectionModal.tsx'
 import { FloorTargetSelectionModal } from './FloorTargetSelectionModal.tsx'
 import { ReturnPolicySelectionModal } from './ReturnPolicySelectionModal.tsx'
 import { ExpeditionConfirmModal } from './ExpeditionConfirmModal.tsx'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionPreparationScreenProps {
   partyId: number
@@ -204,7 +205,7 @@ export const ExpeditionPreparationScreen = ({
                         <>
                           <div className="text-xs text-gray-600">Lv{member.level}</div>
                           <div className="overflow-hidden w-8 h-8 rounded-full">
-                            <img src={member.avatar} alt={member.name} className="object-cover w-full h-full" />
+                            <img src={getGoblinAvatar(member)} alt={member.name} className="object-cover w-full h-full" />
                           </div>
                           <div className="text-xs text-gray-600">HP{member.stats.hp}</div>
                         </>

--- a/goblin_web/src/presentation/components/ExpeditionResultScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionResultScreen.tsx
@@ -1,6 +1,7 @@
 import type { ExpeditionReplay, Goblin } from '../../shared/types'
 import { areasData } from '../../shared/data'
 import { getFactor } from '../../shared/data/factors'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionResultScreenProps {
   expeditionReplay: ExpeditionReplay
@@ -81,7 +82,7 @@ export const ExpeditionResultScreen = ({
               >
                 <div className="flex overflow-hidden flex-shrink-0 justify-center items-center w-10 h-10 bg-gray-200 rounded">
                   <img
-                    src={goblin?.avatar}
+                    src={getGoblinAvatar(goblin)}
                     alt={goblin?.name}
                     className={`w-full h-full object-cover ${dead ? 'grayscale' : ''}`}
                   />

--- a/goblin_web/src/presentation/components/ExpeditionSetupScreen.tsx
+++ b/goblin_web/src/presentation/components/ExpeditionSetupScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Party, Goblin, Dungeon, ExpeditionRequest } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface ExpeditionSetupScreenProps {
   parties: Party[]
@@ -163,7 +164,7 @@ export const ExpeditionSetupScreen = ({
                   {members.map(member => (
                     <div key={member.id} className="flex items-center gap-1 text-xs bg-gray-100 rounded px-2 py-1">
                       <div className="w-5 h-5 bg-gray-200 rounded-full flex items-center justify-center border overflow-hidden">
-                        <img src={member.avatar} alt={member.name} className="w-full h-full object-cover" />
+                        <img src={getGoblinAvatar(member)} alt={member.name} className="w-full h-full object-cover" />
                       </div>
                       <span className="text-gray-600">{member.name}</span>
                     </div>

--- a/goblin_web/src/presentation/components/FormationScreen.tsx
+++ b/goblin_web/src/presentation/components/FormationScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ExpeditionRecord, Goblin, Party } from '../../shared/types'
 import { useCurrentTime } from '../hooks/useCurrentTime.ts'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface FormationScreenProps {
   parties: Party[]
@@ -191,7 +192,7 @@ export const FormationScreen = ({
                           <>
                             <div className="text-xs text-gray-600">Lv{member.level}</div>
                             <div className="overflow-hidden w-8 h-8 rounded-full">
-                              <img src={member.avatar} alt={member.name} className="object-cover w-full h-full" />
+                              <img src={getGoblinAvatar(member)} alt={member.name} className="object-cover w-full h-full" />
                             </div>
                             <div className="text-xs text-gray-600">HP{member.effectiveStats?.hp ?? member.stats.hp}</div>
                           </>

--- a/goblin_web/src/presentation/components/GoblinCard.tsx
+++ b/goblin_web/src/presentation/components/GoblinCard.tsx
@@ -1,4 +1,5 @@
 import type { Goblin } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 import { FactorBadgeList } from './FactorBadge'
 
 interface GoblinCardProps {
@@ -12,7 +13,7 @@ export const GoblinCard = ({ goblin, onClick }: GoblinCardProps) => (
     onClick={onClick}
   >
     <div className="w-12 h-12 flex items-center justify-center">
-      <img src={goblin.avatar} alt={goblin.name} className="w-full h-full object-contain" />
+      <img src={getGoblinAvatar(goblin)} alt={goblin.name} className="w-full h-full object-contain" />
     </div>
     <div className="flex-1">
       <div className="font-bold text-gray-800 text-sm">{goblin.name}</div>

--- a/goblin_web/src/presentation/components/GoblinDetailModal.tsx
+++ b/goblin_web/src/presentation/components/GoblinDetailModal.tsx
@@ -7,6 +7,7 @@ import { getModTemplate } from '../../shared/data/modPoolLoader'
 import { ModStatCalculator } from '../../core/services/ModStatCalculator'
 import factorSlime from '../../assets/factor/factor_slime.svg'
 import factorWolf from '../../assets/factor/factor_wolf.svg'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 /**
  * effectiveStatsが異なるかどうかを比較
@@ -108,7 +109,7 @@ export const GoblinDetailModal = ({
         <div className="p-6 bg-white rounded-xl border-2 border-gray-200 shadow-md">
           <div className="flex gap-4 items-center pb-4 mb-6 border-b-2 border-gray-100">
             <div className="w-20 h-20 bg-gray-100 rounded-full flex items-center justify-center border-[3px] border-gray-400 overflow-hidden">
-              <img src={goblin.avatar} alt={goblin.name} className="object-cover w-full h-full" />
+              <img src={getGoblinAvatar(goblin)} alt={goblin.name} className="object-cover w-full h-full" />
             </div>
             <div>
               <h3 className="text-2xl font-bold text-gray-800">{goblin.name}</h3>

--- a/goblin_web/src/presentation/components/PartyEditScreen.tsx
+++ b/goblin_web/src/presentation/components/PartyEditScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Goblin, Party } from '../../shared/types'
 import { GoblinCard } from './GoblinCard.tsx'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface PartyEditScreenProps {
   partyId: number
@@ -142,7 +143,7 @@ export const PartyEditScreen = ({
               {member ? (
                 <>
                   <div className="w-8 h-8 bg-gray-100 rounded-full flex items-center justify-center mb-1 border border-gray-400 overflow-hidden">
-                    <img src={member.avatar} alt={member.name} className="w-full h-full object-cover" />
+                    <img src={getGoblinAvatar(member)} alt={member.name} className="w-full h-full object-cover" />
                   </div>
                   <div className="text-[10px] text-gray-600 text-center">{member.name}</div>
                   {!isExpedition && (

--- a/goblin_web/src/presentation/components/PartySelectScreen.tsx
+++ b/goblin_web/src/presentation/components/PartySelectScreen.tsx
@@ -1,4 +1,5 @@
 import type { Party, Goblin, Dungeon } from '../../shared/types'
+import { getGoblinAvatar } from '../../shared/utils/goblinAvatar'
 
 interface PartySelectScreenProps {
   parties: Party[]
@@ -54,7 +55,7 @@ export const PartySelectScreen = ({ parties, goblins, dungeon, onSelectParty, on
                 {members.map(member => (
                   <div key={member.id} className="flex items-center gap-1 text-xs bg-gray-50 rounded px-2 py-1 border border-gray-300">
                     <div className="w-6 h-6 bg-gray-100 rounded-full flex items-center justify-center border border-gray-400 overflow-hidden">
-                      <img src={member.avatar} alt={member.name} className="w-full h-full object-cover" />
+                      <img src={getGoblinAvatar(member)} alt={member.name} className="w-full h-full object-cover" />
                     </div>
                     <span className="text-gray-600">{member.name}</span>
                   </div>

--- a/goblin_web/src/shared/utils/goblinAvatar.ts
+++ b/goblin_web/src/shared/utils/goblinAvatar.ts
@@ -1,0 +1,35 @@
+import type { Goblin } from '../types'
+import { factorDatabase } from '../data/factors'
+
+const DEFAULT_AVATAR = '/src/assets/goblin/goblin.png'
+
+const raceAvatarMap: Record<string, string> = {
+  'ホブゴブリン': '/src/assets/goblin/hobgoblin.png',
+  'ウルフゴブリン': '/src/assets/goblin/wolf_goblin.png',
+  'スライムゴブリン': '/src/assets/goblin/slime_goblin.png',
+  'オークゴブリン': '/src/assets/goblin/orc_goblin.png',
+  'ゴブリン': DEFAULT_AVATAR,
+}
+
+export const getGoblinAvatar = (goblin?: Goblin | null): string => {
+  if (!goblin) {
+    return DEFAULT_AVATAR
+  }
+
+  if (goblin.avatar && goblin.avatar !== DEFAULT_AVATAR) {
+    return goblin.avatar
+  }
+
+  if (goblin.variantFactorId) {
+    const variantAvatar = factorDatabase[goblin.variantFactorId]?.variantConfig?.avatar
+    if (variantAvatar) {
+      return variantAvatar
+    }
+  }
+
+  if (goblin.race && goblin.race in raceAvatarMap) {
+    return raceAvatarMap[goblin.race]
+  }
+
+  return goblin.avatar ?? DEFAULT_AVATAR
+}


### PR DESCRIPTION
## Summary
- ゴブリン詳細画面に実効ステータス表示とMod詳細を追加
- ゴブリン追放（削除）機能を追加
- 遠征準備画面をモーダルベースのダンジョン/帰還条件選択に改善
- 探索時間見積もり表示を追加
- goblin_webにgoblinAvatarユーティリティを追加

## Test plan
- [ ] ゴブリン詳細画面で実効ステータスとModが正しく表示されることを確認
- [ ] ゴブリン追放機能が正しく動作することを確認
- [ ] 遠征準備画面のモーダル選択が正しく動作することを確認
- [ ] 探索時間見積もりが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)