### PR TITLE
refactor: implement singleton pattern for SQLite repositories and app initialization

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useEffect } from 'react'
+import { useMemo, useCallback, useEffect, useState } from 'react'
 import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Image, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -22,13 +22,27 @@ export default function ExpeditionResultScreen() {
 
   const { getPartyById } = usePartyService()
   const { goblins } = useGoblinService()
-  const { dungeons, markDungeonCleared } = useDungeonProgress()
-  const { expeditionRecords, getExpeditionById, isLoading: isExpeditionLoading } = useExpeditionService()
+  const { dungeons, progress, markDungeonCleared, markUnlockNotified } = useDungeonProgress()
+  const {
+    expeditionRecords,
+    getExpeditionById,
+    refreshExpeditions,
+    isLoading: isExpeditionLoading,
+  } = useExpeditionService()
+  const [hasRetriedLoad, setHasRetriedLoad] = useState(false)
 
   const expeditionRecord = useMemo(() => {
     if (!expeditionId) return null
-    return getExpeditionById(expeditionId)
+    const byId = getExpeditionById(expeditionId)
+    if (byId) return byId
+    return expeditionRecords.find(record => record.id === expeditionId) ?? null
   }, [expeditionId, getExpeditionById, expeditionRecords])
+
+  useEffect(() => {
+    if (!expeditionId || isExpeditionLoading || expeditionRecord || hasRetriedLoad) return
+    refreshExpeditions()
+    setHasRetriedLoad(true)
+  }, [expeditionId, expeditionRecord, hasRetriedLoad, isExpeditionLoading, refreshExpeditions])
 
   const replay = expeditionRecord?.replay ?? null
   const resolvedPartyId = expeditionRecord?.partyId ?? (partyId ? parseInt(partyId, 10) : null)
@@ -99,13 +113,23 @@ export default function ExpeditionResultScreen() {
     router.replace('/formation')
   }, [])
 
-  const area = replay ? areasData.find(a => a.id === replay.meta.areaId) : null
+  const area = replay ? areasData.find(a => a.id === replay.meta.areaId) : dungeon
   const unlockNext = area?.unlockNext
   const nextAreaName = unlockNext
     ? areasData.find(a => a.id === unlockNext)?.name || unlockNext
     : null
+  const [showUnlockNotice, setShowUnlockNotice] = useState(false)
 
-  if (expeditionId && isExpeditionLoading) {
+  useEffect(() => {
+    if (!unlockNext || !isSuccess) return
+    const nextProgress = progress[unlockNext]
+    if (!nextProgress || !nextProgress.unlocked) return
+    if (nextProgress.unlockNotified) return
+    setShowUnlockNotice(true)
+    markUnlockNotified(unlockNext)
+  }, [unlockNext, isSuccess, progress, markUnlockNotified])
+
+  if (expeditionId && (isExpeditionLoading || (!expeditionRecord && !hasRetriedLoad))) {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.loadingContainer}>
@@ -184,7 +208,7 @@ export default function ExpeditionResultScreen() {
           <Text style={styles.summaryText}>{goldGained.toLocaleString()} Gold を獲得</Text>
         </View>
 
-        {nextAreaName && isSuccess && (
+        {nextAreaName && isSuccess && showUnlockNotice && (
           <View style={styles.section}>
             <Text style={styles.summaryText}>次のエリア「{nextAreaName}」が解放されました</Text>
           </View>

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -74,11 +74,14 @@ interface GoblinDetailModalProps {
 function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps) {
   const { deleteGoblin } = useGoblinService()
 
-  if (!goblin) return null
+  const effectiveStats = useMemo(
+    () => (goblin ? ModStatCalculator.calculate(goblin) : null),
+    [goblin]
+  )
+  const expForNext = goblin ? getExpForNextLevel(goblin.level) : 0
+  const expProgress = goblin ? getExpProgress(goblin.level, goblin.experience) : 0
 
-  const effectiveStats = useMemo(() => ModStatCalculator.calculate(goblin), [goblin])
-  const expForNext = getExpForNextLevel(goblin.level)
-  const expProgress = getExpProgress(goblin.level, goblin.experience)
+  if (!goblin) return null
 
   const handleBanish = () => {
     Alert.alert(

--- a/goblin_native/app/_layout.tsx
+++ b/goblin_native/app/_layout.tsx
@@ -1,11 +1,79 @@
+import { useEffect, useState } from 'react'
+import { View, ActivityIndicator, Text, StyleSheet } from 'react-native'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { AuthProvider } from '@/presentation/contexts/AuthContext'
 import { ExpeditionStateProvider } from '@/presentation/contexts/ExpeditionStateContext'
+import { getDatabase } from '@/infrastructure/database'
+import { SQLiteDungeonProgressRepository } from '@/infrastructure/repositories/SQLiteDungeonProgressRepository'
+import { SQLiteGoblinRepository } from '@/infrastructure/repositories/SQLiteGoblinRepository'
+import { SQLitePartyRepository } from '@/infrastructure/repositories/SQLitePartyRepository'
+import { SQLiteBaseStateRepository } from '@/infrastructure/repositories/SQLiteBaseStateRepository'
+import { SQLiteExpeditionRepository } from '@/infrastructure/repositories/SQLiteExpeditionRepository'
+import { SQLitePendingGoblinRepository } from '@/infrastructure/repositories/SQLitePendingGoblinRepository'
+import { areasData } from '@/shared/data'
 
 export default function RootLayout() {
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  useEffect(() => {
+    // アプリ起動時にDBとリポジトリを初期化
+    const initializeApp = async () => {
+      try {
+        // 第1段階: DBインスタンスの初期化（マイグレーション実行）
+        console.log('[RootLayout] Initializing database...')
+        await getDatabase()
+        console.log('[RootLayout] Database initialized')
+
+        // 第2段階: 全リポジトリの初期化（キャッシュの初期化）
+        console.log('[RootLayout] Initializing repositories...')
+
+        // 各リポジトリを並列で初期化
+        await Promise.all([
+          SQLiteGoblinRepository.getInstance().initialize(),
+          SQLitePartyRepository.getInstance().initialize(),
+          SQLiteBaseStateRepository.getInstance().initialize(),
+          SQLiteExpeditionRepository.getInstance().initialize(),
+          SQLitePendingGoblinRepository.getInstance().initialize(),
+          SQLiteDungeonProgressRepository.getInstance().initialize(),
+        ])
+
+        // ダンジョン進行状況のデフォルトデータを保存
+        const dungeonProgressRepo = SQLiteDungeonProgressRepository.getInstance()
+        const storedProgress = dungeonProgressRepo.getAll()
+        areasData.forEach((dungeon, index) => {
+          if (!storedProgress[dungeon.id]) {
+            dungeonProgressRepo.save(dungeon.id, {
+              unlocked: dungeon.unlocked ?? index === 0,
+              cleared: dungeon.cleared ?? false,
+              unlockNotified: false,
+            })
+          }
+        })
+
+        console.log('[RootLayout] All repositories initialized successfully')
+        setIsInitialized(true)
+      } catch (error) {
+        console.error('[RootLayout] Failed to initialize app:', error)
+      }
+    }
+    initializeApp()
+  }, [])
+
+  // 初期化完了まではローディング画面を表示
+  if (!isInitialized) {
+    return (
+      <SafeAreaProvider>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#3B82F6" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaProvider>
+    )
+  }
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
@@ -21,3 +89,17 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   )
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6B7280',
+  },
+})

--- a/goblin_native/docs/implementation_guide.md
+++ b/goblin_native/docs/implementation_guide.md
@@ -8,6 +8,8 @@
 |-------------|------|
 | [migration_tasks.md](./migration_tasks.md) | 移行タスク一覧・差分・UI実装詳細 |
 | [sqlite_migration.md](./sqlite_migration.md) | SQLiteスキーマ設計・Repository実装パターン |
+| [project_structure.md](./project_structure.md) | ディレクトリ構成・責務一覧 |
+| [screen_reference.md](./screen_reference.md) | 画面リファレンス |
 
 ---
 
@@ -44,7 +46,8 @@ src/infrastructure/database/
 ├── index.ts          # DB接続・初期化
 ├── schema.ts         # テーブル定義
 └── migrations/
-    └── v1.ts         # 初期スキーマ
+    ├── v1.ts         # 初期スキーマ
+    └── v2.ts         # v2スキーマ（unlock_notified追加）
 ```
 
 **実装ファイル**: `src/infrastructure/database/index.ts`
@@ -53,13 +56,78 @@ src/infrastructure/database/
 import * as SQLite from 'expo-sqlite'
 
 const DB_NAME = 'goblin_kingdom.db'
-let db: SQLite.SQLiteDatabase | null = null
+const CURRENT_SCHEMA_VERSION = 2
 
+let db: SQLite.SQLiteDatabase | null = null
+let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
+
+/**
+ * データベース接続を取得
+ * シングルトンパターンで同一インスタンスを返す
+ */
 export const getDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
   if (db) return db
-  db = await SQLite.openDatabaseAsync(DB_NAME)
-  await runMigrations(db)
-  return db
+
+  // 初期化中の場合は同じPromiseを返す（重複初期化防止）
+  if (initializationPromise) {
+    return initializationPromise
+  }
+
+  initializationPromise = initializeDatabase()
+  return initializationPromise
+}
+
+const initializeDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
+  const database = await SQLite.openDatabaseAsync(DB_NAME)
+  await runMigrations(database)
+  db = database
+  return database
+}
+```
+
+### 1.5 アプリ起動時の初期化
+
+**実装ファイル**: `app/_layout.tsx`
+
+```typescript
+import { useEffect, useState } from 'react'
+import { getDatabase } from '@/infrastructure/database'
+import { SQLiteGoblinRepository } from '@/infrastructure/repositories/SQLiteGoblinRepository'
+// ... 他のリポジトリをインポート
+
+export default function RootLayout() {
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        // 第1段階: DBインスタンスの初期化（マイグレーション実行）
+        await getDatabase()
+
+        // 第2段階: 全リポジトリの初期化（キャッシュの初期化）
+        await Promise.all([
+          SQLiteGoblinRepository.getInstance().initialize(),
+          SQLitePartyRepository.getInstance().initialize(),
+          SQLiteBaseStateRepository.getInstance().initialize(),
+          SQLiteExpeditionRepository.getInstance().initialize(),
+          SQLitePendingGoblinRepository.getInstance().initialize(),
+          SQLiteDungeonProgressRepository.getInstance().initialize(),
+        ])
+
+        setIsInitialized(true)
+      } catch (error) {
+        console.error('Failed to initialize app:', error)
+      }
+    }
+    initializeApp()
+  }, [])
+
+  // 初期化完了までローディング画面を表示
+  if (!isInitialized) {
+    return <LoadingScreen />
+  }
+
+  return <MainContent />
 }
 ```
 
@@ -94,9 +162,11 @@ export const migrateV1 = async (db: SQLite.SQLiteDatabase) => {
 
 ### 完了条件
 - [ ] `expo-sqlite` インストール完了
-- [ ] `getDatabase()` でDB接続可能
+- [ ] `getDatabase()` でDB接続可能（シングルトンパターン）
 - [ ] 全7テーブル作成完了
 - [ ] アプリ起動時にマイグレーション実行
+- [ ] `app/_layout.tsx` で全リポジトリを初期化
+- [ ] 初期化完了までローディング画面を表示
 
 ---
 
@@ -105,6 +175,12 @@ export const migrateV1 = async (db: SQLite.SQLiteDatabase) => {
 **目的**: ゲームの基本データ（ゴブリン、パーティ、ダンジョン進行）を管理
 
 **参照**: [sqlite_migration.md](./sqlite_migration.md) のリポジトリ実装例
+
+**設計原則**:
+1. **シングルトンパターン**: `getInstance()` メソッドでインスタンスを取得
+2. **内部キャッシュ**: `initialize()` でDBからデータをロードし、キャッシュに保持
+3. **同期的インターフェース**: キャッシュを使用して同期的にデータを取得
+4. **非同期保存**: 書き込みは非同期でDBに保存し、即座にキャッシュを更新
 
 ### 2.1 SQLiteGoblinRepository
 
@@ -116,10 +192,13 @@ src/infrastructure/repositories/SQLiteGoblinRepository.ts
 
 | メソッド | 説明 |
 |---------|------|
-| `getAll()` | 全ゴブリン取得 |
-| `getById(id)` | ID指定で取得 |
-| `save(goblin)` | 保存（INSERT OR REPLACE） |
-| `delete(id)` | 削除 |
+| `getInstance()` | シングルトンインスタンス取得（静的メソッド） |
+| `initialize()` | DBからデータをロードしてキャッシュ初期化 |
+| `getGoblins()` | 全ゴブリン取得（同期的、キャッシュから） |
+| `getGoblin(id)` | ID指定で取得（同期的、キャッシュから） |
+| `saveGoblin(goblin)` | 保存（キャッシュ即更新、DB非同期保存） |
+| `deleteGoblin(id)` | 削除（キャッシュ即更新、DB非同期削除） |
+| `setOnDataChange(callback)` | データ変更通知コールバック設定 |
 
 ### 2.2 SQLitePartyRepository
 
@@ -162,16 +241,35 @@ src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
 
 **参照**: [migration_tasks.md](./migration_tasks.md) のContext/Hooks移行タスク
 
+**重要**: リポジトリは `app/_layout.tsx` で既に初期化済みのため、Hooksでは `getInstance()` で取得してデータを読み込むだけ。
+
 ### 3.1 useGoblinService 修正
 
 ```typescript
 // src/presentation/hooks/useGoblinService.ts
 import { SQLiteGoblinRepository } from '@/infrastructure/repositories/SQLiteGoblinRepository'
 
-const repository = new SQLiteGoblinRepository()
-
 export const useGoblinService = () => {
-  // AsyncStorage → SQLite に切り替え
+  const [goblins, setGoblins] = useState<Goblin[]>([])
+
+  const goblinRepository = useMemo(() => {
+    return SQLiteGoblinRepository.getInstance()  // シングルトン取得
+  }, [])
+
+  useEffect(() => {
+    // 既に初期化済みなので、データを取得するだけ
+    const refreshGoblins = () => {
+      setGoblins(goblinRepository.getGoblins())
+    }
+
+    // データ変更通知を設定
+    goblinRepository.setOnDataChange(refreshGoblins)
+
+    // 初期データ読み込み
+    refreshGoblins()
+  }, [goblinRepository])
+
+  return { goblins, /* ... */ }
 }
 ```
 
@@ -180,13 +278,23 @@ export const useGoblinService = () => {
 ```typescript
 // src/presentation/hooks/usePartyService.ts
 import { SQLitePartyRepository } from '@/infrastructure/repositories/SQLitePartyRepository'
+
+// getInstance() でシングルトン取得、初期化済みのためデータ取得のみ
+const partyRepository = useMemo(() => {
+  return SQLitePartyRepository.getInstance()
+}, [])
 ```
 
 ### 3.3 useDungeonProgress 修正
 
 ```typescript
 // src/presentation/hooks/useDungeonProgress.ts
-// AsyncStorage → SQLiteDungeonProgressRepository に切り替え
+import { SQLiteDungeonProgressRepository } from '@/infrastructure/repositories/SQLiteDungeonProgressRepository'
+
+// getInstance() でシングルトン取得、初期化済みのためデータ取得のみ
+const repository = useMemo(() => {
+  return SQLiteDungeonProgressRepository.getInstance()
+}, [])
 ```
 
 ### 完了条件

--- a/goblin_native/docs/project_structure.md
+++ b/goblin_native/docs/project_structure.md
@@ -1,0 +1,121 @@
+# goblin_native ディレクトリ構成・コンポーネント概要
+
+## 関連ドキュメント
+- [screen_reference.md](./screen_reference.md) 画面リファレンス
+- [implementation_guide.md](./implementation_guide.md) 実装順序ガイド
+- [migration_tasks.md](./migration_tasks.md) 移行タスク一覧
+- [sqlite_migration.md](./sqlite_migration.md) SQLite移行設計
+
+## 目的
+- アプリの全体構成（画面/ドメイン/データ/インフラ）を俯瞰し、改修時の参照点を整理します。
+
+## 主要ディレクトリ
+
+```
+app/                       Expo Router 画面（タブ/画面レイアウト）
+assets/                    画像などの静的アセット
+docs/                      プロジェクト内ドキュメント
+src/                       アプリ本体（ドメイン/ユースケース/インフラ/プレゼンテーション）
+  config/                  外部サービス設定（例: Firebase）
+  core/                    ドメイン・ユースケース・サービス
+    domain/                エンティティ
+    repositories/          リポジトリIF
+    services/              ゲームロジック/計算系
+    usecases/              アプリケーションユースケース
+  infrastructure/          DB・リポジトリ実装
+    database/              SQLiteスキーマ/初期化/マイグレーション
+    repositories/          SQLiteリポジトリ
+  presentation/            UIの状態管理レイヤ
+    contexts/              Context/Store
+    hooks/                 画面ロジック用カスタムフック
+    components/            共有UIコンポーネント（現時点は空）
+  shared/                  共通定義/データ/ユーティリティ
+    constants/             定数
+    data/                  マスターデータ（敵/遠征エリア/因子/Mod など）
+    types/                 型定義
+    utils/                 画像マッピング/スケーリングなど
+  types/                   型拡張（例: svg.d.ts）
+```
+
+## 画面（`app/`）
+- `app/_layout.tsx`
+  - ルートレイアウト。
+  - アプリ起動時にDBとリポジトリを初期化（シングルトンパターン）。
+  - 初期化完了までローディング画面を表示。
+- `app/(tabs)/_layout.tsx`
+  - タブ構成のレイアウト定義。
+- `app/(tabs)/index.tsx`
+  - ゴブリン一覧/詳細（モーダル）などのUI。
+- `app/(tabs)/base.tsx`
+  - 拠点管理（拠点ステータス、保留ゴブリンの受入/追放）。
+- `app/(tabs)/formation/`
+  - 遠征（編成〜再生〜結果）フロー。
+  - `index.tsx`: 入口/編成メニュー
+  - `preparation.tsx`: 遠征準備
+  - `edit.tsx`: パーティ編成編集
+  - `playback.tsx`: 遠征/戦闘の再生
+  - `log.tsx`: 遠征ログ
+  - `battle-log.tsx`: 戦闘ログ
+  - `result.tsx`: 遠征結果
+
+## プレゼンテーション層（`src/presentation/`）
+- `contexts/`
+  - `AuthContext.tsx` / `AuthContextValue.ts`: 認証状態の保持。
+  - `ExpeditionStateContext.tsx` / `ExpeditionStateContextValue.ts`: 遠征状態の保持。
+  - `battleLogStore.ts`: バトルログのストア。
+- `hooks/`
+  - 全てのhooksは `getInstance()` でシングルトンリポジトリを取得。
+  - アプリ起動時に既に初期化済みのため、データ取得のみを実行。
+  - 主なhooks:
+    - `useGoblinService.ts`: ゴブリン取得・保存・削除など。
+    - `usePartyService.ts`: パーティ操作。
+    - `useExpeditionService.ts` / `useExpeditionFlow.ts`: 遠征操作・フロー管理。
+    - `usePendingGoblins.ts`: 保留ゴブリン管理。
+    - `useBaseState.ts`: 拠点状態。
+    - `useDungeonProgress.ts`: ダンジョン進行。
+    - `useCurrentTime.ts`: 時刻ユーティリティ。
+
+## コア層（`src/core/`）
+- `domain/`
+  - `GoblinEntity.ts` / `PartyEntity.ts` / `EnemyEntity.ts` などのエンティティ。
+- `repositories/`
+  - `IGoblinRepository.ts` / `IPartyRepository.ts` などのIF。
+- `services/`
+  - 戦闘/成長/因子/Mod 計算など（例: `BattleSystem.ts`, `ExperienceSystem.ts`, `ModStatCalculator.ts`）。
+- `usecases/`
+  - 遠征開始/完了/戦闘実行/パーティ管理などのユースケース。
+
+## インフラ層（`src/infrastructure/`）
+- `database/`
+  - `schema.ts`: SQLiteスキーマ。
+  - `migrations/v1.ts`: 初期マイグレーション。
+  - `migrations/v2.ts`: v2マイグレーション（unlock_notified追加）。
+  - `index.ts`: DB初期化/アクセス（シングルトンパターン）。
+- `repositories/`
+  - 全てのリポジトリは**シングルトンパターン**を採用。
+  - `getInstance()` メソッドでインスタンスを取得。
+  - 内部キャッシュを使用して同期的なインターフェースを提供。
+  - 主なリポジトリ:
+    - `SQLiteGoblinRepository.ts`
+    - `SQLitePartyRepository.ts`
+    - `SQLiteBaseStateRepository.ts`
+    - `SQLiteExpeditionRepository.ts`
+    - `SQLitePendingGoblinRepository.ts`
+    - `SQLiteDungeonProgressRepository.ts`
+
+## 共有データ/型（`src/shared/`）
+- `data/`
+  - `enemy/` / `expeditionArea/` のJSON
+  - `modPool.json` / `modPoolLoader.ts`
+  - `skills.ts` / `races.ts` / `factors.ts`
+- `types/`
+  - `Goblin.ts` / `Party.ts` / `Expedition.ts` / `Battle.ts` などの型定義。
+- `utils/`
+  - `goblinImages.ts` / `factorImages.ts` / `scaling.ts`
+- `constants/`
+  - `colors.ts`
+
+## 補足
+- `dist/` はビルド成果物。
+- `assets/` は画像などの静的アセット。
+- `config/firebase.ts` は外部サービス設定（Firebase）。

--- a/goblin_native/docs/sqlite_migration.md
+++ b/goblin_native/docs/sqlite_migration.md
@@ -6,6 +6,8 @@
 |-------------|------|
 | **[implementation_guide.md](./implementation_guide.md)** | 実装順序ガイド（推奨） |
 | [migration_tasks.md](./migration_tasks.md) | 移行タスク一覧・UI実装詳細 |
+| [project_structure.md](./project_structure.md) | ディレクトリ構成・責務一覧 |
+| [screen_reference.md](./screen_reference.md) | 画面リファレンス |
 
 ## 概要
 
@@ -95,7 +97,11 @@ type BaseState = {
 
 #### DungeonProgress
 ```typescript
-type DungeonProgressState = Record<string, { unlocked: boolean; cleared: boolean }>
+type DungeonProgressState = Record<string, {
+  unlocked: boolean
+  cleared: boolean
+  unlockNotified: boolean  // アンロック通知済みフラグ
+}>
 ```
 
 ---
@@ -206,8 +212,9 @@ INSERT OR IGNORE INTO base_state (id, capacity, rank) VALUES (1, 8, 1);
 ```sql
 CREATE TABLE dungeon_progress (
   dungeon_id TEXT PRIMARY KEY,
-  unlocked INTEGER NOT NULL DEFAULT 0,  -- BOOLEAN
-  cleared INTEGER NOT NULL DEFAULT 0,   -- BOOLEAN
+  unlocked INTEGER NOT NULL DEFAULT 0,        -- BOOLEAN
+  cleared INTEGER NOT NULL DEFAULT 0,         -- BOOLEAN
+  unlock_notified INTEGER NOT NULL DEFAULT 0, -- BOOLEAN（アンロック通知済みフラグ）
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 ```
@@ -258,14 +265,32 @@ npx expo install expo-sqlite
 import * as SQLite from 'expo-sqlite'
 
 const DB_NAME = 'goblin_kingdom.db'
+const CURRENT_SCHEMA_VERSION = 2
 
 let db: SQLite.SQLiteDatabase | null = null
+let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
 
+/**
+ * データベース接続を取得
+ * シングルトンパターンで同一インスタンスを返す
+ */
 export const getDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
   if (db) return db
-  db = await SQLite.openDatabaseAsync(DB_NAME)
-  await runMigrations(db)
-  return db
+
+  // 初期化中の場合は同じPromiseを返す（重複初期化防止）
+  if (initializationPromise) {
+    return initializationPromise
+  }
+
+  initializationPromise = initializeDatabase()
+  return initializationPromise
+}
+
+const initializeDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
+  const database = await SQLite.openDatabaseAsync(DB_NAME)
+  await runMigrations(database)
+  db = database
+  return database
 }
 
 const runMigrations = async (database: SQLite.SQLiteDatabase) => {
@@ -273,7 +298,55 @@ const runMigrations = async (database: SQLite.SQLiteDatabase) => {
 }
 ```
 
+### アプリ起動時の初期化
+
+```typescript
+// app/_layout.tsx
+import { getDatabase } from '@/infrastructure/database'
+import { SQLiteGoblinRepository } from '@/infrastructure/repositories/SQLiteGoblinRepository'
+import { SQLitePartyRepository } from '@/infrastructure/repositories/SQLitePartyRepository'
+// ... 他のリポジトリ
+
+export default function RootLayout() {
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        // 第1段階: DBインスタンスの初期化（マイグレーション実行）
+        await getDatabase()
+
+        // 第2段階: 全リポジトリの初期化（キャッシュの初期化）
+        await Promise.all([
+          SQLiteGoblinRepository.getInstance().initialize(),
+          SQLitePartyRepository.getInstance().initialize(),
+          // ... 他のリポジトリ
+        ])
+
+        setIsInitialized(true)
+      } catch (error) {
+        console.error('Failed to initialize app:', error)
+      }
+    }
+    initializeApp()
+  }, [])
+
+  if (!isInitialized) {
+    return <LoadingScreen />
+  }
+
+  return <MainContent />
+}
+```
+
 ### リポジトリ実装例
+
+全てのリポジトリは以下の設計原則に従います：
+
+1. **シングルトンパターン**: `getInstance()` メソッドでインスタンスを取得
+2. **内部キャッシュ**: `initialize()` でDBからデータをロードし、キャッシュに保持
+3. **同期的インターフェース**: キャッシュを使用して同期的にデータを取得
+4. **非同期保存**: 書き込みは非同期でDBに保存し、即座にキャッシュを更新
 
 ```typescript
 // src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -282,22 +355,91 @@ import type { IGoblinRepository } from '@/core/repositories/IGoblinRepository'
 import { getDatabase } from '../database'
 
 export class SQLiteGoblinRepository implements IGoblinRepository {
-  async getAll(): Promise<Goblin[]> {
-    const db = await getDatabase()
-    const rows = await db.getAllAsync<GoblinRow>('SELECT * FROM goblins')
-    return rows.map(this.rowToGoblin)
+  private static instance: SQLiteGoblinRepository | null = null
+  private cache: Map<number, Goblin> = new Map()
+  private initialized = false
+  private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLiteGoblinRepository {
+    if (!SQLiteGoblinRepository.instance) {
+      SQLiteGoblinRepository.instance = new SQLiteGoblinRepository()
+    }
+    return SQLiteGoblinRepository.instance
   }
 
-  async getById(id: number): Promise<Goblin | null> {
+  /**
+   * リポジトリを初期化し、DBからデータをロード
+   * アプリ起動時に1回だけ実行される
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
     const db = await getDatabase()
-    const row = await db.getFirstAsync<GoblinRow>(
-      'SELECT * FROM goblins WHERE id = ?',
-      [id]
-    )
-    return row ? this.rowToGoblin(row) : null
+    const rows = await db.getAllAsync<GoblinRow>('SELECT * FROM goblins ORDER BY id')
+
+    this.cache.clear()
+    for (const row of rows) {
+      const goblin = this.rowToGoblin(row)
+      this.cache.set(goblin.id, goblin)
+    }
+
+    this.initialized = true
   }
 
-  async save(goblin: Goblin): Promise<void> {
+  /**
+   * データ変更時のコールバックを設定
+   */
+  setOnDataChange(callback: () => void): void {
+    this.onDataChangeCallback = callback
+  }
+
+  /**
+   * 全ゴブリンを取得（同期的）
+   */
+  getGoblins(): Goblin[] {
+    return Array.from(this.cache.values())
+  }
+
+  /**
+   * 指定IDのゴブリンを取得（同期的）
+   */
+  getGoblin(id: number): Goblin | null {
+    return this.cache.get(id) ?? null
+  }
+
+  /**
+   * ゴブリンを保存
+   * キャッシュを即座に更新し、DBへは非同期で保存
+   */
+  saveGoblin(goblin: Goblin): void {
+    this.cache.set(goblin.id, goblin)
+
+    this.saveAsync(goblin).catch(err => {
+      console.error('[SQLiteGoblinRepository] Failed to save:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  /**
+   * ゴブリンを削除
+   */
+  deleteGoblin(id: number): void {
+    this.cache.delete(id)
+
+    this.deleteAsync(id).catch(err => {
+      console.error('[SQLiteGoblinRepository] Failed to delete:', err)
+    })
+
+    this.notifyDataChange()
+  }
+
+  // --- Private methods ---
+
+  private async saveAsync(goblin: Goblin): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO goblins
@@ -322,7 +464,7 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     )
   }
 
-  async delete(id: number): Promise<void> {
+  private async deleteAsync(id: number): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM goblins WHERE id = ?', [id])
   }
@@ -339,14 +481,16 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
       effectiveStats: row.effective_stats_json
         ? JSON.parse(row.effective_stats_json)
         : undefined,
-      factors: row.factors_json
-        ? JSON.parse(row.factors_json)
-        : undefined,
+      factors: row.factors_json ? JSON.parse(row.factors_json) : undefined,
       variantFactorId: row.variant_factor_id ?? undefined,
       individualValue: row.individual_value ?? undefined,
-      mods: row.mods_json
-        ? JSON.parse(row.mods_json)
-        : undefined,
+      mods: row.mods_json ? JSON.parse(row.mods_json) : undefined,
+    }
+  }
+
+  private notifyDataChange(): void {
+    if (this.onDataChangeCallback) {
+      this.onDataChangeCallback()
     }
   }
 }

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -4,9 +4,10 @@
  */
 import * as SQLite from 'expo-sqlite'
 import { migrateV1 } from './migrations/v1'
+import { migrateV2 } from './migrations/v2'
 
 const DB_NAME = 'goblin_kingdom.db'
-const CURRENT_SCHEMA_VERSION = 1
+const CURRENT_SCHEMA_VERSION = 2
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -51,7 +52,12 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
   }
 
   // 将来のマイグレーション追加時はここに追加
-  // if (currentVersion < 2) { await migrateV2(database); await setSchemaVersion(database, 2); }
+  if (currentVersion < 2) {
+    console.log('[DB] Running migration v2...')
+    await migrateV2(database)
+    await setSchemaVersion(database, 2)
+    console.log('[DB] Migration v2 completed')
+  }
 }
 
 /**

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -15,6 +15,7 @@ let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
 /**
  * データベース接続を取得
  * シングルトンパターンで同一インスタンスを返す
+ * 初期化失敗時は再試行可能
  */
 export const getDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
   if (db) return db
@@ -24,7 +25,12 @@ export const getDatabase = async (): Promise<SQLite.SQLiteDatabase> => {
     return initializationPromise
   }
 
-  initializationPromise = initializeDatabase()
+  // 初期化失敗時にPromiseをリセットして再試行可能にする
+  initializationPromise = initializeDatabase().catch(error => {
+    initializationPromise = null
+    throw error
+  })
+
   return initializationPromise
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v2.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v2.ts
@@ -1,0 +1,16 @@
+/**
+ * スキーママイグレーション (v2)
+ * dungeon_progress に unlock_notified カラムを追加
+ */
+import type * as SQLite from 'expo-sqlite'
+
+export const migrateV2 = async (db: SQLite.SQLiteDatabase): Promise<void> => {
+  const columns = await db.getAllAsync<{ name: string }>(
+    "PRAGMA table_info('dungeon_progress')"
+  )
+  const hasUnlockNotified = columns.some(column => column.name === 'unlock_notified')
+  if (hasUnlockNotified) return
+  await db.execAsync(
+    'ALTER TABLE dungeon_progress ADD COLUMN unlock_notified INTEGER NOT NULL DEFAULT 0'
+  )
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -106,6 +106,7 @@ export const SCHEMA = {
       dungeon_id TEXT PRIMARY KEY,
       unlocked INTEGER NOT NULL DEFAULT 0,
       cleared INTEGER NOT NULL DEFAULT 0,
+      unlock_notified INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `,

--- a/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
@@ -20,9 +20,20 @@ const DEFAULT_BASE_STATE: BaseState = {
 }
 
 export class SQLiteBaseStateRepository implements IBaseStateRepository {
+  private static instance: SQLiteBaseStateRepository | null = null
   private cache: BaseState | null = null
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLiteBaseStateRepository {
+    if (!SQLiteBaseStateRepository.instance) {
+      SQLiteBaseStateRepository.instance = new SQLiteBaseStateRepository()
+    }
+    return SQLiteBaseStateRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -9,12 +9,14 @@ interface DungeonProgressRow {
   dungeon_id: string
   unlocked: number
   cleared: number
+  unlock_notified: number
   updated_at: string
 }
 
 interface DungeonProgress {
   unlocked: boolean
   cleared: boolean
+  unlockNotified: boolean
 }
 
 export interface IDungeonProgressRepository {
@@ -26,9 +28,20 @@ export interface IDungeonProgressRepository {
 }
 
 export class SQLiteDungeonProgressRepository implements IDungeonProgressRepository {
+  private static instance: SQLiteDungeonProgressRepository | null = null
   private cache: Map<string, DungeonProgress> = new Map()
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLiteDungeonProgressRepository {
+    if (!SQLiteDungeonProgressRepository.instance) {
+      SQLiteDungeonProgressRepository.instance = new SQLiteDungeonProgressRepository()
+    }
+    return SQLiteDungeonProgressRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード
@@ -44,6 +57,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
       this.cache.set(row.dungeon_id, {
         unlocked: row.unlocked === 1,
         cleared: row.cleared === 1,
+        unlockNotified: row.unlock_notified === 1,
       })
     }
 
@@ -92,7 +106,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
    * ダンジョンを解放済みにする
    */
   unlock(dungeonId: string): void {
-    const current = this.cache.get(dungeonId) ?? { unlocked: false, cleared: false }
+    const current = this.cache.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false }
     this.save(dungeonId, { ...current, unlocked: true })
   }
 
@@ -100,7 +114,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
    * ダンジョンをクリア済みにする
    */
   markCleared(dungeonId: string): void {
-    const current = this.cache.get(dungeonId) ?? { unlocked: true, cleared: false }
+    const current = this.cache.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false }
     this.save(dungeonId, { ...current, unlocked: true, cleared: true })
   }
 
@@ -110,9 +124,14 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO dungeon_progress
-       (dungeon_id, unlocked, cleared, updated_at)
-       VALUES (?, ?, ?, datetime('now'))`,
-      [dungeonId, progress.unlocked ? 1 : 0, progress.cleared ? 1 : 0]
+       (dungeon_id, unlocked, cleared, unlock_notified, updated_at)
+       VALUES (?, ?, ?, ?, datetime('now'))`,
+      [
+        dungeonId,
+        progress.unlocked ? 1 : 0,
+        progress.cleared ? 1 : 0,
+        progress.unlockNotified ? 1 : 0,
+      ]
     )
   }
 

--- a/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
@@ -31,9 +31,20 @@ export interface IExpeditionRepository {
 }
 
 export class SQLiteExpeditionRepository implements IExpeditionRepository {
+  private static instance: SQLiteExpeditionRepository | null = null
   private cache: Map<string, ExpeditionRecord> = new Map()
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLiteExpeditionRepository {
+    if (!SQLiteExpeditionRepository.instance) {
+      SQLiteExpeditionRepository.instance = new SQLiteExpeditionRepository()
+    }
+    return SQLiteExpeditionRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード

--- a/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
@@ -23,9 +23,20 @@ interface PendingGoblinRow {
 }
 
 export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
+  private static instance: SQLitePendingGoblinRepository | null = null
   private cache: Map<number, Goblin> = new Map()
   private initialized = false
   private onDataChangeCallback: (() => void) | null = null
+
+  /**
+   * シングルトンインスタンスを取得
+   */
+  static getInstance(): SQLitePendingGoblinRepository {
+    if (!SQLitePendingGoblinRepository.instance) {
+      SQLitePendingGoblinRepository.instance = new SQLitePendingGoblinRepository()
+    }
+    return SQLitePendingGoblinRepository.instance
+  }
 
   /**
    * リポジトリを初期化し、DBからデータをロード

--- a/goblin_native/src/presentation/hooks/useBaseState.ts
+++ b/goblin_native/src/presentation/hooks/useBaseState.ts
@@ -6,14 +6,8 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import type { BaseState } from '@/shared/types'
 import { SQLiteBaseStateRepository } from '@/infrastructure/repositories'
 
-// シングルトンリポジトリインスタンス
-let repositoryInstance: SQLiteBaseStateRepository | null = null
-
 const getRepository = (): SQLiteBaseStateRepository => {
-  if (!repositoryInstance) {
-    repositoryInstance = new SQLiteBaseStateRepository()
-  }
-  return repositoryInstance
+  return SQLiteBaseStateRepository.getInstance()
 }
 
 export function useBaseState() {
@@ -21,28 +15,19 @@ export function useBaseState() {
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLiteBaseStateRepository | null>(null)
 
-  // リポジトリの初期化とデータ取得
+  // リポジトリからデータを取得（アプリ起動時に既に初期化済み）
   useEffect(() => {
     const repository = getRepository()
     repositoryRef.current = repository
-
-    const initializeAndLoad = async () => {
-      try {
-        await repository.initialize()
-        setBaseState(repository.getBaseState())
-      } catch (error) {
-        console.error('[useBaseState] Failed to initialize:', error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
 
     // データ変更時のコールバックを設定
     repository.setOnDataChange(() => {
       setBaseState(repository.getBaseState())
     })
 
-    initializeAndLoad()
+    // 既に初期化済みなのでデータを取得
+    setBaseState(repository.getBaseState())
+    setIsLoading(false)
   }, [])
 
   // 拠点ランクアップ

--- a/goblin_native/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_native/src/presentation/hooks/useDungeonProgress.ts
@@ -19,6 +19,7 @@ const buildDefaultProgress = (): DungeonProgressState => {
     defaults[dungeon.id] = {
       unlocked: dungeon.unlocked ?? index === 0,
       cleared: dungeon.cleared ?? false,
+      unlockNotified: false,
     }
   })
   return defaults
@@ -29,7 +30,7 @@ export const useDungeonProgress = () => {
   const [isLoading, setIsLoading] = useState(true)
 
   const repository = useMemo<DungeonProgressRepository>(() => {
-    return new SQLiteDungeonProgressRepository()
+    return SQLiteDungeonProgressRepository.getInstance()
   }, [])
 
   const refreshProgress = useCallback(() => {
@@ -39,27 +40,10 @@ export const useDungeonProgress = () => {
   }, [repository])
 
   useEffect(() => {
-    const initRepository = async () => {
-      if (repository.initialize) {
-        await repository.initialize()
-      }
-
-      // 初期データがない場合はデフォルトを保存
-      const storedProgress = repository.getAll()
-      const defaults = buildDefaultProgress()
-
-      // 新規ダンジョンの初期状態を保存
-      for (const [dungeonId, defaultState] of Object.entries(defaults)) {
-        if (!storedProgress[dungeonId]) {
-          repository.save(dungeonId, defaultState)
-        }
-      }
-
-      refreshProgress()
-      setIsLoading(false)
-    }
-    initRepository()
-  }, [repository, refreshProgress])
+    // アプリ起動時に既に初期化されているので、データを読み込むだけ
+    refreshProgress()
+    setIsLoading(false)
+  }, [refreshProgress])
 
   const updateProgress = useCallback(
     (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
@@ -80,14 +64,44 @@ export const useDungeonProgress = () => {
     (dungeon: Dungeon, cleared: boolean) => {
       updateProgress(prev => {
         const nextProgress: DungeonProgressState = { ...prev }
-        const current = nextProgress[dungeon.id] ?? { unlocked: dungeon.unlocked ?? false, cleared: false }
-        nextProgress[dungeon.id] = { ...current, unlocked: true, cleared: cleared || current.cleared }
-
-        if (cleared && dungeon.unlockNext) {
-          const target = nextProgress[dungeon.unlockNext] ?? { unlocked: false, cleared: false }
-          nextProgress[dungeon.unlockNext] = { ...target, unlocked: true }
+        const current = nextProgress[dungeon.id] ?? {
+          unlocked: dungeon.unlocked ?? false,
+          cleared: false,
+          unlockNotified: false,
+        }
+        nextProgress[dungeon.id] = {
+          ...current,
+          unlocked: true,
+          cleared: cleared || current.cleared,
         }
 
+        if (cleared && dungeon.unlockNext) {
+          const target = nextProgress[dungeon.unlockNext]
+          // 既にアンロック済みの場合は状態を変更しない（unlockNotifiedフラグを保持）
+          if (!target || !target.unlocked) {
+            nextProgress[dungeon.unlockNext] = {
+              ...(target ?? { cleared: false, unlockNotified: false }),
+              unlocked: true,
+            }
+          }
+        }
+
+        return nextProgress
+      })
+    },
+    [updateProgress]
+  )
+
+  const markUnlockNotified = useCallback(
+    (dungeonId: string) => {
+      updateProgress(prev => {
+        const nextProgress: DungeonProgressState = { ...prev }
+        const current = nextProgress[dungeonId] ?? {
+          unlocked: false,
+          cleared: false,
+          unlockNotified: false,
+        }
+        nextProgress[dungeonId] = { ...current, unlockNotified: true }
         return nextProgress
       })
     },
@@ -110,5 +124,6 @@ export const useDungeonProgress = () => {
     isLoading,
     updateProgress,
     markDungeonCleared,
+    markUnlockNotified,
   }
 }

--- a/goblin_native/src/presentation/hooks/useExpeditionService.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionService.ts
@@ -2,15 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ExpeditionRecord, ExpeditionReplay } from '@/shared/types'
 import { SQLiteExpeditionRepository } from '@/infrastructure/repositories'
 
-let repositoryInstance: SQLiteExpeditionRepository | null = null
 let dataChangeSubscribers: Set<() => void> = new Set()
 let dataChangeListenerBound = false
 
 const getRepository = (): SQLiteExpeditionRepository => {
-  if (!repositoryInstance) {
-    repositoryInstance = new SQLiteExpeditionRepository()
-  }
-  return repositoryInstance
+  return SQLiteExpeditionRepository.getInstance()
 }
 
 export const useExpeditionService = () => {
@@ -35,24 +31,15 @@ export const useExpeditionService = () => {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    const initializeAndLoad = async () => {
-      try {
-        await repository.initialize()
-        setExpeditionRecords(repository.getAll())
-      } catch (error) {
-        console.error('[useExpeditionService] Failed to initialize:', error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
     bindDataChangeListener(repository)
     const handleDataChange = () => {
       setExpeditionRecords(repository.getAll())
     }
     dataChangeSubscribers.add(handleDataChange)
 
-    initializeAndLoad()
+    // 既に初期化済みなのでデータを取得
+    setExpeditionRecords(repository.getAll())
+    setIsLoading(false)
 
     return () => {
       dataChangeSubscribers.delete(handleDataChange)

--- a/goblin_native/src/presentation/hooks/useGoblinService.ts
+++ b/goblin_native/src/presentation/hooks/useGoblinService.ts
@@ -27,19 +27,15 @@ export const useGoblinService = () => {
   }, [getGoblinListUseCase])
 
   useEffect(() => {
-    const initRepository = async () => {
-      if (goblinRepository.initialize) {
-        await goblinRepository.initialize()
-      }
-      refreshGoblins()
-      setRepositoryInitialized(true)
-    }
+    // データ変更時のコールバックを設定
     if (goblinRepository.setOnDataChange) {
       goblinRepository.setOnDataChange(() => {
         refreshGoblins()
       })
     }
-    initRepository()
+    // 既に初期化済みなのでデータを取得
+    refreshGoblins()
+    setRepositoryInitialized(true)
   }, [goblinRepository, refreshGoblins])
 
   const getGoblinById = useCallback(

--- a/goblin_native/src/presentation/hooks/usePartyService.ts
+++ b/goblin_native/src/presentation/hooks/usePartyService.ts
@@ -60,16 +60,11 @@ export const usePartyService = () => {
   }, [partyRepository, getPartyListUseCase])
 
   useEffect(() => {
-    const initRepository = async () => {
-      if (partyRepository.initialize) {
-        await partyRepository.initialize()
-      }
-      const currentParties = getPartyListUseCase.execute()
-      setParties(currentParties)
-      setRepositoryInitialized(true)
-    }
-    initRepository()
-  }, [partyRepository, getPartyListUseCase])
+    // 既に初期化済みなのでデータを取得
+    const currentParties = getPartyListUseCase.execute()
+    setParties(currentParties)
+    setRepositoryInitialized(true)
+  }, [getPartyListUseCase])
 
   const getPartyById = useCallback(
     (partyId: number) => getPartyByIdUseCase.execute(partyId),

--- a/goblin_native/src/presentation/hooks/usePendingGoblins.ts
+++ b/goblin_native/src/presentation/hooks/usePendingGoblins.ts
@@ -6,14 +6,8 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import type { Goblin } from '@/shared/types'
 import { SQLitePendingGoblinRepository } from '@/infrastructure/repositories'
 
-// シングルトンリポジトリインスタンス
-let repositoryInstance: SQLitePendingGoblinRepository | null = null
-
 const getRepository = (): SQLitePendingGoblinRepository => {
-  if (!repositoryInstance) {
-    repositoryInstance = new SQLitePendingGoblinRepository()
-  }
-  return repositoryInstance
+  return SQLitePendingGoblinRepository.getInstance()
 }
 
 export function usePendingGoblins() {
@@ -21,28 +15,19 @@ export function usePendingGoblins() {
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLitePendingGoblinRepository | null>(null)
 
-  // リポジトリの初期化とデータ取得
+  // リポジトリからデータを取得（アプリ起動時に既に初期化済み）
   useEffect(() => {
     const repository = getRepository()
     repositoryRef.current = repository
-
-    const initializeAndLoad = async () => {
-      try {
-        await repository.initialize()
-        setPendingGoblins(repository.getPendingGoblins())
-      } catch (error) {
-        console.error('[usePendingGoblins] Failed to initialize:', error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
 
     // データ変更時のコールバックを設定
     repository.setOnDataChange(() => {
       setPendingGoblins(repository.getPendingGoblins())
     })
 
-    initializeAndLoad()
+    // 既に初期化済みなのでデータを取得
+    setPendingGoblins(repository.getPendingGoblins())
+    setIsLoading(false)
   }, [])
 
   // 待機中ゴブリンを追加

--- a/goblin_native/src/shared/types/DungeonProgress.ts
+++ b/goblin_native/src/shared/types/DungeonProgress.ts
@@ -1,1 +1,4 @@
-export type DungeonProgressState = Record<string, { unlocked: boolean; cleared: boolean }>
+export type DungeonProgressState = Record<
+  string,
+  { unlocked: boolean; cleared: boolean; unlockNotified: boolean }
+>


### PR DESCRIPTION
## 概要

データベースとリポジトリの初期化を最適化し、アプリ起動時の一括初期化とシングルトンパターンを導入しました。

## 主な変更

### 1. リポジトリのシングルトン化
- 全てのSQLiteリポジトリに`getInstance()`メソッドを追加
  - `SQLiteBaseStateRepository`
  - `SQLiteDungeonProgressRepository`
  - `SQLiteExpeditionRepository`
  - `SQLitePendingGoblinRepository`

### 2. アプリ起動時の一括初期化 (`app/_layout.tsx`)
- **第1段階**: DBインスタンスの初期化（マイグレーション実行）
- **第2段階**: 全リポジトリの並列初期化
- 初期化完了までローディング画面を表示
- データの一貫性と初期化順序を保証

### 3. データベーススキーマの拡張
- `dungeon_progress`テーブルに`unlock_notified`カラムを追加
- マイグレーションv2を実装
- アンロック通知の初回表示制御を実現

### 4. ダンジョン進行状況の改善
- アンロック通知を初回のみ表示する機能を実装
- `markDungeonCleared`で既にアンロック済みのエリアは状態を変更しない
- `area`の取得を`dungeon`からフォールバックするように修正

### 5. Hooksの最適化
- 各Hookから初期化処理を削除
- `getInstance()`でシングルトンリポジトリを取得
- アプリ起動時に既に初期化済みのため、データ取得のみ実行

### 6. ドキュメントの更新
- `docs/sqlite_migration.md`: シングルトンパターンと初期化プロセスを追加
- `docs/implementation_guide.md`: 実装ガイドを最新の設計に更新
- `docs/project_structure.md`: プロジェクト構成を更新

## 改善効果

1. **パフォーマンス向上**: 各画面で初期化を待つ必要がなく、アプリ起動後すぐにデータ利用可能
2. **データの一貫性**: 全画面で同じリポジトリインスタンスとキャッシュを共有
3. **初期化の確実性**: アプリ起動時に1回だけ初期化され、確実にデータがロードされる
4. **コードの簡潔化**: Hookから初期化処理が削除され、コードがシンプルに
5. **バグ修正**: ダンジョンアンロック通知が初回のみ表示されるように修正

## アーキテクチャ改善

```
┌────────────────────────────────────────────┐
│ アプリ起動（app/_layout.tsx）              │
│                                            │
│ ▼ 第1段階: DBインスタンス初期化            │
│   await getDatabase()                      │
│   └→ SQLiteデータベース（1つだけ）         │
│   └→ マイグレーション実行                  │
│                                            │
│ ▼ 第2段階: 全リポジトリ初期化（並列）      │
│   await Promise.all([...])                 │
│   ├→ GoblinRepository                     │
│   ├→ PartyRepository                      │
│   ├→ BaseStateRepository                  │
│   ├→ ExpeditionRepository                 │
│   ├→ PendingGoblinRepository              │
│   └→ DungeonProgressRepository            │
│                                            │
│ ▼ 各画面・Hook                             │
│   すべて同じリポジトリインスタンスを共有   │
│   キャッシュが同期され、パフォーマンス向上 │
└────────────────────────────────────────────┘
```

## テスト項目

- [x] アプリ起動時にローディング画面が表示される
- [x] 初期化完了後にメイン画面が表示される
- [x] ゴブリンリストが正しく表示される
- [x] ダンジョンアンロック通知が初回のみ表示される
- [x] メニューに戻って再度リザルト画面を開いても通知は表示されない
- [x] 同じダンジョンを2回目、3回目とクリアしても通知は表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)