### PR TITLE
fix: remove dysfunctional callback system and add explicit refresh calls

### DIFF
--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from 'react'
 import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView, ActivityIndicator, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { useFocusEffect } from 'expo-router'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import type { Goblin } from '@/shared/types'
 import { getFactor } from '@/shared/data/factors'
@@ -226,7 +227,7 @@ function GoblinDetailModal({ goblin, visible, onClose }: GoblinDetailModalProps)
 }
 
 export default function GoblinListScreen() {
-  const { goblins, isLoading } = useGoblinService()
+  const { goblins, isLoading, refreshGoblins } = useGoblinService()
   const [selectedGoblin, setSelectedGoblin] = useState<Goblin | null>(null)
   const [modalVisible, setModalVisible] = useState(false)
 
@@ -239,6 +240,12 @@ export default function GoblinListScreen() {
     setModalVisible(false)
     setSelectedGoblin(null)
   }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      refreshGoblins()
+    }, [refreshGoblins])
+  )
 
   if (isLoading) {
     return (

--- a/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
@@ -23,7 +23,6 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
   private static instance: SQLiteBaseStateRepository | null = null
   private cache: BaseState | null = null
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -62,13 +61,6 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
   }
 
   /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
-  }
-
-  /**
    * 拠点状態を取得
    */
   getBaseState(): BaseState | null {
@@ -84,8 +76,6 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
     this.saveAsync(state).catch(err => {
       console.error('[SQLiteBaseStateRepository] Failed to save:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -141,11 +131,5 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
     const maxPending = pendingMax?.max_id ?? 0
 
     return Math.max(maxGoblin, maxPending) + 1
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
-    }
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -31,7 +31,6 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
   private static instance: SQLiteDungeonProgressRepository | null = null
   private cache: Map<string, DungeonProgress> = new Map()
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -65,13 +64,6 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
   }
 
   /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
-  }
-
-  /**
    * 全ダンジョンの進行状況を取得
    */
   getAll(): DungeonProgressState {
@@ -98,8 +90,6 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
     this.saveAsync(dungeonId, progress).catch(err => {
       console.error('[SQLiteDungeonProgressRepository] Failed to save:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -133,11 +123,5 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
         progress.unlockNotified ? 1 : 0,
       ]
     )
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
-    }
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
@@ -34,7 +34,6 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
   private static instance: SQLiteExpeditionRepository | null = null
   private cache: Map<string, ExpeditionRecord> = new Map()
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -64,13 +63,6 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     }
 
     this.initialized = true
-  }
-
-  /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
   }
 
   /**
@@ -114,8 +106,6 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     this.saveAsync(record).catch(err => {
       console.error('[SQLiteExpeditionRepository] Failed to save:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -127,8 +117,6 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     this.deleteAsync(id).catch(err => {
       console.error('[SQLiteExpeditionRepository] Failed to delete:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -204,12 +192,6 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
       replay: row.replay_json ? JSON.parse(row.replay_json) : undefined,
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at),
-    }
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
     }
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -27,7 +27,6 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
   private static instance: SQLiteGoblinRepository | null = null
   private cache: Map<number, Goblin> = new Map()
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -58,13 +57,6 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
   }
 
   /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
-  }
-
-  /**
    * 全ゴブリンを取得
    */
   getGoblins(): Goblin[] {
@@ -89,8 +81,6 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     this.saveGoblinAsync(goblin).catch(err => {
       console.error('[SQLiteGoblinRepository] Failed to save goblin:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -102,8 +92,6 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     this.deleteGoblinAsync(id).catch(err => {
       console.error('[SQLiteGoblinRepository] Failed to delete goblin:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -180,12 +168,6 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
       mods: row.mods_json
         ? JSON.parse(row.mods_json)
         : undefined,
-    }
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
     }
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -22,7 +22,6 @@ export class SQLitePartyRepository implements IPartyRepository {
   private static instance: SQLitePartyRepository | null = null
   private cache: Map<number, Party> = new Map()
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -66,13 +65,6 @@ export class SQLitePartyRepository implements IPartyRepository {
   }
 
   /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
-  }
-
-  /**
    * 全パーティを取得
    */
   getParties(): Party[] {
@@ -95,8 +87,6 @@ export class SQLitePartyRepository implements IPartyRepository {
     this.savePartyAsync(party).catch(err => {
       console.error('[SQLitePartyRepository] Failed to save party:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -108,8 +98,6 @@ export class SQLitePartyRepository implements IPartyRepository {
     this.deletePartyAsync(id).catch(err => {
       console.error('[SQLitePartyRepository] Failed to delete party:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -197,12 +185,6 @@ export class SQLitePartyRepository implements IPartyRepository {
       dungeonId: row.dungeon_id ?? undefined,
       targetFloor: row.target_floor ?? undefined,
       returnPolicy: (row.return_policy as ExpeditionRequest['returnPolicy']) ?? undefined,
-    }
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
     }
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
@@ -26,7 +26,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
   private static instance: SQLitePendingGoblinRepository | null = null
   private cache: Map<number, Goblin> = new Map()
   private initialized = false
-  private onDataChangeCallback: (() => void) | null = null
 
   /**
    * シングルトンインスタンスを取得
@@ -59,13 +58,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
   }
 
   /**
-   * データ変更時のコールバックを設定
-   */
-  setOnDataChange(callback: () => void): void {
-    this.onDataChangeCallback = callback
-  }
-
-  /**
    * 待機中の全ゴブリンを取得
    */
   getPendingGoblins(): Goblin[] {
@@ -81,8 +73,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
     this.addAsync(goblin).catch(err => {
       console.error('[SQLitePendingGoblinRepository] Failed to add:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -94,8 +84,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
     this.removeAsync(id).catch(err => {
       console.error('[SQLitePendingGoblinRepository] Failed to remove:', err)
     })
-
-    this.notifyDataChange()
   }
 
   /**
@@ -107,8 +95,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
     this.clearAsync().catch(err => {
       console.error('[SQLitePendingGoblinRepository] Failed to clear:', err)
     })
-
-    this.notifyDataChange()
   }
 
   // --- Private methods ---
@@ -168,12 +154,6 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
       mods: row.mods_json
         ? JSON.parse(row.mods_json)
         : undefined,
-    }
-  }
-
-  private notifyDataChange(): void {
-    if (this.onDataChangeCallback) {
-      this.onDataChangeCallback()
     }
   }
 }

--- a/goblin_native/src/presentation/hooks/useBaseState.ts
+++ b/goblin_native/src/presentation/hooks/useBaseState.ts
@@ -20,12 +20,7 @@ export function useBaseState() {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    // データ変更時のコールバックを設定
-    repository.setOnDataChange(() => {
-      setBaseState(repository.getBaseState())
-    })
-
-    // 既に初期化済みなのでデータを取得
+    // 初回のデータ取得
     setBaseState(repository.getBaseState())
     setIsLoading(false)
   }, [])

--- a/goblin_native/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_native/src/presentation/hooks/useDungeonProgress.ts
@@ -8,11 +8,6 @@ import { areasData } from '../../shared/data'
 import type { Dungeon } from '../../shared/types'
 import type { DungeonProgressState } from '../../shared/types/DungeonProgress'
 
-type DungeonProgressRepository = SQLiteDungeonProgressRepository & {
-  initialize?: () => Promise<void>
-  setOnDataChange?: (callback: () => void) => void
-}
-
 const buildDefaultProgress = (): DungeonProgressState => {
   const defaults: DungeonProgressState = {}
   areasData.forEach((dungeon, index) => {
@@ -29,7 +24,7 @@ export const useDungeonProgress = () => {
   const [progress, setProgress] = useState<DungeonProgressState>(() => buildDefaultProgress())
   const [isLoading, setIsLoading] = useState(true)
 
-  const repository = useMemo<DungeonProgressRepository>(() => {
+  const repository = useMemo(() => {
     return SQLiteDungeonProgressRepository.getInstance()
   }, [])
 

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -220,7 +220,7 @@ export const useExpeditionFlow = ({
         completeExpeditionRecord(record.id, record.replay!)
         processedExpeditionsRef.current.add(record.id)
         if (refreshParties) {
-          await refreshParties()
+          refreshParties()
         }
       } catch (error) {
         console.warn('[useExpeditionFlow] Failed to complete expedition', error)

--- a/goblin_native/src/presentation/hooks/useExpeditionService.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionService.ts
@@ -2,9 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ExpeditionRecord, ExpeditionReplay } from '@/shared/types'
 import { SQLiteExpeditionRepository } from '@/infrastructure/repositories'
 
-let dataChangeSubscribers: Set<() => void> = new Set()
-let dataChangeListenerBound = false
-
 const getRepository = (): SQLiteExpeditionRepository => {
   return SQLiteExpeditionRepository.getInstance()
 }
@@ -13,14 +10,6 @@ export const useExpeditionService = () => {
   const [expeditionRecords, setExpeditionRecords] = useState<ExpeditionRecord[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLiteExpeditionRepository | null>(null)
-
-  const bindDataChangeListener = useCallback((repository: SQLiteExpeditionRepository) => {
-    if (dataChangeListenerBound) return
-    repository.setOnDataChange(() => {
-      dataChangeSubscribers.forEach(callback => callback())
-    })
-    dataChangeListenerBound = true
-  }, [])
 
   const refreshExpeditions = useCallback(() => {
     if (!repositoryRef.current) return
@@ -31,20 +20,10 @@ export const useExpeditionService = () => {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    bindDataChangeListener(repository)
-    const handleDataChange = () => {
-      setExpeditionRecords(repository.getAll())
-    }
-    dataChangeSubscribers.add(handleDataChange)
-
-    // 既に初期化済みなのでデータを取得
+    // 初回のデータ取得
     setExpeditionRecords(repository.getAll())
     setIsLoading(false)
-
-    return () => {
-      dataChangeSubscribers.delete(handleDataChange)
-    }
-  }, [bindDataChangeListener])
+  }, [])
 
   const getExpeditionById = useCallback((id: string): ExpeditionRecord | null => {
     if (!repositoryRef.current) return null
@@ -60,7 +39,8 @@ export const useExpeditionService = () => {
   const saveExpeditionRecord = useCallback((record: ExpeditionRecord) => {
     if (!repositoryRef.current) return
     repositoryRef.current.save(record)
-  }, [])
+    refreshExpeditions()
+  }, [refreshExpeditions])
 
   const updateExpeditionReplay = useCallback((id: string, replay: ExpeditionReplay) => {
     if (!repositoryRef.current) return
@@ -71,12 +51,14 @@ export const useExpeditionService = () => {
       replay,
       updatedAt: new Date(),
     })
-  }, [])
+    refreshExpeditions()
+  }, [refreshExpeditions])
 
   const completeExpeditionRecord = useCallback((id: string, replay: ExpeditionReplay) => {
     if (!repositoryRef.current) return
     repositoryRef.current.complete(id, replay)
-  }, [])
+    refreshExpeditions()
+  }, [refreshExpeditions])
 
   return {
     expeditionRepository: repositoryRef.current,

--- a/goblin_native/src/presentation/hooks/useGoblinService.ts
+++ b/goblin_native/src/presentation/hooks/useGoblinService.ts
@@ -4,16 +4,11 @@ import { SQLiteGoblinRepository } from '../../infrastructure/repositories/SQLite
 import type { IGoblinRepository } from '../../core/repositories'
 import { GetGoblinListUseCase } from '../../core/usecases'
 
-type ListenerCapableGoblinRepository = IGoblinRepository & {
-  initialize?: () => Promise<void>
-  setOnDataChange?: (callback: () => void) => void
-}
-
 export const useGoblinService = () => {
   const [repositoryInitialized, setRepositoryInitialized] = useState(false)
   const [goblins, setGoblins] = useState<Goblin[]>([])
 
-  const goblinRepository = useMemo<ListenerCapableGoblinRepository>(() => {
+  const goblinRepository = useMemo<IGoblinRepository>(() => {
     return SQLiteGoblinRepository.getInstance()
   }, [])
 
@@ -27,16 +22,10 @@ export const useGoblinService = () => {
   }, [getGoblinListUseCase])
 
   useEffect(() => {
-    // データ変更時のコールバックを設定
-    if (goblinRepository.setOnDataChange) {
-      goblinRepository.setOnDataChange(() => {
-        refreshGoblins()
-      })
-    }
-    // 既に初期化済みなのでデータを取得
+    // 初回のデータ取得
     refreshGoblins()
     setRepositoryInitialized(true)
-  }, [goblinRepository, refreshGoblins])
+  }, [refreshGoblins])
 
   const getGoblinById = useCallback(
     (goblinId: number): Goblin => {

--- a/goblin_native/src/presentation/hooks/usePartyService.ts
+++ b/goblin_native/src/presentation/hooks/usePartyService.ts
@@ -11,17 +11,11 @@ import {
   UpdatePartyMembersUseCase,
 } from '../../core/usecases'
 
-type ListenerCapablePartyRepository = IPartyRepository & {
-  initialize?: () => Promise<void>
-  reload?: () => Promise<void>
-  setOnDataChange?: (callback: () => void) => void
-}
-
 export const usePartyService = () => {
   const [repositoryInitialized, setRepositoryInitialized] = useState(false)
   const [parties, setParties] = useState<Party[]>([])
 
-  const partyRepository = useMemo<ListenerCapablePartyRepository>(() => {
+  const partyRepository = useMemo<IPartyRepository>(() => {
     return SQLitePartyRepository.getInstance()
   }, [])
 
@@ -50,14 +44,10 @@ export const usePartyService = () => {
     [partyRepository],
   )
 
-  const refreshParties = useCallback(async () => {
-    // DBから再読み込み
-    if (partyRepository.reload) {
-      await partyRepository.reload()
-    }
+  const refreshParties = useCallback(() => {
     const currentParties = getPartyListUseCase.execute()
     setParties(currentParties)
-  }, [partyRepository, getPartyListUseCase])
+  }, [getPartyListUseCase])
 
   useEffect(() => {
     // 既に初期化済みなのでデータを取得

--- a/goblin_native/src/presentation/hooks/usePendingGoblins.ts
+++ b/goblin_native/src/presentation/hooks/usePendingGoblins.ts
@@ -20,12 +20,7 @@ export function usePendingGoblins() {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    // データ変更時のコールバックを設定
-    repository.setOnDataChange(() => {
-      setPendingGoblins(repository.getPendingGoblins())
-    })
-
-    // 既に初期化済みなのでデータを取得
+    // 初回のデータ取得
     setPendingGoblins(repository.getPendingGoblins())
     setIsLoading(false)
   }, [])


### PR DESCRIPTION
## Summary
- シングルトンリポジトリのコールバックシステムを削除し、明示的なリフレッシュ呼び出しに置き換え
- 画面遷移時のデータ更新問題と遠征記録の自動更新問題を修正

## Problem
1. **コールバックが機能していなかった**
   - シングルトンリポジトリは1つのコールバックしか保持できない
   - 画面遷移時に新しい画面のコールバックで上書きされ、前の画面のコールバックが無効化
   
2. **データ更新が反映されない**
   - 拠点でゴブリンを追加 → ゴブリンリスト画面に戻っても表示されない
   - 遠征記録の更新後に`expeditionRecords`が再取得されず、履歴表示や自動完了判定が停止

3. **型エラー**
   - `IPartyRepository`に`reload`メソッドが存在しないのに参照していた

## Solution
### 1. コールバックシステムの削除
- 全SQLiteリポジトリ（6ファイル）から以下を削除:
  - `onDataChangeCallback`プロパティ
  - `setOnDataChange()`メソッド
  - `notifyDataChange()`メソッド

### 2. 明示的なリフレッシュ呼び出し
- **ゴブリンリスト画面**: `useFocusEffect`を追加し、画面フォーカス時にリフレッシュ
- **遠征サービス**: 更新系メソッド（`saveExpeditionRecord`, `updateExpeditionReplay`, `completeExpeditionRecord`）の後に`refreshExpeditions()`を呼び出し
- **その他のサービス**: 既に適切にリフレッシュしていることを確認

### 3. 型エラーの修正
- `usePartyService`から`reload()`呼び出しを削除（不要、かつインターフェースに存在しない）
- `refreshParties`を同期関数に変更
- `useExpeditionFlow`の`await refreshParties()`を`refreshParties()`に修正

## Changes
- **Repositories (6 files)**: コールバックシステムを削除
  - `SQLiteGoblinRepository.ts`
  - `SQLitePartyRepository.ts`
  - `SQLitePendingGoblinRepository.ts`
  - `SQLiteBaseStateRepository.ts`
  - `SQLiteExpeditionRepository.ts`
  - `SQLiteDungeonProgressRepository.ts`

- **Hooks (7 files)**: コールバックセットアップを削除、リフレッシュ呼び出しを追加
  - `useGoblinService.ts`
  - `usePartyService.ts`
  - `usePendingGoblins.ts`
  - `useBaseState.ts`
  - `useExpeditionService.ts`
  - `useDungeonProgress.ts`
  - `useExpeditionFlow.ts`

- **Screen (1 file)**: データリフレッシュ機能を追加
  - `app/(tabs)/index.tsx`

## Test plan
- [ ] 拠点でゴブリンを追加 → ゴブリンリスト画面に戻る → 追加したゴブリンが表示される
- [ ] 遠征を開始 → 遠征が完了 → 遠征履歴に表示される
- [ ] 遠征の自動完了判定が正常に動作する
- [ ] パーティ編成画面とゴブリンリスト画面の行き来でデータが正しく表示される
- [ ] ビルドエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)