### PR TITLE
feat: unify goblin card component and improve UI compactness

### DIFF
--- a/goblin_native/app/(tabs)/formation/edit.tsx
+++ b/goblin_native/app/(tabs)/formation/edit.tsx
@@ -4,7 +4,7 @@ import { router, useLocalSearchParams, Stack } from 'expo-router'
 import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
-import { getFactorImage } from '@/shared/utils/factorImages'
+import { GoblinCard } from '@/presentation/components/GoblinCard'
 import type { Goblin } from '@/shared/types'
 
 const MAX_PARTY_SIZE = 6
@@ -57,50 +57,6 @@ function PartySlot({ goblin, isEmpty, isSelected, onPress, onRemove }: SlotProps
   )
 }
 
-interface GoblinListItemProps {
-  goblin: Goblin
-  isAssigned: boolean
-  isAssignedElsewhere: boolean
-  onPress: () => void
-}
-
-function GoblinListItem({ goblin, isAssigned, isAssignedElsewhere }: GoblinListItemProps) {
-  const FactorIcon1 = goblin.factors?.[0] ? getFactorImage(goblin.factors[0]) : null
-  const FactorIcon2 = goblin.factors?.[1] ? getFactorImage(goblin.factors[1]) : null
-
-  return (
-    <View style={[
-      styles.goblinItem,
-      isAssigned && styles.goblinItemAssigned,
-      isAssignedElsewhere && styles.goblinItemDisabled,
-    ]}>
-      <Image source={getGoblinImage(goblin.avatar)} style={styles.goblinAvatar} />
-      <View style={styles.goblinInfo}>
-        <Text style={[styles.goblinName, isAssignedElsewhere && styles.goblinNameDisabled]}>
-          {goblin.name}
-        </Text>
-        <Text style={[styles.goblinRace, isAssignedElsewhere && styles.goblinRaceDisabled]}>
-          {goblin.race}
-        </Text>
-        <Text style={[styles.goblinLevel, isAssignedElsewhere && styles.goblinLevelDisabled]}>
-          Lv.{goblin.level}
-        </Text>
-        <View style={styles.factorIcons}>
-          {FactorIcon1 && <FactorIcon1 width={20} height={20} />}
-          {FactorIcon2 && <FactorIcon2 width={20} height={20} />}
-        </View>
-      </View>
-      {isAssignedElsewhere && (
-        <Text style={styles.assignedBadge}>他PT</Text>
-      )}
-      {isAssigned && !isAssignedElsewhere && (
-        <View style={styles.checkmark}>
-          <Text style={styles.checkmarkText}>v</Text>
-        </View>
-      )}
-    </View>
-  )
-}
 
 export default function PartyEditScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
@@ -289,18 +245,13 @@ export default function PartyEditScreen() {
           ) : (
             <View style={styles.goblinList}>
               {availableGoblins.map(goblin => (
-                <TouchableOpacity
+                <GoblinCard
                   key={goblin.id}
+                  goblin={goblin}
                   onPress={() => handleGoblinSelect(goblin)}
-                  activeOpacity={assignedToOtherParty.has(goblin.id) ? 1 : 0.7}
-                >
-                  <GoblinListItem
-                    goblin={goblin}
-                    isAssigned={selectedMemberIds.includes(goblin.id)}
-                    isAssignedElsewhere={assignedToOtherParty.has(goblin.id)}
-                    onPress={() => handleGoblinSelect(goblin)}
-                  />
-                </TouchableOpacity>
+                  isAssigned={selectedMemberIds.includes(goblin.id)}
+                  isAssignedElsewhere={assignedToOtherParty.has(goblin.id)}
+                />
               ))}
             </View>
           )}
@@ -372,7 +323,7 @@ const styles = StyleSheet.create({
   },
   slotContainer: {
     width: '30%',
-    aspectRatio: 0.85,
+    aspectRatio: 1.0,
     borderRadius: 12,
     borderWidth: 2,
     borderStyle: 'dashed',
@@ -406,8 +357,8 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   slotAvatar: {
-    width: 48,
-    height: 48,
+    width: 40,
+    height: 40,
     borderRadius: 4,
     marginBottom: 4,
   },
@@ -447,83 +398,5 @@ const styles = StyleSheet.create({
   },
   goblinList: {
     gap: 8,
-  },
-  goblinItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 12,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  goblinItemAssigned: {
-    backgroundColor: '#EFF6FF',
-    borderColor: '#3B82F6',
-  },
-  goblinItemDisabled: {
-    backgroundColor: '#F9FAFB',
-    opacity: 0.6,
-  },
-  goblinAvatar: {
-    width: 56,
-    height: 56,
-    borderRadius: 8,
-    marginRight: 12,
-  },
-  goblinInfo: {
-    flex: 1,
-  },
-  goblinName: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#1F2937',
-    marginBottom: 2,
-  },
-  goblinNameDisabled: {
-    color: '#9CA3AF',
-  },
-  goblinRace: {
-    fontSize: 12,
-    color: '#6B7280',
-    marginBottom: 2,
-  },
-  goblinRaceDisabled: {
-    color: '#9CA3AF',
-  },
-  goblinLevel: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#374151',
-    marginBottom: 4,
-  },
-  goblinLevelDisabled: {
-    color: '#9CA3AF',
-  },
-  factorIcons: {
-    flexDirection: 'row',
-    gap: 4,
-  },
-  assignedBadge: {
-    fontSize: 10,
-    fontWeight: '600',
-    color: '#9CA3AF',
-    backgroundColor: '#F3F4F6',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 4,
-  },
-  checkmark: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-    backgroundColor: '#3B82F6',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  checkmarkText: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
   },
 })

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -3,54 +3,15 @@ import { View, Text, FlatList, TouchableOpacity, StyleSheet, Modal, ScrollView, 
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useFocusEffect } from 'expo-router'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
+import { GoblinCard } from '@/presentation/components/GoblinCard'
 import type { Goblin } from '@/shared/types'
 import { getFactor } from '@/shared/data/factors'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
-import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 import { getExpForNextLevel, getExpProgress } from '@/core/services/ExperienceSystem'
 import { getModTemplate } from '@/shared/data/modPoolLoader'
 
-interface GoblinCardProps {
-  goblin: Goblin
-  onPress: () => void
-}
-
-function GoblinCard({ goblin, onPress }: GoblinCardProps) {
-  const stats = getEffectiveStats(goblin)
-
-  return (
-    <TouchableOpacity style={styles.card} onPress={onPress}>
-      <View style={styles.iconContainer}>
-        <Image source={getGoblinImage(goblin.avatar)} style={styles.goblinImage} />
-      </View>
-      <View style={styles.cardInfo}>
-        <Text style={styles.goblinName}>{goblin.name}</Text>
-        <Text style={styles.goblinLevel}>Lv.{goblin.level}</Text>
-        {goblin.factors && goblin.factors.length > 0 && (
-          <View style={styles.factorRow}>
-            {goblin.factors.slice(0, 3).map((factorId, idx) => {
-              const FactorIcon = getFactorImage(factorId)
-              return (
-                <View key={idx} style={styles.factorBadge}>
-                  <FactorIcon width={16} height={16} />
-                </View>
-              )
-            })}
-            {goblin.factors.length > 3 && (
-              <Text style={styles.moreFactors}>+{goblin.factors.length - 3}</Text>
-            )}
-          </View>
-        )}
-      </View>
-      <View style={styles.statsContainer}>
-        <Text style={styles.statText}>HP:{stats.hp}</Text>
-        <Text style={styles.statText}>ATK:{stats.atk}</Text>
-      </View>
-    </TouchableOpacity>
-  )
-}
 
 const STAT_LABELS: Record<string, string> = {
   hp_percent: 'HP',
@@ -273,15 +234,13 @@ export default function GoblinListScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right', 'bottom']}>
-      <FlatList
-        data={goblins}
-        keyExtractor={(item) => String(item.id)}
-        renderItem={({ item }) => (
-          <GoblinCard goblin={item} onPress={() => handleGoblinPress(item)} />
-        )}
-        contentContainerStyle={styles.listContent}
-        ItemSeparatorComponent={() => <View style={styles.separator} />}
-      />
+      <View style={styles.listContent}>
+        {goblins.map((goblin) => (
+          <View key={goblin.id} style={styles.cardWrapper}>
+            <GoblinCard goblin={goblin} onPress={() => handleGoblinPress(goblin)} />
+          </View>
+        ))}
+      </View>
       <GoblinDetailModal
         goblin={selectedGoblin}
         visible={modalVisible}
@@ -333,70 +292,8 @@ const styles = StyleSheet.create({
   listContent: {
     padding: 16,
   },
-  separator: {
-    height: 12,
-  },
-  card: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
-  },
-  iconContainer: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: '#F3F4F6',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 12,
-    overflow: 'hidden',
-  },
-  goblinImage: {
-    width: 40,
-    height: 40,
-    resizeMode: 'contain',
-  },
-  cardInfo: {
-    flex: 1,
-  },
-  goblinName: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: '#1F2937',
-  },
-  goblinLevel: {
-    fontSize: 14,
-    color: '#6B7280',
-    marginTop: 2,
-  },
-  factorRow: {
-    flexDirection: 'row',
-    marginTop: 4,
-    alignItems: 'center',
-  },
-  factorBadge: {
-    backgroundColor: '#EEF2FF',
-    borderRadius: 4,
-    padding: 2,
-    marginRight: 4,
-  },
-  moreFactors: {
-    fontSize: 10,
-    color: '#6B7280',
-  },
-  statsContainer: {
-    alignItems: 'flex-end',
-  },
-  statText: {
-    fontSize: 12,
-    color: '#6B7280',
+  cardWrapper: {
+    marginBottom: 12,
   },
   modalContainer: {
     flex: 1,

--- a/goblin_native/src/presentation/components/GoblinCard.tsx
+++ b/goblin_native/src/presentation/components/GoblinCard.tsx
@@ -1,0 +1,173 @@
+import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native'
+import { getGoblinImage } from '@/shared/utils/goblinImages'
+import { getFactorImage } from '@/shared/utils/factorImages'
+import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import type { Goblin } from '@/shared/types'
+
+interface GoblinCardProps {
+  goblin: Goblin
+  onPress?: () => void
+  isAssigned?: boolean
+  isAssignedElsewhere?: boolean
+  disabled?: boolean
+}
+
+export function GoblinCard({
+  goblin,
+  onPress,
+  isAssigned = false,
+  isAssignedElsewhere = false,
+  disabled = false
+}: GoblinCardProps) {
+  const stats = getEffectiveStats(goblin)
+  const FactorIcon1 = goblin.factors?.[0] ? getFactorImage(goblin.factors[0]) : null
+  const FactorIcon2 = goblin.factors?.[1] ? getFactorImage(goblin.factors[1]) : null
+
+  const content = (
+    <View style={[
+      styles.container,
+      isAssigned && styles.containerAssigned,
+      isAssignedElsewhere && styles.containerDisabled,
+    ]}>
+      <Image source={getGoblinImage(goblin.avatar)} style={styles.avatar} />
+      <View style={styles.info}>
+        <Text style={[styles.name, isAssignedElsewhere && styles.nameDisabled]}>
+          {goblin.name}
+        </Text>
+        <Text style={[styles.race, isAssignedElsewhere && styles.raceDisabled]}>
+          {goblin.race}
+        </Text>
+        <Text style={[styles.level, isAssignedElsewhere && styles.levelDisabled]}>
+          Lv.{goblin.level}
+        </Text>
+        <View style={styles.factorIcons}>
+          {FactorIcon1 && <FactorIcon1 width={20} height={20} />}
+          {FactorIcon2 && <FactorIcon2 width={20} height={20} />}
+        </View>
+      </View>
+      <View style={styles.statsContainer}>
+        <Text style={[styles.statText, isAssignedElsewhere && styles.statTextDisabled]}>
+          HP: {stats.hp}
+        </Text>
+        <Text style={[styles.statText, isAssignedElsewhere && styles.statTextDisabled]}>
+          ATK: {stats.atk}
+        </Text>
+      </View>
+      {isAssignedElsewhere && (
+        <Text style={styles.assignedBadge}>他PT</Text>
+      )}
+      {isAssigned && !isAssignedElsewhere && (
+        <View style={styles.checkmark}>
+          <Text style={styles.checkmarkText}>v</Text>
+        </View>
+      )}
+    </View>
+  )
+
+  if (onPress && !disabled) {
+    return (
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={isAssignedElsewhere ? 1 : 0.7}
+      >
+        {content}
+      </TouchableOpacity>
+    )
+  }
+
+  return content
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  containerAssigned: {
+    backgroundColor: '#EFF6FF',
+    borderColor: '#3B82F6',
+  },
+  containerDisabled: {
+    backgroundColor: '#F9FAFB',
+    opacity: 0.6,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 8,
+    marginRight: 10,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1F2937',
+    marginBottom: 1,
+  },
+  nameDisabled: {
+    color: '#9CA3AF',
+  },
+  race: {
+    fontSize: 11,
+    color: '#6B7280',
+    marginBottom: 1,
+  },
+  raceDisabled: {
+    color: '#9CA3AF',
+  },
+  level: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 2,
+  },
+  levelDisabled: {
+    color: '#9CA3AF',
+  },
+  factorIcons: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  statsContainer: {
+    alignItems: 'flex-end',
+    marginRight: 8,
+  },
+  statText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 2,
+  },
+  statTextDisabled: {
+    color: '#9CA3AF',
+  },
+  assignedBadge: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: '#9CA3AF',
+    backgroundColor: '#F3F4F6',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+  },
+  checkmark: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#3B82F6',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkmarkText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+  },
+})


### PR DESCRIPTION
## Summary
- 共通のGoblinCardコンポーネントを作成し、コードの重複を削減
- すべてのゴブリンカードにHP・ATKステータスを表示
- ゴブリン一覧とパーティ編集画面のUIデザインを統一
- カードサイズをコンパクト化し、画面表示効率を向上

## Changes
### 新規作成
- `src/presentation/components/GoblinCard.tsx`: 共通ゴブリンカードコンポーネント

### 変更
- `app/(tabs)/index.tsx`: 独自のGoblinCard削除、共通コンポーネント使用
- `app/(tabs)/formation/edit.tsx`: GoblinListItem削除、共通コンポーネント使用

### UI改善
- パーティメンバースロット: aspect ratio 0.85 → 1.0、アバター 48px → 40px
- 利用可能なゴブリンリスト: アバター 40px、パディング・フォントサイズを縮小
- 両画面でHP・ATK情報を表示

## Test plan
- [ ] ゴブリン一覧画面で全ゴブリンが正しく表示される
- [ ] パーティ編集画面で利用可能なゴブリンリストが正しく表示される
- [ ] HP・ATK情報が両画面で表示される
- [ ] 選択状態、他PT所属バッジが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)