### PR TITLE
fix: use effective HP instead of base HP in expedition playback

### DIFF
--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -14,6 +14,7 @@ import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord } from '@/shared
 import type { BattleLogEntry } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
+import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 
 interface LogEntry {
   id: string
@@ -272,7 +273,7 @@ export default function ExpeditionPlaybackScreen() {
 
     const initialPartyHp = replay.meta.party.map(memberId => {
       const goblin = goblins.find(g => g.id === parseInt(memberId, 10))
-      return goblin?.stats.hp ?? 100
+      return goblin ? ModStatCalculator.calculate(goblin).hp : 100
     })
     let tempHp = [...initialPartyHp]
     let tempFloor = 1
@@ -422,7 +423,7 @@ export default function ExpeditionPlaybackScreen() {
       <View style={styles.partyGrid}>
         {replay.meta.party.map((memberId, index) => {
           const goblin = goblins.find(g => g.id === parseInt(memberId, 10))
-          const maxHp = goblin?.stats.hp ?? 100
+          const maxHp = goblin ? ModStatCalculator.calculate(goblin).hp : 100
           const currentHp = partyHp[index] ?? maxHp
           return (
             <View key={memberId} style={styles.partyCard}>


### PR DESCRIPTION
## Summary
- 探索ログ画面でパーティメンバーのHP表示が実際の探索進行とズレていた問題を修正
- 原因: プレイバック画面が基礎HP(`goblin.stats.hp`)で初期化していたが、ExpeditionEngineは実効HP(`ModStatCalculator.calculate().hp`、因子・Mod適用後)を使用していた
- HP初期値とmaxHp表示の両方を`ModStatCalculator`による実効HPに統一

## Test plan
- [ ] 因子やModを持つゴブリンで遠征を実行し、プレイバック画面のHPが正しく表示されることを確認
- [ ] 全滅する遠征で、HP 0のタイミングがログと一致することを確認
- [ ] 因子・Modのないゴブリンでも正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)