### PR TITLE
feat: ダンジョンレベルベースの宝箱ドロップシステム

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -12,11 +12,10 @@ import type {
   PartyState,
   ExpeditionEndReason,
   AreaConfig,
-  TreasureTable,
 } from '../../shared/types'
 import { getAreaConfig } from '../../shared/data/expeditionArea'
 import { getEnemyDatabase } from '../../shared/data/enemy'
-import { getEquipmentTemplate } from '../../shared/data/equipmentPoolLoader'
+import { getEquipmentTemplate, getEquipmentByDungeonLevel } from '../../shared/data/equipmentPoolLoader'
 import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 
@@ -137,7 +136,7 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const treasureDrops = this.rollTreasureDrops(area.treasureTable, enemies, droppedTemplateIds)
+            const treasureDrops = this.rollTreasureDrops(area.dropChance, area.areaLevel, enemies, droppedTemplateIds)
             if (treasureDrops.length > 0) {
               events.push({
                 type: "treasure",
@@ -193,7 +192,7 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const defaultTreasure = this.rollTreasureDrops(area.treasureTable, enemies, droppedTemplateIds)
+            const defaultTreasure = this.rollTreasureDrops(area.dropChance, area.areaLevel, enemies, droppedTemplateIds)
             if (defaultTreasure.length > 0) {
               events.push({
                 type: "treasure",
@@ -254,7 +253,7 @@ export class ExpeditionEngine {
 
       // ボス戦勝利時の宝箱ドロップ判定
       if (bossCombat.outcome === 'win') {
-        const bossTreasure = this.rollTreasureDrops(area.treasureTable, bossEnemies, droppedTemplateIds)
+        const bossTreasure = this.rollTreasureDrops(area.dropChance, area.areaLevel, bossEnemies, droppedTemplateIds)
         if (bossTreasure.length > 0) {
           events.push({
             type: "treasure",
@@ -494,36 +493,27 @@ export class ExpeditionEngine {
 
   /**
    * 宝箱ドロップを判定（同一遠征中に同じアイテムは1個まで）
-   * 1. ダンジョンの treasureTable で通常アイテムを抽選
+   * 1. ダンジョンレベルに対応する装備プールから均等抽選
    * 2. 敵個別の equipmentDrops でレアアイテムを抽選
    */
   private rollTreasureDrops(
-    treasureTable: TreasureTable | undefined,
+    dropChance: number | undefined,
+    dungeonLevel: number,
     enemies: Enemy[],
     droppedIds: Set<string>
   ): TreasureDrop[] {
     const drops: TreasureDrop[] = []
 
-    // ダンジョンの宝箱テーブルから通常アイテムを抽選
-    if (treasureTable) {
-      // 未ドロップのアイテムだけを候補にする
-      const candidates = treasureTable.items.filter(item => !droppedIds.has(item.templateId))
+    // ダンジョンレベルに応じた装備プールから抽選
+    if (dropChance !== undefined && this.rng() < dropChance) {
+      const pool = getEquipmentByDungeonLevel(dungeonLevel)
+      const candidates = pool.filter(t => !droppedIds.has(t.id))
 
-      if (candidates.length > 0 && this.rng() < treasureTable.dropChance) {
-        const totalWeight = candidates.reduce((sum, item) => sum + item.weight, 0)
-        const roll = this.rng() * totalWeight
-        let current = 0
-        for (const item of candidates) {
-          current += item.weight
-          if (roll <= current) {
-            const template = getEquipmentTemplate(item.templateId)
-            if (template) {
-              drops.push({ templateId: item.templateId, name: template.name })
-              droppedIds.add(item.templateId)
-            }
-            break
-          }
-        }
+      if (candidates.length > 0) {
+        const index = Math.floor(this.rng() * candidates.length)
+        const selected = candidates[index]
+        drops.push({ templateId: selected.id, name: selected.name })
+        droppedIds.add(selected.id)
       }
     }
 

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -17,6 +17,8 @@
       "range": "melee",
       "price": 5,
       "unlockRank": 1,
+      "dropLevelMin": 1,
+      "dropLevelMax": 2,
       "description": "その辺に落ちていた棒切れ。無いよりはマシ"
     },
     {
@@ -33,6 +35,8 @@
       "range": "melee",
       "price": 15,
       "unlockRank": 1,
+      "dropLevelMin": 4,
+      "dropLevelMax": 10,
       "description": "木を削って作った棍棒。ゴブリンの定番武器"
     },
     {
@@ -50,6 +54,8 @@
       "range": "melee",
       "price": 30,
       "unlockRank": 1,
+      "dropLevelMin": 8,
+      "dropLevelMax": 15,
       "description": "銅で鍛えた初めてのまともな剣"
     },
     {
@@ -67,6 +73,8 @@
       "range": "melee",
       "price": 60,
       "unlockRank": 1,
+      "dropLevelMin": 8,
+      "dropLevelMax": 15,
       "description": "幅広の刃を持つ片手剣。攻守のバランスが良い"
     },
     {
@@ -84,6 +92,8 @@
       "range": "melee",
       "price": 100,
       "unlockRank": 1,
+      "dropLevelMin": 12,
+      "dropLevelMax": 25,
       "description": "標準的な長剣。扱いやすく初心者向き"
     },
     {
@@ -100,6 +110,8 @@
       "effects": [{ "type": "def_to_hp", "value": 4 }],
       "range": "melee",
       "price": 500,
+      "dropLevelMin": 20,
+      "dropLevelMax": 40,
       "description": "ミスリル銀で鍛えられた剣。軽く鋭い"
     },
     {
@@ -116,6 +128,8 @@
       "effects": [{ "type": "def_to_hp", "value": 5 }],
       "range": "melee",
       "price": 2500,
+      "dropLevelMin": 35,
+      "dropLevelMax": 60,
       "description": "王家に伝わる名剣。気品ある輝きを放つ"
     },
     {
@@ -133,6 +147,8 @@
       "range": "melee",
       "price": 12500,
       "unlockRank": 3,
+      "dropLevelMin": 50,
+      "dropLevelMax": 80,
       "description": "皇帝の威光を宿す剣。圧倒的な切れ味"
     },
     {
@@ -150,6 +166,8 @@
       "range": "melee",
       "price": 60000,
       "unlockRank": 5,
+      "dropLevelMin": 70,
+      "dropLevelMax": 105,
       "description": "古代文明の技術で造られた剣。失われた力が宿る"
     },
     {
@@ -166,6 +184,8 @@
       "effects": [{ "type": "def_to_hp", "value": 8 }],
       "range": "melee",
       "price": 240000,
+      "dropLevelMin": 95,
+      "dropLevelMax": 135,
       "description": "竜の骨から鍛造された大剣。重く、振るうには相応の力が要る"
     },
     {
@@ -182,6 +202,8 @@
       "effects": [{ "type": "def_to_hp", "value": 9 }],
       "range": "melee",
       "price": 720000,
+      "dropLevelMin": 120,
+      "dropLevelMax": 150,
       "description": "最硬の鉱石アダマンタイトで造られた剣。振るえる者は限られる"
     },
 
@@ -200,6 +222,8 @@
       "range": "ranged",
       "price": 10,
       "unlockRank": 1,
+      "dropLevelMin": 1,
+      "dropLevelMax": 2,
       "description": "Y字の枝とゴム紐で作った投石器。小石を飛ばす"
     },
     {
@@ -215,6 +239,8 @@
       "range": "ranged",
       "price": 40,
       "unlockRank": 1,
+      "dropLevelMin": 4,
+      "dropLevelMax": 10,
       "description": "小型の弓。取り回しが良く、後衛から援護できる"
     },
     {
@@ -234,6 +260,8 @@
       "range": "ranged",
       "price": 1000,
       "unlockRank": 1,
+      "dropLevelMin": 12,
+      "dropLevelMax": 25,
       "description": "本格的な長弓。遠距離から正確に射抜く"
     },
     {
@@ -252,6 +280,8 @@
       ],
       "range": "ranged",
       "price": 5000,
+      "dropLevelMin": 20,
+      "dropLevelMax": 40,
       "description": "ミスリル銀で補強された弓。軽く、矢の飛距離が伸びる"
     },
     {
@@ -270,6 +300,8 @@
       ],
       "range": "ranged",
       "price": 25000,
+      "dropLevelMin": 35,
+      "dropLevelMax": 60,
       "description": "王室御用達の名弓。精密な射撃が可能"
     },
     {
@@ -289,6 +321,8 @@
       "range": "ranged",
       "price": 125000,
       "unlockRank": 3,
+      "dropLevelMin": 50,
+      "dropLevelMax": 80,
       "description": "皇帝の狩猟弓。一矢で大型獣をも貫く"
     },
     {
@@ -308,6 +342,8 @@
       "range": "ranged",
       "price": 500000,
       "unlockRank": 5,
+      "dropLevelMin": 70,
+      "dropLevelMax": 105,
       "description": "古代遺跡から発掘された弓。矢が自ら標的を追う"
     },
     {
@@ -326,6 +362,8 @@
       ],
       "range": "ranged",
       "price": 1500000,
+      "dropLevelMin": 95,
+      "dropLevelMax": 135,
       "description": "竜の腱を弦にした弓。放たれた矢は風を裂く"
     },
     {
@@ -344,6 +382,8 @@
       ],
       "range": "ranged",
       "price": 3000000,
+      "dropLevelMin": 120,
+      "dropLevelMax": 150,
       "description": "アダマンタイトの矢を放つ究極の弓。貫けぬ物はない"
     }
   ]

--- a/goblin_native/src/shared/data/equipmentPoolLoader.ts
+++ b/goblin_native/src/shared/data/equipmentPoolLoader.ts
@@ -38,6 +38,19 @@ export function getShopEquipment(baseRank: number): EquipmentTemplate[] {
 }
 
 /**
+ * ダンジョンレベルに対応する装備テンプレートを取得
+ */
+export function getEquipmentByDungeonLevel(dungeonLevel: number): EquipmentTemplate[] {
+  return templates.filter(
+    (t) =>
+      t.dropLevelMin !== undefined &&
+      t.dropLevelMax !== undefined &&
+      dungeonLevel >= t.dropLevelMin &&
+      dungeonLevel <= t.dropLevelMax
+  )
+}
+
+/**
  * 装備プールのバージョン情報を取得
  */
 export function getEquipmentPoolVersion(): string {

--- a/goblin_native/src/shared/data/expeditionArea/slime_cave.json
+++ b/goblin_native/src/shared/data/expeditionArea/slime_cave.json
@@ -16,12 +16,6 @@
     "xpFloor": [4, 6],
     "xpBoss": 12
   },
-  "treasureTable": {
-    "dropChance": 0.15,
-    "items": [
-      { "templateId": "sword_cypress_stick", "weight": 50 },
-      { "templateId": "bow_slingshot", "weight": 50 }
-    ]
-  },
+  "dropChance": 0.15,
   "unlockNext": "forest_outskirts"
 }

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -74,6 +74,8 @@ export interface EquipmentTemplate {
   range?: WeaponRange
   price: number
   unlockRank?: number  // 店売り解放に必要な拠点ランク（未設定=店売りなし）
+  dropLevelMin?: number  // 宝箱ドロップするダンジョンレベル下限（未設定=ドロップなし）
+  dropLevelMax?: number  // 宝箱ドロップするダンジョンレベル上限
   description?: string
 }
 

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -76,16 +76,6 @@ export interface RewardSummary {
   treasureDrops?: TreasureDrop[]  // 宝箱から獲得した装備
 }
 
-export interface TreasureTableEntry {
-  templateId: string  // EquipmentTemplate.id
-  weight: number      // 抽選ウェイト
-}
-
-export interface TreasureTable {
-  dropChance: number             // 戦闘勝利ごとの宝箱出現確率 (0.0〜1.0)
-  items: TreasureTableEntry[]    // 出現時のアイテム抽選テーブル
-}
-
 export interface AreaConfig {
   id: string
   name: string
@@ -109,6 +99,6 @@ export interface AreaConfig {
     xpFloor: number[]
     xpBoss: number
   }
-  treasureTable?: TreasureTable  // ダンジョンの宝箱ドロップ設定
+  dropChance?: number  // 戦闘勝利ごとの宝箱出現確率 (0.0〜1.0)、areaLevelに応じた装備がドロップ
   unlockNext?: string
 }

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -48,8 +48,6 @@ export type {
   ExpeditionReplay,
   TimelineEvent,
   TreasureDrop,
-  TreasureTableEntry,
-  TreasureTable,
   ExpeditionRecord,
   RewardSummary,
   AreaConfig,


### PR DESCRIPTION
## Summary
- ダンジョンごとの個別ドロップテーブル（treasureTable.items）を廃止し、装備テンプレートに`dropLevelMin`/`dropLevelMax`を定義する方式に変更
- ダンジョンの`areaLevel`に応じて自動的にドロップ候補が決定される
- areaLevel 1〜150のスケールで全20種の武器にドロップレベル範囲を設定

## Test plan
- [ ] スライムの洞窟(Lv1)でひのきの棒・スリングショットがドロップすることを確認
- [ ] 周辺の森(Lv2)でひのきの棒・スリングショットがドロップすることを確認
- [ ] ゴブリン集落(Lv5)でこんぼう・ショートボウがドロップすることを確認
- [ ] オークの野営地(Lv8)でこんぼう・ショートボウ・銅の剣・ブロードソードがドロップすることを確認
- [ ] areaLevel 3のダンジョンではドロップ候補がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)