### PR TITLE
feat: 拠点ランクシステムの実装

### DIFF
--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react'
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator, Image } from 'react-native'
+import { useState, useCallback, useMemo } from 'react'
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useFocusEffect } from 'expo-router'
 import { useBaseState } from '@/presentation/hooks/useBaseState'
@@ -9,6 +9,8 @@ import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
 import { getModTemplate } from '@/shared/data/modPoolLoader'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
+import { checkRankUpAvailable, BASE_RANK_CONFIGS } from '@/core/services/BaseRankSystem'
+import { areasData } from '@/shared/data'
 
 const STAT_LABELS: Record<string, string> = {
   hp_percent: 'HP',
@@ -28,17 +30,38 @@ function getStatLabel(stat: string): string {
 }
 
 export default function BaseManagementScreen() {
-  const { isLoading: baseLoading, rank, capacity } = useBaseState()
+  const { isLoading: baseLoading, rank, capacity, maxParties, maxGoblins, ivBonus, baseState, gold, performRankUp } = useBaseState()
   const { pendingGoblins, isLoading: pendingLoading, removePendingGoblin, refreshPendingGoblins } = usePendingGoblins()
   const { goblins, saveGoblin } = useGoblinService()
 
   const [selectedGoblinIds, setSelectedGoblinIds] = useState<Set<number>>(new Set())
+  const [isRankingUp, setIsRankingUp] = useState(false)
 
   const currentGoblinCount = goblins.length
   const availableSlots = Math.max(0, capacity - currentGoblinCount)
   const maxPendingGoblins = rank * 5
   const selectedCount = selectedGoblinIds.size
   const canAddSelected = selectedCount > 0 && selectedCount <= availableSlots
+
+  // 次のランクアップ情報を計算
+  const nextRankInfo = useMemo(() => {
+    if (!baseState) return null
+    const nextConfig = BASE_RANK_CONFIGS.find(c => c.rank === rank + 1)
+    if (!nextConfig) return null
+
+    const targetDungeon = areasData.find(d => d.id === nextConfig.unlockCondition.dungeonId)
+    const isCaptured = baseState.capturedDungeons.includes(nextConfig.unlockCondition.dungeonId)
+
+    return {
+      nextRank: nextConfig.rank,
+      dungeonName: targetDungeon?.name || nextConfig.unlockCondition.dungeonId,
+      isCaptured,
+      maxParties: nextConfig.maxParties,
+      maxGoblins: nextConfig.maxGoblins,
+      ivBonus: nextConfig.ivBonus,
+      upgradeCost: nextConfig.upgradeCost,
+    }
+  }, [baseState, rank])
 
   const toggleGoblinSelection = useCallback((goblinId: number) => {
     setSelectedGoblinIds(prev => {
@@ -71,6 +94,36 @@ export default function BaseManagementScreen() {
     setSelectedGoblinIds(new Set())
   }, [pendingGoblins, selectedGoblinIds, selectedCount, removePendingGoblin])
 
+  const handleRankUp = useCallback(() => {
+    if (!nextRankInfo) return
+
+    Alert.alert(
+      'ランクアップ確認',
+      `拠点をランク${nextRankInfo.nextRank}にランクアップしますか？\n\n引っ越し資金: ${nextRankInfo.upgradeCost}G\n所持ゴールド: ${gold}G`,
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        {
+          text: 'ランクアップ',
+          onPress: () => {
+            setIsRankingUp(true)
+            const result = performRankUp()
+            setIsRankingUp(false)
+
+            if (result.success) {
+              Alert.alert(
+                'ランクアップ成功！',
+                `拠点がランク${nextRankInfo.nextRank}になりました！\n\n新しい能力が解放されました。`,
+                [{ text: 'OK' }]
+              )
+            } else {
+              Alert.alert('ランクアップ失敗', result.error, [{ text: 'OK' }])
+            }
+          },
+        },
+      ]
+    )
+  }, [nextRankInfo, gold, performRankUp])
+
   useFocusEffect(
     useCallback(() => {
       refreshPendingGoblins()
@@ -99,25 +152,91 @@ export default function BaseManagementScreen() {
             <View style={styles.statusItem}>
               <Text style={styles.statusLabel}>拠点ランク</Text>
               <View style={styles.statusValueBox}>
-                <Text style={styles.statusValueText}>{rank}</Text>
+                <Text style={styles.statusValueText}>Lv. {rank}</Text>
+              </View>
+            </View>
+            <View style={styles.statusItem}>
+              <Text style={styles.statusLabel}>所持ゴールド</Text>
+              <View style={styles.statusValueBox}>
+                <Text style={styles.statusValueText}>{gold}G</Text>
+              </View>
+            </View>
+            <View style={styles.statusItem}>
+              <Text style={styles.statusLabel}>最大PT数</Text>
+              <View style={styles.statusValueBox}>
+                <Text style={styles.statusValueText}>{maxParties}</Text>
               </View>
             </View>
             <View style={styles.statusItem}>
               <Text style={styles.statusLabel}>収容数</Text>
               <View style={styles.statusValueBox}>
-                <Text style={styles.statusValueText}>{capacity}</Text>
+                <Text style={styles.statusValueText}>{maxGoblins}</Text>
+              </View>
+            </View>
+            <View style={styles.statusItem}>
+              <Text style={styles.statusLabel}>個体値ボーナス</Text>
+              <View style={styles.statusValueBox}>
+                <Text style={styles.statusValueText}>+{ivBonus}</Text>
               </View>
             </View>
             <View style={styles.statusItem}>
               <Text style={styles.statusLabel}>現在のゴブリン</Text>
-              <Text style={styles.statusValuePlain}>{currentGoblinCount} / {capacity}</Text>
-            </View>
-            <View style={styles.statusItem}>
-              <Text style={styles.statusLabel}>空き枠</Text>
-              <Text style={styles.statusValuePlain}>{availableSlots}</Text>
+              <Text style={styles.statusValuePlain}>{currentGoblinCount} / {maxGoblins}</Text>
             </View>
           </View>
         </View>
+
+        {nextRankInfo && (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>次のランクアップ</Text>
+            <View style={styles.rankUpInfo}>
+              <View style={styles.rankUpRow}>
+                <Text style={styles.rankUpLabel}>目標拠点ランク:</Text>
+                <Text style={styles.rankUpValue}>Lv. {nextRankInfo.nextRank}</Text>
+              </View>
+              <View style={styles.rankUpRow}>
+                <Text style={styles.rankUpLabel}>引っ越し資金:</Text>
+                <Text style={styles.rankUpValue}>{nextRankInfo.upgradeCost}G</Text>
+              </View>
+              <View style={styles.rankUpRow}>
+                <Text style={styles.rankUpLabel}>必要な制圧:</Text>
+                <View style={styles.rankUpDungeonRow}>
+                  <Text style={[styles.rankUpValue, nextRankInfo.isCaptured && styles.rankUpCompleted]}>
+                    {nextRankInfo.dungeonName}
+                  </Text>
+                  {nextRankInfo.isCaptured && (
+                    <Text style={styles.rankUpCheck}>✓</Text>
+                  )}
+                </View>
+              </View>
+              <View style={styles.divider} />
+              <Text style={styles.rankUpBenefitsTitle}>ランクアップ時の効果:</Text>
+              <View style={styles.rankUpBenefits}>
+                <Text style={styles.rankUpBenefit}>• 最大PT数: {maxParties} → {nextRankInfo.maxParties}</Text>
+                <Text style={styles.rankUpBenefit}>• 収容数: {maxGoblins} → {nextRankInfo.maxGoblins}</Text>
+                <Text style={styles.rankUpBenefit}>• 個体値ボーナス: +{ivBonus} → +{nextRankInfo.ivBonus}</Text>
+              </View>
+
+              {nextRankInfo.isCaptured && (
+                <TouchableOpacity
+                  style={[
+                    styles.rankUpButton,
+                    (gold < nextRankInfo.upgradeCost || isRankingUp) && styles.rankUpButtonDisabled
+                  ]}
+                  onPress={handleRankUp}
+                  disabled={gold < nextRankInfo.upgradeCost || isRankingUp}
+                >
+                  <Text style={[
+                    styles.rankUpButtonText,
+                    (gold < nextRankInfo.upgradeCost || isRankingUp) && styles.rankUpButtonTextDisabled
+                  ]}>
+                    {isRankingUp ? '実行中...' : `ランク${nextRankInfo.nextRank}にランクアップ (${nextRankInfo.upgradeCost}G)`}
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        )}
 
         {pendingGoblins.length > 0 && (
           <View style={styles.card}>
@@ -484,5 +603,75 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#6B7280',
     lineHeight: 18,
+  },
+  rankUpInfo: {
+    gap: 10,
+  },
+  rankUpRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  rankUpLabel: {
+    fontSize: 13,
+    color: '#6B7280',
+    flex: 1,
+  },
+  rankUpValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1F2937',
+  },
+  rankUpDungeonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  rankUpCompleted: {
+    color: '#10B981',
+    textDecorationLine: 'line-through',
+  },
+  rankUpCheck: {
+    fontSize: 16,
+    color: '#10B981',
+    fontWeight: '700',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#E5E7EB',
+    marginVertical: 4,
+  },
+  rankUpBenefitsTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#4B5563',
+    marginBottom: 4,
+  },
+  rankUpBenefits: {
+    gap: 4,
+  },
+  rankUpBenefit: {
+    fontSize: 12,
+    color: '#6B7280',
+    lineHeight: 18,
+  },
+  rankUpButton: {
+    backgroundColor: '#3B82F6',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    marginTop: 12,
+    alignItems: 'center',
+  },
+  rankUpButtonDisabled: {
+    backgroundColor: '#D1D5DB',
+  },
+  rankUpButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+  rankUpButtonTextDisabled: {
+    color: '#9CA3AF',
   },
 })

--- a/goblin_native/app/_layout.tsx
+++ b/goblin_native/app/_layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout() {
       try {
         // 第1段階: DBインスタンスの初期化（マイグレーション実行）
         console.log('[RootLayout] Initializing database...')
+
         await getDatabase()
         console.log('[RootLayout] Database initialized')
 

--- a/goblin_native/docs/base_rank_system.md
+++ b/goblin_native/docs/base_rank_system.md
@@ -1,0 +1,368 @@
+# 拠点ランクシステム設計
+
+## 概要
+
+ゴブリンが勢力を拡大し、敵の拠点を制圧することで拠点ランクを上げるシステム。
+拠点ランクの上昇により、パーティ編成数、ゴブリン収容数、個体値ボーナスが増加する。
+
+## 拠点ランクの進行
+
+### ランクアップ条件
+
+| ランク | 制圧対象ダンジョン | クリア回数 | 解放される機能 |
+|--------|-------------------|-----------|---------------|
+| 1 (初期) | - | - | 基本機能 |
+| 2 | ゴブリン集落 | 1回 | 2PT編成、ゴブリン20体収容 |
+| 3 | 盗賊のアジト（山道の洞窟） | 1回 | 3PT編成、ゴブリン35体収容 |
+| 4 | 交易路の関所 / オークキャンプ / ハーフリングの農村 | 1回 | 4PT編成、ゴブリン50体収容 |
+| 5 | ドワーフ坑道 / リザードマンの湿地集落 / ミノタウロス迷宮 | 1回 | 5PT編成、ゴブリン70体収容 |
+| 6 | 人間の辺境の街塞 / 吸血鬼の古城 | 1回 | 6PT編成、ゴブリン100体収容 |
+| 7 (最終) | 王都防衛戦 | 1回 | 8PT編成、ゴブリン150体収容 |
+
+### ランク4以降の選択肢
+
+ランク4以降は複数のダンジョンから選択可能。プレイヤーの戦略に応じてルートを選べる。
+
+**ランク3→4の選択肢**：
+- **交易路の関所**: 経済ルート（将来的に資金ボーナスなど）
+- **オークキャンプ**: 軍事ルート（戦闘力強化）
+- **ハーフリングの農村**: 生産ルート（食料・素材生産）
+
+**ランク4→5の選択肢**：
+- **ドワーフ坑道**: 工業ルート（装備製作）
+- **リザードマンの湿地集落**: 種族多様化ルート（特殊遺伝子）
+- **ミノタウロス迷宮**: 軍事強化ルート
+
+**ランク5→6の選択肢**：
+- **人間の辺境の街塞**: 正攻法ルート
+- **吸血鬼の古城**: 闇ルート（特殊能力）
+
+## 拠点ランクによる効果
+
+### 基本効果
+
+```typescript
+const BASE_RANK_CONFIGS = [
+  {
+    rank: 1,
+    maxParties: 1,        // 編成可能なパーティ数
+    maxGoblins: 10,       // 収容可能なゴブリン数
+    ivBonus: 0,           // 個体値ボーナス
+  },
+  {
+    rank: 2,
+    maxParties: 2,
+    maxGoblins: 20,
+    ivBonus: 2,           // +2
+  },
+  {
+    rank: 3,
+    maxParties: 3,
+    maxGoblins: 35,
+    ivBonus: 4,           // +4
+  },
+  {
+    rank: 4,
+    maxParties: 4,
+    maxGoblins: 50,
+    ivBonus: 6,           // +6
+  },
+  {
+    rank: 5,
+    maxParties: 5,
+    maxGoblins: 70,
+    ivBonus: 8,           // +8
+  },
+  {
+    rank: 6,
+    maxParties: 6,
+    maxGoblins: 100,
+    ivBonus: 10,          // +10
+  },
+  {
+    rank: 7,
+    maxParties: 8,
+    maxGoblins: 150,
+    ivBonus: 12,          // +12
+  },
+];
+```
+
+## 個体値計算システム
+
+### 基本ロジック
+
+```
+最終個体値 = エリアレベルベース個体値 + 拠点ランクボーナス
+→ 1-64の範囲にクランプ
+```
+
+### エリアレベルごとのベース個体値範囲
+
+各ダンジョンエリアには「エリアレベル」（1-8）が設定されており、これがゴブリン生成時のベース個体値を決定する。
+
+```typescript
+const AREA_LEVEL_IV_RANGES: Record<number, [number, number]> = {
+  1: [1, 8],      // 序盤（スライム洞窟、周辺の森）
+  2: [6, 14],     // 初期中盤（ゴブリン集落、盗賊のアジト、ハーフリング農村）
+  3: [12, 20],    // 中盤（交易路の関所、小さな鉱山、沼地の見張り小屋）
+  4: [18, 28],    // 中盤後期（ドワーフ坑道、オークキャンプ、アンデッド墳墓）
+  5: [26, 36],    // 上級（リザードマン集落、ハーピーの崖巣、トロルの峡谷）
+  6: [34, 44],    // 終盤（ミノタウロス迷宮、吸血鬼の古城、ドラゴンの火山巣）
+  7: [42, 52],    // 最終盤（人間の街塞、騎士団本部、学術都市）
+  8: [50, 60],    // 最終決戦（王都防衛戦）
+};
+```
+
+### 個体値とModの関係
+
+個体値により、抽選可能なModのTierが変化する：
+
+| 個体値範囲 | 抽選可能なTier | 例 |
+|-----------|---------------|-----|
+| 1-5 | Tier 6のみ | 「頑丈な」「元気な」 |
+| 6-15 | Tier 6-5 | 「堅固な」「活力の」 |
+| 16-27 | Tier 6-4 | 「強靭な」「生命の」 |
+| 28-43 | Tier 6-3 | 「不屈の」 |
+| 44-59 | Tier 6-2 | 「鋼鉄の」 |
+| 60-64 | Tier 6-1 (全て) | 「不滅の」 |
+
+### 計算例
+
+**例1: ランク1拠点でエリアレベル1のダンジョンをクリア**
+```
+ベース個体値: 1-8（ランダム） → 仮に5
+拠点ランクボーナス: +0
+最終個体値: 5
+→ Tier 6のModのみ抽選可能
+```
+
+**例2: ランク3拠点でエリアレベル3のダンジョンをクリア**
+```
+ベース個体値: 12-20（ランダム） → 仮に16
+拠点ランクボーナス: +4
+最終個体値: 20
+→ Tier 6-4のModが抽選可能
+```
+
+**例3: ランク7拠点でエリアレベル8のダンジョンをクリア**
+```
+ベース個体値: 50-60（ランダム） → 仮に55
+拠点ランクボーナス: +12
+最終個体値: 67 → 64にクランプ
+→ 全TierのModが抽選可能（Tier 1が高確率）
+```
+
+**例4: ランク7拠点でエリアレベル1のダンジョンを周回**
+```
+ベース個体値: 1-8（ランダム） → 仮に6
+拠点ランクボーナス: +12
+最終個体値: 18
+→ Tier 6-4までのModが抽選可能
+```
+
+### ゲームプレイへの影響
+
+**メリット**：
+1. **難易度と報酬の相関**: 難しいダンジョンほど高個体値のゴブリンが得られる
+2. **拠点成長の価値**: 拠点ランクを上げれば、すべての遠征でゴブリンの質が底上げされる
+3. **選択肢の多様性**:
+   - 高難易度に挑戦して高個体値狙い
+   - 低難易度を周回してゴブリン数を集める（個体値は低め）
+   - バランスを取って中難易度を攻略
+
+**プレイヤーの戦略**：
+- **序盤**: エリアレベル1-2を周回して戦力を整える
+- **中盤**: 拠点ランクを上げつつ、エリアレベル3-5に挑戦
+- **終盤**: 高ランク拠点 + 高レベルエリアで最強ゴブリンを量産
+
+## データ構造
+
+### BaseState（拠点状態）
+
+```typescript
+interface BaseState {
+  rank: number;                    // 現在の拠点ランク（1-7）
+  capturedDungeons: string[];      // 制圧済みダンジョンIDのリスト
+  currentMaxParties: number;       // 現在の最大パーティ数
+  currentMaxGoblins: number;       // 現在の最大ゴブリン数
+  currentIVBonus: number;          // 現在の個体値ボーナス
+}
+```
+
+### DungeonArea（ダンジョンエリア）
+
+```typescript
+interface DungeonArea {
+  id: string;                      // ダンジョンID
+  name: string;                    // ダンジョン名
+  areaLevel: number;               // エリアレベル（1-8）
+  isBaseCapture: boolean;          // 拠点化可能か
+  requiredRank?: number;           // 挑戦に必要な拠点ランク
+  rankUpTarget?: number;           // このダンジョン制圧で到達するランク
+  // ... その他のプロパティ
+}
+```
+
+### BaseRankConfig（ランク設定）
+
+```typescript
+interface BaseRankConfig {
+  rank: number;
+  maxParties: number;
+  maxGoblins: number;
+  ivBonus: number;
+  unlockCondition: {
+    dungeonId: string;             // 制圧する必要のあるダンジョンID
+    clearCount?: number;           // 必要なクリア回数（デフォルト1）
+  };
+}
+```
+
+## 実装ロジック
+
+### 個体値計算関数
+
+```typescript
+function calculateIndividualValue(
+  areaLevel: number,
+  baseRank: number,
+  random: () => number
+): number {
+  // エリアレベルのベース範囲を取得
+  const [min, max] = AREA_LEVEL_IV_RANGES[areaLevel] || [1, 8];
+  const baseIV = Math.floor(min + (max - min) * random());
+
+  // 拠点ランクボーナスを加算
+  const bonus = BASE_RANK_BONUS[baseRank] || 0;
+  const finalIV = baseIV + bonus;
+
+  // 1-64にクランプ
+  return Math.max(1, Math.min(64, finalIV));
+}
+```
+
+### ランクアップ可否チェック
+
+```typescript
+function checkRankUpAvailable(baseState: BaseState): {
+  canRankUp: boolean;
+  requirement?: string;
+  nextRank?: number;
+} {
+  const nextConfig = BASE_RANK_CONFIGS.find(c => c.rank === baseState.rank + 1);
+  if (!nextConfig) {
+    return { canRankUp: false };
+  }
+
+  const hasCaptured = baseState.capturedDungeons.includes(
+    nextConfig.unlockCondition.dungeonId
+  );
+
+  if (!hasCaptured) {
+    return {
+      canRankUp: false,
+      requirement: `${nextConfig.unlockCondition.dungeonId}を制圧する必要があります`,
+      nextRank: nextConfig.rank
+    };
+  }
+
+  return { canRankUp: true, nextRank: nextConfig.rank };
+}
+```
+
+### ダンジョン制圧処理
+
+```typescript
+async function captureDungeon(
+  dungeonId: string,
+  baseState: BaseState
+): Promise<BaseState> {
+  // 制圧済みリストに追加
+  if (!baseState.capturedDungeons.includes(dungeonId)) {
+    baseState.capturedDungeons.push(dungeonId);
+  }
+
+  // ランクアップ可能かチェック
+  const { canRankUp, nextRank } = checkRankUpAvailable(baseState);
+
+  if (canRankUp && nextRank) {
+    const nextConfig = BASE_RANK_CONFIGS.find(c => c.rank === nextRank);
+    if (nextConfig) {
+      baseState.rank = nextRank;
+      baseState.currentMaxParties = nextConfig.maxParties;
+      baseState.currentMaxGoblins = nextConfig.maxGoblins;
+      baseState.currentIVBonus = nextConfig.ivBonus;
+    }
+  }
+
+  return baseState;
+}
+```
+
+## 将来的な拡張
+
+### 拠点ごとの特殊効果
+
+制圧したダンジョンに応じて、追加の効果を付与する可能性：
+
+```typescript
+interface CapturedDungeonBonus {
+  dungeonId: string;
+  bonusType: 'genetic' | 'economic' | 'military' | 'production';
+  effects: {
+    goldBonus?: number;              // 資金ボーナス%
+    materialBonus?: string[];        // 獲得しやすい素材
+    geneticBonus?: string[];         // 獲得しやすい種族遺伝子
+    expeditionCostReduction?: number; // 遠征コスト削減%
+    goblinBirthRate?: number;        // ゴブリン生成速度%
+  };
+}
+```
+
+**例**：
+- **交易路の関所**: 資金+30%
+- **ドワーフ坑道**: 鉱物素材獲得率UP、ドワーフ遺伝子ボーナス
+- **ハーフリング農村**: 遠征コスト-15%、食料生産
+
+### 防衛システム
+
+拠点ごとに防衛力を設定し、定期的に人間軍の反撃イベントが発生：
+
+```typescript
+interface BaseDefense {
+  level: number;                   // 防衛レベル
+  lastAttackTime: number | null;   // 最後の攻撃時刻
+  isUnderAttack: boolean;          // 攻撃中フラグ
+}
+```
+
+## 実装優先順位
+
+### Phase 1: 基本システム
+1. BaseStateデータ構造の実装
+2. 個体値計算ロジックの実装
+3. ランクアップ判定ロジックの実装
+4. GoblinBirthServiceへの統合
+
+### Phase 2: UI実装
+1. 拠点ランク表示画面
+2. ランクアップ通知
+3. ダンジョン制圧状況の表示
+4. 次のランクアップ条件の表示
+
+### Phase 3: ゲームバランス調整
+1. エリアレベルの設定
+2. 個体値範囲の微調整
+3. ランクアップ条件の調整
+
+### Phase 4: 拡張機能
+1. 拠点ごとの特殊効果
+2. 防衛システム
+3. 複数拠点管理
+
+## 関連ドキュメント
+
+- [dungen_idea.md](./dungen_idea.md): 遠征先のアイデアとランクアップ候補
+- [project_structure.md](./project_structure.md): プロジェクト構成
+- [implementation_guide.md](./implementation_guide.md): 実装ガイド

--- a/goblin_native/docs/migration_tasks.md
+++ b/goblin_native/docs/migration_tasks.md
@@ -20,11 +20,11 @@
 | コアロジック (core/) | 完全 | 完全移植 | 100% |
 | 型定義 (shared/types/) | 完全 | 完全移植 | 100% |
 | データ (shared/data/) | 完全 | 完全移植 | 100% |
-| Repository | Firestore + Json | SQLite (設計完了/実装待ち) | 10% |
+| Repository | Firestore + Json | SQLite (主要Repository実装済み) | 90% |
 | Services (infrastructure) | 1ファイル | 0ファイル | 0% |
-| Context | 2ファイル | 2ファイル (簡略化) | 70% |
-| Hooks | 5ファイル | 5ファイル (簡略化) | 70% |
-| UIコンポーネント | 22ファイル (3,768行) | 11ファイル (1,790行/サンプル) | 10% |
+| Context | 2ファイル | 2ファイル（ExpeditionStateは簡略化） | 80% |
+| Hooks | 5ファイル | 主要HookはSQLite連携済み | 90% |
+| UIコンポーネント | 22ファイル (3,768行) | app配下で主要画面実装済み（改善余地あり） | 70% |
 
 ---
 
@@ -36,21 +36,21 @@
 |--------|---------------|------|------|--------|
 | 高 | GoblinDetailModal.tsx | 290 | ゴブリン詳細・装備管理・ステータス表示 | 中 |
 | 高 | FormationTabScreen.tsx | 382 | ビューモード管理・画面遷移制御 | 高 |
-| 高 | FormationScreen.tsx | 279 | パーティ一覧・遠征履歴表示 | 中 |
-| 高 | ExpeditionPlaybackScreen.tsx | 417 | 遠征リアルタイム再生・アニメーション | 高 |
-| 高 | ExpeditionPreparationScreen.tsx | 331 | 遠征準備・設定画面 | 中 |
+| 高 | FormationScreen.tsx | 279 | パーティ一覧・遠征履歴表示 | 中（基本実装済み、改善余地あり） |
+| 高 | ExpeditionPlaybackScreen.tsx | 417 | 遠征リアルタイム再生・アニメーション | 中（基本実装済み、再生制御は未対応） |
+| 高 | ExpeditionPreparationScreen.tsx | 331 | 遠征準備・設定画面 | 低（基本実装済み） |
 | 中 | ExpeditionLogScreen.tsx | 434 | 遠征ログ詳細表示 | 中 |
-| 中 | PartyEditScreen.tsx | 196 | パーティメンバー編集 | 低 |
-| 中 | ExpeditionResultScreen.tsx | 162 | 遠征結果・報酬表示 | 低 |
-| 中 | BaseManagementScreen.tsx | 301 | 拠点管理・ゴブリン受け入れ | 中 |
+| 中 | PartyEditScreen.tsx | 196 | パーティメンバー編集 | 低（実装済み） |
+| 中 | ExpeditionResultScreen.tsx | 162 | 遠征結果・報酬表示 | 低（実装済み、因子表示は未対応） |
+| 中 | BaseManagementScreen.tsx | 301 | 拠点管理・ゴブリン受け入れ | 低（実装済み） |
 | 中 | ExpeditionSetupScreen.tsx | 248 | 遠征設定（未使用の可能性あり） | 中 |
-| 低 | DungeonSelectionModal.tsx | 83 | ダンジョン選択モーダル | 低 |
-| 低 | DungeonConfirmModal.tsx | 63 | ダンジョン確認モーダル | 低 |
-| 低 | ReturnPolicySelectionModal.tsx | 78 | 帰還ポリシー選択モーダル | 低 |
+| 低 | DungeonSelectionModal.tsx | 83 | ダンジョン選択モーダル | 実装済み（画面内モーダルとして統合） |
+| 低 | DungeonConfirmModal.tsx | 63 | ダンジョン確認モーダル | 未実装 |
+| 低 | ReturnPolicySelectionModal.tsx | 78 | 帰還ポリシー選択モーダル | 実装済み（画面内モーダルとして統合） |
 | 低 | FloorTargetSelectionModal.tsx | 59 | 目標階層選択モーダル | 低 |
 | 低 | ExpeditionConfirmModal.tsx | 102 | 遠征開始確認モーダル | 低 |
 | 低 | FactorBadge.tsx | 77 | 因子バッジ表示 | 低 |
-| 低 | GoblinCard.tsx | 27 | ゴブリンカード（リスト用） | 低 |
+| 低 | GoblinCard.tsx | 27 | ゴブリンカード（リスト用） | 実装済み |
 | 低 | DungeonScreen.tsx | 70 | ダンジョン画面 | 低 |
 | 低 | PartySelectScreen.tsx | 68 | パーティ選択画面 | 低 |
 | 低 | GoblinListScreen.tsx | 56 | ゴブリン一覧画面 | 低 |
@@ -63,14 +63,14 @@
 
 | ファイル | 現在の行数 | 対応する goblin_web | 状態 |
 |----------|-----------|---------------------|------|
-| app/(tabs)/index.tsx | 252 | GoblinListScreen + GoblinDetailModal | サンプル実装 |
-| app/(tabs)/formation/index.tsx | 161 | FormationScreen | サンプル実装 |
-| app/(tabs)/formation/preparation.tsx | 183 | ExpeditionPreparationScreen | サンプル実装 |
-| app/(tabs)/formation/edit.tsx | 151 | PartyEditScreen | サンプル実装 |
-| app/(tabs)/formation/playback.tsx | 228 | ExpeditionPlaybackScreen | サンプル実装 |
-| app/(tabs)/formation/result.tsx | 190 | ExpeditionResultScreen | サンプル実装 |
+| app/(tabs)/index.tsx | 252 | GoblinListScreen + GoblinDetailModal | 基本実装済み（詳細機能差分あり） |
+| app/(tabs)/formation/index.tsx | 161 | FormationScreen | 基本実装済み |
+| app/(tabs)/formation/preparation.tsx | 183 | ExpeditionPreparationScreen | 基本実装済み |
+| app/(tabs)/formation/edit.tsx | 151 | PartyEditScreen | 基本実装済み |
+| app/(tabs)/formation/playback.tsx | 228 | ExpeditionPlaybackScreen | 基本実装済み（再生制御差分あり） |
+| app/(tabs)/formation/result.tsx | 190 | ExpeditionResultScreen | 基本実装済み（因子表示差分あり） |
 | app/(tabs)/formation/log.tsx | 122 | ExpeditionLogScreen | サンプル実装 |
-| app/(tabs)/base.tsx | 351 | BaseManagementScreen | サンプル実装 |
+| app/(tabs)/base.tsx | 351 | BaseManagementScreen | 基本実装済み |
 
 ---
 
@@ -83,12 +83,12 @@
 
 | Repository | SQLiteスキーマ | 実装 | 状態 |
 |------------|---------------|------|------|
-| GoblinRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
-| PartyRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
-| PendingGoblinRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
-| BaseStateRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
-| ExpeditionRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
-| DungeonProgressRepository | ✅ 設計完了 | ⬜ 未実装 | 実装待ち |
+| GoblinRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
+| PartyRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
+| PendingGoblinRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
+| BaseStateRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
+| ExpeditionRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
+| DungeonProgressRepository | ✅ 設計完了 | ✅ 実装済み | 運用中 |
 
 ### 2.2 Repository 実装タスク
 
@@ -101,7 +101,7 @@
   - src/infrastructure/database/schema.ts (スキーマ定義)
   - src/infrastructure/database/migrations/v1.ts (初期マイグレーション)
 
-□ SQLite Repository の実装
+□ SQLite Repository の追加改善
   - SQLiteGoblinRepository.ts
   - SQLitePartyRepository.ts
   - SQLitePendingGoblinRepository.ts
@@ -127,9 +127,9 @@
 ### 3.2 タスク
 
 ```
-□ DungeonProgressはSQLiteDungeonProgressRepositoryで管理
-  - useDungeonProgress.tsをSQLiteリポジトリに接続
-  - 現在は暫定的にAsyncStorageを使用中（TODO: 移行）
+□ DungeonProgressの運用改善
+  - useDungeonProgress.ts は SQLite リポジトリ連携済み
+  - 同期戦略/通知フローを必要に応じて拡張
 ```
 
 ---
@@ -147,10 +147,10 @@
 
 | Hook | goblin_web | goblin_native | 差分 |
 |------|------------|---------------|------|
-| useGoblinService | Json/Firestore 切替 | SQLite接続待ち | SQLite Repository 未実装 |
-| usePartyService | Json/Firestore 切替 | SQLite接続待ち | SQLite Repository 未実装 |
-| useExpeditionFlow | Firestore Repository 連携 | 簡略化 | SQLite Repository 未連携 |
-| useDungeonProgress | localStorage + Firestore | AsyncStorage (暫定) | SQLite移行待ち |
+| useGoblinService | Json/Firestore 切替 | SQLite連携済み | 同期レイヤー未実装 |
+| usePartyService | Json/Firestore 切替 | SQLite連携済み | 同期レイヤー未実装 |
+| useExpeditionFlow | Firestore Repository 連携 | SQLite連携済み | 詳細ログ/再生制御に改善余地 |
+| useDungeonProgress | localStorage + Firestore | SQLite連携済み | 通知/同期の改善余地 |
 | useCurrentTime | 完全 | 完全移植 | 同等 |
 
 ### 4.3 タスク
@@ -160,19 +160,13 @@
   - SQLiteExpeditionRepository との連携
   - リアルタイム更新対応
 
-□ useGoblinService をSQLiteに接続
-  - SQLiteGoblinRepository との連携
+□ useGoblinService / usePartyService / useDungeonProgress の運用改善
+  - いずれも SQLite 連携済み
+  - 監視・通知・同期方針を必要に応じて拡張
 
-□ usePartyService をSQLiteに接続
-  - SQLitePartyRepository との連携
-
-□ useDungeonProgress をSQLiteに移行
-  - 現在はAsyncStorage使用（暫定）
-  - SQLiteDungeonProgressRepository に切替
-
-□ useExpeditionFlow を完全実装
-  - 遠征開始・完了フロー
-  - SQLiteExpeditionRepository 連携
+□ useExpeditionFlow の機能拡張
+  - 遠征開始・完了フローは実装済み
+  - 詳細ログ連携と再生制御の強化
 ```
 
 ---
@@ -457,19 +451,19 @@ const sampleGoblins: Goblin[] = [
 | src/shared/data/** | src/shared/data/** | ✅ 完全移植 |
 | src/shared/constants/** | src/shared/constants/** | ✅ 完全移植 |
 | src/config/firebase.ts | src/config/firebase.ts | ✅ 移植済み（RN対応） |
-| src/infrastructure/repositories/Firestore*.ts | SQLite版を新規作成 | ⚠️ SQLite版設計完了/実装待ち |
+| src/infrastructure/repositories/Firestore*.ts | SQLite版を新規作成 | ✅ SQLite版実装済み（継続改善） |
 | src/infrastructure/repositories/Json*.ts | SQLite版で代替 | ❌ 不要 |
 | src/infrastructure/services/FirestoreDungeonProgressService.ts | SQLite版で代替 | ❌ 不要 |
-| - | src/infrastructure/database/ | ⚠️ 新規作成待ち |
-| - | src/infrastructure/repositories/SQLite*.ts | ⚠️ 新規作成待ち |
+| - | src/infrastructure/database/ | ✅ 実装済み |
+| - | src/infrastructure/repositories/SQLite*.ts | ✅ 実装済み |
 | src/presentation/contexts/AuthContext.tsx | src/presentation/contexts/AuthContext.tsx | ✅ 移植済み |
 | src/presentation/contexts/ExpeditionStateContext.tsx | src/presentation/contexts/ExpeditionStateContext.tsx | ⚠️ 簡略化 |
-| src/presentation/hooks/useGoblinService.ts | src/presentation/hooks/useGoblinService.ts | ⚠️ SQLite接続待ち |
-| src/presentation/hooks/usePartyService.ts | src/presentation/hooks/usePartyService.ts | ⚠️ SQLite接続待ち |
-| src/presentation/hooks/useExpeditionFlow.ts | src/presentation/hooks/useExpeditionFlow.ts | ⚠️ 簡略化 |
-| src/presentation/hooks/useDungeonProgress.ts | src/presentation/hooks/useDungeonProgress.ts | ⚠️ AsyncStorage暫定/SQLite移行待ち |
+| src/presentation/hooks/useGoblinService.ts | src/presentation/hooks/useGoblinService.ts | ✅ SQLite連携済み |
+| src/presentation/hooks/usePartyService.ts | src/presentation/hooks/usePartyService.ts | ✅ SQLite連携済み |
+| src/presentation/hooks/useExpeditionFlow.ts | src/presentation/hooks/useExpeditionFlow.ts | ⚠️ SQLite連携済み（機能改善余地） |
+| src/presentation/hooks/useDungeonProgress.ts | src/presentation/hooks/useDungeonProgress.ts | ✅ SQLite連携済み |
 | src/presentation/hooks/useCurrentTime.ts | src/presentation/hooks/useCurrentTime.ts | ✅ 完全移植 |
-| src/presentation/components/*.tsx (22ファイル) | app/(tabs)/*.tsx (11ファイル) | ❌ サンプル実装のみ |
+| src/presentation/components/*.tsx (22ファイル) | app/(tabs)/*.tsx (11ファイル) | ⚠️ 主要画面実装済み（機能差分あり） |
 
 ---
 

--- a/goblin_native/docs/remaining_tasks.md
+++ b/goblin_native/docs/remaining_tasks.md
@@ -20,28 +20,28 @@ Web版(goblin_web)とReact Native版(goblin_native)の差異を解消するた�
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | Web: 6人、Native: 4人 |
+| 現状 | Web: 6人、Native: 6人（統一済み） |
 | 対象ファイル | `app/(tabs)/formation/edit.tsx` |
-| 作業内容 | `MAX_PARTY_SIZE` を6に変更、UIを6スロット表示に対応 |
+| 作業内容 | 対応済み（`MAX_PARTY_SIZE = 6`、UI 6スロット対応） |
 | 参照 | `goblin_web/src/presentation/components/PartyEditScreen.tsx` |
 
 ### 1.2 ExpeditionEngine の移植
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | Native版はランダム生成の仮実装 |
-| 対象ファイル | 新規: `src/core/services/ExpeditionEngine.ts` |
-| 作業内容 | Web版のExpeditionEngineをReact Native用に移植 |
+| 現状 | 実装済み（`ExpeditionEngine.ts` あり） |
+| 対象ファイル | `src/core/services/ExpeditionEngine.ts` |
+| 作業内容 | 移植後の挙動調整・テスト強化を継続 |
 | 参照 | `goblin_web/src/core/services/ExpeditionEngine.ts` |
-| 依存 | BattleSystem.tsも移植が必要 |
+| 依存 | BattleSystem.ts は実装済み |
 
 ### 1.3 遠征プレイバックの完全実装
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | 固定イベントのシミュレーション表示 |
+| 現状 | `replay` ベースの再生実装済み（改善余地あり） |
 | 対象ファイル | `app/(tabs)/formation/playback.tsx` |
-| 作業内容 | ExpeditionEngine を使用した本格的なリプレイ再生 |
+| 作業内容 | 追加改善（再生制御や演出） |
 | 参照 | `goblin_web/src/presentation/components/ExpeditionPlaybackScreen.tsx` (417行) |
 
 ---
@@ -70,9 +70,9 @@ Web版(goblin_web)とReact Native版(goblin_native)の差異を解消するた�
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | 表示なし |
+| 現状 | 実装済み（推定探索時間を表示） |
 | 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
-| 作業内容 | ダンジョン・パーティ構成から推定時間を計算して表示 |
+| 作業内容 | 必要に応じて表示文言/単位を調整 |
 | 参照 | `goblin_web/src/presentation/components/ExpeditionPreparationScreen.tsx` |
 
 ### 2.4 因子獲得表示
@@ -101,9 +101,9 @@ Web版(goblin_web)とReact Native版(goblin_native)の差異を解消するた�
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | 簡易表示 |
+| 現状 | 実装済み（イベント進行に応じて更新） |
 | 対象ファイル | `app/(tabs)/formation/playback.tsx` |
-| 作業内容 | 各メンバーのHP/最大HPをリアルタイム更新表示 |
+| 作業内容 | 表示精度/演出の改善を検討 |
 
 ### 3.2 緊急帰還ボタン
 
@@ -117,25 +117,25 @@ Web版(goblin_web)とReact Native版(goblin_native)の差異を解消するた�
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | ScrollView内に統合 |
+| 現状 | モーダル化済み |
 | 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
-| 作業内容 | Web版と同様にモーダルで選択する形式に変更（任意） |
+| 作業内容 | 対応済み（任意改善のみ） |
 | 参照 | `goblin_web/src/presentation/components/DungeonSelectionModal.tsx` (83行) |
 
 ### 3.4 帰還ポリシー選択モーダル化
 
 | 項目 | 内容 |
 |-----|------|
-| 現状 | ScrollView内に統合 |
+| 現状 | モーダル化済み |
 | 対象ファイル | `app/(tabs)/formation/preparation.tsx` |
-| 作業内容 | Web版と同様にモーダルで選択する形式に変更（任意） |
+| 作業内容 | 対応済み（任意改善のみ） |
 | 参照 | `goblin_web/src/presentation/components/ReturnPolicySelectionModal.tsx` (78行) |
 
 ---
 
 ## コア移植タスク（優先度1の前提）
 
-ExpeditionEngineを動作させるために必要なコアロジックの移植：
+ExpeditionEngineを動作させるために必要なコアロジックは移植済みです。
 
 | ファイル | 行数 | 説明 |
 |---------|------|------|
@@ -148,10 +148,10 @@ ExpeditionEngineを動作させるために必要なコアロジックの移植�
 
 ```
 src/core/services/
-├── ExpeditionEngine.ts      ← 移植
-├── BattleSystem.ts          ← 移植
-├── ExperienceSystem.ts      ← 移植
-└── GoblinBirthService.ts    ← 移植
+├── ExpeditionEngine.ts      ← 実装済み
+├── BattleSystem.ts          ← 実装済み
+├── ExperienceSystem.ts      ← 実装済み
+└── GoblinBirthService.ts    ← 実装済み
 ```
 
 ---
@@ -159,23 +159,16 @@ src/core/services/
 ## 実装順序推奨
 
 ```
-Step 1: コアサービス移植
-  └── BattleSystem.ts
-  └── ExpeditionEngine.ts
-  └── ExperienceSystem.ts
-
-Step 2: 遠征プレイバック完全実装
-  └── playback.tsx を ExpeditionEngine 連携に書き換え
-
-Step 3: 遠征ログ完全実装
+Step 1: 遠征ログ完全実装
   └── log.tsx を replay データ表示に書き換え
 
-Step 4: パーティ人数統一
-  └── edit.tsx の MAX_PARTY_SIZE を 6 に変更
-
-Step 5: その他機能追加
+Step 2: 再生制御機能の追加
   └── 再生制御
-  └── 推定時間表示
+
+Step 3: 目標階層UIの拡張
+  └── 目標階層選択モーダル
+
+Step 4: 結果画面の報酬詳細化
   └── 因子獲得表示
 ```
 
@@ -184,22 +177,22 @@ Step 5: その他機能追加
 ## 完了条件チェックリスト
 
 ### 優先度1
-- [ ] パーティ最大人数が Web/Native で統一されている
-- [ ] ExpeditionEngine が Native で動作する
-- [ ] 遠征プレイバックが ExpeditionEngine ベースで動作する
+- [x] パーティ最大人数が Web/Native で統一されている
+- [x] ExpeditionEngine が Native で動作する
+- [x] 遠征プレイバックが ExpeditionEngine ベースで動作する
 
 ### 優先度2
 - [ ] 遠征ログが実際の replay データを表示する
 - [ ] 再生制御（一時停止・スキップ・速度変更）が動作する
-- [ ] 推定探索時間が表示される
+- [x] 推定探索時間が表示される
 - [ ] 因子獲得が結果画面に表示される
 - [ ] 目標階層選択が独立したUIで選択可能
 
 ### 優先度3
-- [ ] パーティHP がリアルタイム更新表示される
+- [x] パーティHP がリアルタイム更新表示される
 - [ ] 緊急帰還ボタンが動作する
-- [ ] ダンジョン選択がモーダル化されている（任意）
-- [ ] 帰還ポリシー選択がモーダル化されている（任意）
+- [x] ダンジョン選択がモーダル化されている（任意）
+- [x] 帰還ポリシー選択がモーダル化されている（任意）
 
 ---
 

--- a/goblin_native/docs/screen_reference.md
+++ b/goblin_native/docs/screen_reference.md
@@ -25,12 +25,12 @@
 - `formation/index` → `formation/preparation`（待機パーティを選択）
 - `formation/index` → `formation/playback`（遠征中パーティを選択）
 - `formation/index` → `formation/result`（履歴の完了分を選択）
+- `formation/index` → `formation/playback`（履歴の進行中分を選択）
 - `formation/preparation` → `formation/edit`（メンバー編集）
 - `formation/preparation` → `formation`（出撃完了後に戻る）
 - `formation/playback` → `formation/battle-log`（戦闘詳細ログ）
 - `formation/playback` → `formation`（戻る）
 - `formation/result` → `formation`（メニューに戻る）
-- `formation/log` → `formation`（戻る）
 
 ## 画面遷移の詳細条件（補足）
 ### Formation 一覧からの分岐
@@ -60,6 +60,7 @@
 - `formation/result` → `formation`（「メニューに戻る」）
 - `formation/log` → `formation`（戻る）
 - `formation/battle-log` → `formation/playback`（戻る）
+  - `canGoBack()` が false の場合は `formation/playback` に `replace`。
 
 ### List / Base
 - List: 一覧 → 詳細モーダル（閉じるで一覧へ）
@@ -152,6 +153,7 @@
 - UI概要:
   - ダンジョン階層に応じた疑似ログを生成表示。
 - 補足: 実ログは未接続（ExpeditionRepository連携予定）。
+- 補足: 現在は `formation/index` からの導線は未接続（必要時に直接遷移で利用）。
 
 ### 戦闘ログ
 - ルート: `/(tabs)/formation/battle-log` → `app/(tabs)/formation/battle-log.tsx`
@@ -176,7 +178,7 @@
   - 次エリア解放メッセージ。
 
 ## メモ
-- 現時点の `src/presentation/components/` は空で、画面は `app/` 直下に実装されています。
+- 画面の主実装は `app/` 直下です。`src/presentation/components/` には `GoblinCard.tsx` があります。
 - 画面側のロジックは `presentation/hooks` に分散しています。
 
 ## 主要イベントとデータ更新対応表（概要）

--- a/goblin_native/src/core/services/BaseRankSystem.ts
+++ b/goblin_native/src/core/services/BaseRankSystem.ts
@@ -1,0 +1,254 @@
+import type { BaseRankConfig, BaseState, RankUpCheckResult } from '../../shared/types/BaseState'
+
+/**
+ * 拠点ランク設定
+ */
+export const BASE_RANK_CONFIGS: BaseRankConfig[] = [
+  {
+    rank: 1,
+    maxParties: 1,
+    maxGoblins: 10,
+    ivBonus: 0,
+    upgradeCost: 0,  // 初期ランク
+    unlockCondition: { dungeonId: 'initial' },
+  },
+  {
+    rank: 2,
+    maxParties: 2,
+    maxGoblins: 20,
+    ivBonus: 2,
+    upgradeCost: 100,  // ランク2への引っ越し資金
+    unlockCondition: {
+      dungeonId: 'goblin_village',  // ゴブリン集落（既存）
+      clearCount: 1,
+    },
+  },
+  {
+    rank: 3,
+    maxParties: 3,
+    maxGoblins: 35,
+    ivBonus: 4,
+    upgradeCost: 500,  // ランク3への引っ越し資金
+    unlockCondition: {
+      dungeonId: 'orc_camp',  // オークの野営地（既存）
+      clearCount: 1,
+    },
+  },
+  {
+    rank: 4,
+    maxParties: 4,
+    maxGoblins: 50,
+    ivBonus: 6,
+    upgradeCost: 1500,
+    unlockCondition: {
+      dungeonId: 'trade_checkpoint', // 将来追加予定
+      clearCount: 1,
+    },
+  },
+  {
+    rank: 5,
+    maxParties: 5,
+    maxGoblins: 70,
+    ivBonus: 8,
+    upgradeCost: 4000,
+    unlockCondition: {
+      dungeonId: 'dwarf_mine', // 将来追加予定
+      clearCount: 1,
+    },
+  },
+  {
+    rank: 6,
+    maxParties: 6,
+    maxGoblins: 100,
+    ivBonus: 10,
+    upgradeCost: 10000,
+    unlockCondition: {
+      dungeonId: 'human_fortress', // 将来追加予定
+      clearCount: 1,
+    },
+  },
+  {
+    rank: 7,
+    maxParties: 8,
+    maxGoblins: 150,
+    ivBonus: 12,
+    upgradeCost: 25000,
+    unlockCondition: {
+      dungeonId: 'royal_capital', // 将来追加予定
+      clearCount: 1,
+    },
+  },
+]
+
+/**
+ * エリアレベルごとのベース個体値範囲
+ */
+export const AREA_LEVEL_IV_RANGES: Record<number, [number, number]> = {
+  1: [1, 8],      // 序盤（スライム洞窟、周辺の森）
+  2: [6, 14],     // 初期中盤（ゴブリン集落、盗賊のアジト、ハーフリング農村）
+  3: [12, 20],    // 中盤（交易路の関所、小さな鉱山、沼地の見張り小屋）
+  4: [18, 28],    // 中盤後期（ドワーフ坑道、オークキャンプ、アンデッド墳墓）
+  5: [26, 36],    // 上級（リザードマン集落、ハーピーの崖巣、トロルの峡谷）
+  6: [34, 44],    // 終盤（ミノタウロス迷宮、吸血鬼の古城、ドラゴンの火山巣）
+  7: [42, 52],    // 最終盤（人間の街塞、騎士団本部、学術都市）
+  8: [50, 60],    // 最終決戦（王都防衛戦）
+}
+
+/**
+ * 拠点ランクボーナス
+ */
+export const BASE_RANK_BONUS: Record<number, number> = {
+  1: 0,
+  2: 2,
+  3: 4,
+  4: 6,
+  5: 8,
+  6: 10,
+  7: 12,
+}
+
+/**
+ * 個体値を計算する
+ * @param areaLevel ダンジョンのエリアレベル（1-8）
+ * @param baseRank 拠点ランク（1-7）
+ * @param random 乱数生成関数（0-1）
+ * @returns 最終個体値（1-64）
+ */
+export function calculateIndividualValue(
+  areaLevel: number,
+  baseRank: number,
+  random: () => number
+): number {
+  // エリアレベルのベース範囲を取得
+  const [min, max] = AREA_LEVEL_IV_RANGES[areaLevel] || [1, 8]
+  const baseIV = Math.floor(min + (max - min) * random())
+
+  // 拠点ランクボーナスを加算
+  const bonus = BASE_RANK_BONUS[baseRank] || 0
+  const finalIV = baseIV + bonus
+
+  // 1-64にクランプ
+  return Math.max(1, Math.min(64, finalIV))
+}
+
+/**
+ * ランクアップ可能かチェックする
+ * @param baseState 拠点状態
+ * @returns ランクアップ可否チェック結果
+ */
+export function checkRankUpAvailable(baseState: BaseState): RankUpCheckResult {
+  const nextConfig = BASE_RANK_CONFIGS.find((c) => c.rank === baseState.rank + 1)
+  if (!nextConfig) {
+    return { canRankUp: false }
+  }
+
+  const hasCaptured = baseState.capturedDungeons.includes(
+    nextConfig.unlockCondition.dungeonId
+  )
+
+  if (!hasCaptured) {
+    return {
+      canRankUp: false,
+      requirement: `${nextConfig.unlockCondition.dungeonId}を制圧する必要があります`,
+      nextRank: nextConfig.rank,
+    }
+  }
+
+  return { canRankUp: true, nextRank: nextConfig.rank }
+}
+
+/**
+ * ダンジョン制圧を記録する（ランクアップは行わない）
+ * @param dungeonId 制圧したダンジョンID
+ * @param baseState 現在の拠点状態
+ * @returns 更新後の拠点状態
+ */
+export function captureDungeon(
+  dungeonId: string,
+  baseState: BaseState
+): BaseState {
+  // 制圧済みリストに追加
+  const capturedDungeons = baseState.capturedDungeons.includes(dungeonId)
+    ? baseState.capturedDungeons
+    : [...baseState.capturedDungeons, dungeonId]
+
+  return {
+    ...baseState,
+    capturedDungeons,
+  }
+}
+
+/**
+ * ランクアップを実行する（ゴールドを消費）
+ * @param baseState 現在の拠点状態
+ * @returns 更新後の拠点状態、またはエラー
+ */
+export function performRankUp(
+  baseState: BaseState
+): { success: true; state: BaseState } | { success: false; error: string } {
+  const { canRankUp, nextRank, requirement } = checkRankUpAvailable(baseState)
+
+  if (!canRankUp) {
+    return {
+      success: false,
+      error: requirement || 'ランクアップできません',
+    }
+  }
+
+  if (!nextRank) {
+    return {
+      success: false,
+      error: '次のランクが見つかりません',
+    }
+  }
+
+  const nextConfig = BASE_RANK_CONFIGS.find((c) => c.rank === nextRank)
+  if (!nextConfig) {
+    return {
+      success: false,
+      error: 'ランク設定が見つかりません',
+    }
+  }
+
+  // ゴールドが足りるかチェック
+  if (baseState.gold < nextConfig.upgradeCost) {
+    return {
+      success: false,
+      error: `ゴールドが不足しています（必要: ${nextConfig.upgradeCost}G、所持: ${baseState.gold}G）`,
+    }
+  }
+
+  // ランクアップを実行
+  const updatedState: BaseState = {
+    ...baseState,
+    rank: nextRank,
+    currentMaxParties: nextConfig.maxParties,
+    currentMaxGoblins: nextConfig.maxGoblins,
+    currentIVBonus: nextConfig.ivBonus,
+    capacity: nextConfig.maxGoblins,
+    gold: baseState.gold - nextConfig.upgradeCost,
+  }
+
+  return {
+    success: true,
+    state: updatedState,
+  }
+}
+
+/**
+ * 初期の拠点状態を生成する
+ * @returns 初期拠点状態
+ */
+export function createInitialBaseState(): BaseState {
+  const initialConfig = BASE_RANK_CONFIGS[0]
+  return {
+    rank: initialConfig.rank,
+    capacity: initialConfig.maxGoblins,
+    nextGoblinId: 1,
+    capturedDungeons: [],
+    currentMaxParties: initialConfig.maxParties,
+    currentMaxGoblins: initialConfig.maxGoblins,
+    currentIVBonus: initialConfig.ivBonus,
+    gold: 500,  // 初期ゴールド（テスト用に少し多めに設定）
+  }
+}

--- a/goblin_native/src/infrastructure/database/migrations/v3.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v3.ts
@@ -1,0 +1,52 @@
+/**
+ * スキーママイグレーション (v3)
+ * base_state に拠点ランクシステム用のカラムを追加
+ */
+import type * as SQLite from 'expo-sqlite'
+
+export const migrateV3 = async (db: SQLite.SQLiteDatabase): Promise<void> => {
+  const columns = await db.getAllAsync<{ name: string }>(
+    "PRAGMA table_info('base_state')"
+  )
+
+  // 各カラムが存在するかチェック
+  const hasCapturedDungeons = columns.some(column => column.name === 'captured_dungeons_json')
+  const hasCurrentMaxParties = columns.some(column => column.name === 'current_max_parties')
+  const hasCurrentMaxGoblins = columns.some(column => column.name === 'current_max_goblins')
+  const hasCurrentIVBonus = columns.some(column => column.name === 'current_iv_bonus')
+
+  // カラムを追加（存在しない場合のみ）
+  if (!hasCapturedDungeons) {
+    await db.execAsync(
+      "ALTER TABLE base_state ADD COLUMN captured_dungeons_json TEXT NOT NULL DEFAULT '[]'"
+    )
+  }
+
+  if (!hasCurrentMaxParties) {
+    await db.execAsync(
+      'ALTER TABLE base_state ADD COLUMN current_max_parties INTEGER NOT NULL DEFAULT 1'
+    )
+  }
+
+  if (!hasCurrentMaxGoblins) {
+    await db.execAsync(
+      'ALTER TABLE base_state ADD COLUMN current_max_goblins INTEGER NOT NULL DEFAULT 10'
+    )
+  }
+
+  if (!hasCurrentIVBonus) {
+    await db.execAsync(
+      'ALTER TABLE base_state ADD COLUMN current_iv_bonus INTEGER NOT NULL DEFAULT 0'
+    )
+  }
+
+  // goldカラムを追加
+  const hasGold = columns.some(column => column.name === 'gold')
+  if (!hasGold) {
+    await db.execAsync(
+      'ALTER TABLE base_state ADD COLUMN gold INTEGER NOT NULL DEFAULT 0'
+    )
+  }
+
+  console.log('[Migration v3] Base state table migration completed')
+}

--- a/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
@@ -5,18 +5,29 @@
 import type { BaseState } from '../../shared/types'
 import type { IBaseStateRepository } from '../../core/repositories/IBaseStateRepository'
 import { getDatabase } from '../database'
+import { BASE_RANK_CONFIGS } from '../../core/services/BaseRankSystem'
 
 interface BaseStateRow {
   id: number
   capacity: number
   rank: number
+  captured_dungeons_json: string
+  current_max_parties: number
+  current_max_goblins: number
+  current_iv_bonus: number
+  gold: number
   updated_at: string
 }
 
 const DEFAULT_BASE_STATE: BaseState = {
-  capacity: 8,
+  capacity: 10,
   rank: 1,
   nextGoblinId: 1,
+  capturedDungeons: [],
+  currentMaxParties: 1,
+  currentMaxGoblins: 10,
+  currentIVBonus: 0,
+  gold: 500,
 }
 
 export class SQLiteBaseStateRepository implements IBaseStateRepository {
@@ -50,6 +61,11 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
         capacity: row.capacity,
         rank: row.rank,
         nextGoblinId: await this.getNextGoblinId(),
+        capturedDungeons: JSON.parse(row.captured_dungeons_json || '[]'),
+        currentMaxParties: row.current_max_parties,
+        currentMaxGoblins: row.current_max_goblins,
+        currentIVBonus: row.current_iv_bonus,
+        gold: row.gold,
       }
     } else {
       // 初期データがない場合は作成
@@ -80,14 +96,26 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
 
   /**
    * 拠点のランクを上げる
+   * @deprecated 代わりに BaseRankSystem.captureDungeon を使用してください
    */
   upgradeRank(): void {
     if (!this.cache) return
 
+    const nextRank = this.cache.rank + 1
+    const nextConfig = BASE_RANK_CONFIGS.find((c) => c.rank === nextRank)
+
+    if (!nextConfig) {
+      console.warn('[SQLiteBaseStateRepository] Cannot upgrade: max rank reached')
+      return
+    }
+
     const newState: BaseState = {
       ...this.cache,
-      rank: this.cache.rank + 1,
-      capacity: this.cache.capacity + 4, // ランクアップごとに容量+4
+      rank: nextRank,
+      capacity: nextConfig.maxGoblins,
+      currentMaxParties: nextConfig.maxParties,
+      currentMaxGoblins: nextConfig.maxGoblins,
+      currentIVBonus: nextConfig.ivBonus,
     }
 
     this.saveBaseState(newState)
@@ -110,9 +138,20 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
   private async saveAsync(state: BaseState): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
-      `INSERT OR REPLACE INTO base_state (id, capacity, rank, updated_at)
-       VALUES (1, ?, ?, datetime('now'))`,
-      [state.capacity, state.rank]
+      `INSERT OR REPLACE INTO base_state (
+        id, capacity, rank, captured_dungeons_json,
+        current_max_parties, current_max_goblins, current_iv_bonus, gold, updated_at
+      )
+       VALUES (1, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      [
+        state.capacity,
+        state.rank,
+        JSON.stringify(state.capturedDungeons),
+        state.currentMaxParties,
+        state.currentMaxGoblins,
+        state.currentIVBonus,
+        state.gold,
+      ]
     )
   }
 

--- a/goblin_native/src/presentation/hooks/useBaseState.ts
+++ b/goblin_native/src/presentation/hooks/useBaseState.ts
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { BaseState } from '@/shared/types'
 import { SQLiteBaseStateRepository } from '@/infrastructure/repositories'
+import { performRankUp as executeRankUp } from '@/core/services/BaseRankSystem'
 
 const getRepository = (): SQLiteBaseStateRepository => {
   return SQLiteBaseStateRepository.getInstance()
@@ -53,13 +54,34 @@ export function useBaseState() {
     setBaseState(newState)
   }, [baseState])
 
+  // ランクアップを実行
+  const performRankUp = useCallback(() => {
+    if (!repositoryRef.current || !baseState) {
+      return { success: false, error: '拠点状態が読み込まれていません' }
+    }
+
+    const result = executeRankUp(baseState)
+    if (result.success) {
+      repositoryRef.current.saveBaseState(result.state)
+      setBaseState(result.state)
+    }
+
+    return result
+  }, [baseState])
+
   return {
     baseState,
     isLoading,
     upgradeRank,
     getNextGoblinId,
     updateBaseState,
-    capacity: baseState?.capacity ?? 8,
+    performRankUp,
+    capacity: baseState?.capacity ?? 10,
     rank: baseState?.rank ?? 1,
+    baseStateRepository: repositoryRef.current!,
+    maxParties: baseState?.currentMaxParties ?? 1,
+    maxGoblins: baseState?.currentMaxGoblins ?? 10,
+    ivBonus: baseState?.currentIVBonus ?? 0,
+    gold: baseState?.gold ?? 0,
   }
 }

--- a/goblin_native/src/shared/data/expeditionArea/allArea.json
+++ b/goblin_native/src/shared/data/expeditionArea/allArea.json
@@ -31,7 +31,9 @@
       "exploration_time_sec": 40,
       "description": "かつての支配者・ホブゴブリンが君臨する集落。独立を勝ち取るため、反逆の狼煙を上げる。",
       "unlockRequires": "forest_outskirts",
-      "unlockNext": "orc_camp"
+      "unlockNext": "orc_camp",
+      "isBaseCapture": true,
+      "rankUpTarget": 2
     },
     {
       "id": "orc_camp",
@@ -41,7 +43,9 @@
       "exploration_time_sec_first": 90,
       "exploration_time_sec": 45,
       "description": "オーク族が占拠した野営地。序盤の大きな壁となる強敵が待ち受ける。攻略すれば拠点として利用可能。",
-      "unlockRequires": "goblin_village"
+      "unlockRequires": "goblin_village",
+      "isBaseCapture": true,
+      "rankUpTarget": 3
     }
   ]
 }

--- a/goblin_native/src/shared/types/BaseState.ts
+++ b/goblin_native/src/shared/types/BaseState.ts
@@ -1,5 +1,37 @@
+/**
+ * 拠点の状態を表す型
+ */
 export type BaseState = {
-  capacity: number
-  rank: number
-  nextGoblinId?: number
+  capacity: number                 // 収容可能なゴブリン数（互換性のため残す、currentMaxGoblinsと同じ）
+  rank: number                     // 現在の拠点ランク（1-7）
+  nextGoblinId?: number            // 次のゴブリンID
+  capturedDungeons: string[]       // 制圧済みダンジョンIDのリスト
+  currentMaxParties: number        // 現在の最大パーティ数
+  currentMaxGoblins: number        // 現在の最大ゴブリン数
+  currentIVBonus: number           // 現在の個体値ボーナス
+  gold: number                     // 所持ゴールド
+}
+
+/**
+ * 拠点ランク設定
+ */
+export interface BaseRankConfig {
+  rank: number                     // ランク（1-7）
+  maxParties: number               // 編成可能なパーティ数
+  maxGoblins: number               // 収容可能なゴブリン数
+  ivBonus: number                  // 個体値ボーナス
+  upgradeCost: number              // ランクアップに必要なゴールド
+  unlockCondition: {
+    dungeonId: string              // 制圧する必要のあるダンジョンID
+    clearCount?: number            // 必要なクリア回数（デフォルト1）
+  }
+}
+
+/**
+ * ランクアップ可否チェック結果
+ */
+export interface RankUpCheckResult {
+  canRankUp: boolean
+  requirement?: string
+  nextRank?: number
 }

--- a/goblin_native/src/shared/types/Dungeon.ts
+++ b/goblin_native/src/shared/types/Dungeon.ts
@@ -11,4 +11,7 @@ export type Dungeon = {
   difficulty?: string
   unlockNext?: string
   unlockRequires?: string
+  areaLevel?: number                // エリアレベル（1-8）、個体値計算に使用
+  isBaseCapture?: boolean           // 拠点化可能か
+  rankUpTarget?: number             // このダンジョン制圧で到達するランク
 }


### PR DESCRIPTION
## Summary
- ダンジョン制圧に基づく拠点ランクアップシステム（ランク1〜7）を実装
- ランクアップでパーティ上限・ゴブリン収容数・個体値ボーナスが増加
- BaseState型拡張、DBマイグレーションv3、ランクアップUI（確認ダイアログ・コスト表示）

## Test plan
- [ ] 拠点画面でランク情報が正しく表示されること
- [ ] ランクアップ条件（ダンジョン制圧・ゴールド）を満たした状態でランクアップできること
- [ ] DBマイグレーションv3が正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)