### PR TITLE
refactor: リポジトリのキャッシュ層削除とDB直接読み書き化

### DIFF
--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -75,22 +75,22 @@ export default function BaseManagementScreen() {
     })
   }, [])
 
-  const addSelectedGoblins = useCallback(() => {
+  const addSelectedGoblins = useCallback(async () => {
     if (!canAddSelected) return
     const selectedGoblins = pendingGoblins.filter(g => selectedGoblinIds.has(g.id))
-    selectedGoblins.forEach(goblin => {
-      saveGoblin(goblin)
-      removePendingGoblin(goblin.id)
-    })
+    for (const goblin of selectedGoblins) {
+      await saveGoblin(goblin)
+      await removePendingGoblin(goblin.id)
+    }
     setSelectedGoblinIds(new Set())
   }, [canAddSelected, pendingGoblins, selectedGoblinIds, saveGoblin, removePendingGoblin])
 
-  const dismissSelectedGoblins = useCallback(() => {
+  const dismissSelectedGoblins = useCallback(async () => {
     if (selectedCount === 0) return
     const selectedGoblins = pendingGoblins.filter(g => selectedGoblinIds.has(g.id))
-    selectedGoblins.forEach(goblin => {
-      removePendingGoblin(goblin.id)
-    })
+    for (const goblin of selectedGoblins) {
+      await removePendingGoblin(goblin.id)
+    }
     setSelectedGoblinIds(new Set())
   }, [pendingGoblins, selectedGoblinIds, selectedCount, removePendingGoblin])
 
@@ -104,9 +104,9 @@ export default function BaseManagementScreen() {
         { text: 'キャンセル', style: 'cancel' },
         {
           text: 'ランクアップ',
-          onPress: () => {
+          onPress: async () => {
             setIsRankingUp(true)
-            const result = performRankUp()
+            const result = await performRankUp()
             setIsRankingUp(false)
 
             if (result.success) {
@@ -126,7 +126,7 @@ export default function BaseManagementScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      refreshPendingGoblins()
+      void refreshPendingGoblins()
     }, [refreshPendingGoblins])
   )
 

--- a/goblin_native/app/(tabs)/formation/edit.tsx
+++ b/goblin_native/app/(tabs)/formation/edit.tsx
@@ -5,7 +5,7 @@ import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { GoblinCard } from '@/presentation/components/GoblinCard'
-import type { Goblin } from '@/shared/types'
+import type { Goblin, Party } from '@/shared/types'
 
 const MAX_PARTY_SIZE = 6
 
@@ -63,14 +63,14 @@ export default function PartyEditScreen() {
   const { parties, isLoading: partiesLoading, updateMembers, getPartyById, refreshParties } = usePartyService()
   const { goblins, isLoading: goblinsLoading } = useGoblinService()
   const [retryCount, setRetryCount] = useState(0)
+  const [party, setParty] = useState<Party | null>(null)
 
-  const party = useMemo(() => {
-    if (!partyId) return null
-    try {
-      return getPartyById(parseInt(partyId, 10))
-    } catch {
-      return null
+  useEffect(() => {
+    if (!partyId) {
+      setParty(null)
+      return
     }
+    void getPartyById(parseInt(partyId, 10)).then(p => setParty(p)).catch(() => setParty(null))
   }, [partyId, parties, getPartyById])
 
   // パーティが見つからない場合にリトライ
@@ -173,9 +173,9 @@ export default function PartyEditScreen() {
     }
   }, [selectedMemberIds, selectedSlotIndex, assignedToOtherParty])
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     if (!partyId) return
-    updateMembers(parseInt(partyId, 10), selectedMemberIds)
+    await updateMembers(parseInt(partyId, 10), selectedMemberIds)
     router.back()
   }, [partyId, selectedMemberIds, updateMembers])
 

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -155,7 +155,7 @@ export default function FormationScreen() {
   useFocusEffect(
     useCallback(() => {
       void refreshParties()
-      refreshGoblins()
+      void refreshGoblins()
     }, [refreshParties, refreshGoblins])
   )
 
@@ -171,10 +171,10 @@ export default function FormationScreen() {
   }, [maxPartyCount, parties])
 
 
-  const handlePartyPress = useCallback((party: Party | null, index: number) => {
+  const handlePartyPress = useCallback(async (party: Party | null, index: number) => {
     if (!party) {
       // パーティがない場合は新規作成して遷移
-      const newParty = createParty({
+      const newParty = await createParty({
         name: `PT${index + 1}`,
         memberIds: [],
       })

--- a/goblin_native/app/(tabs)/formation/log.tsx
+++ b/goblin_native/app/(tabs)/formation/log.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useState, useEffect } from 'react'
 import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -36,9 +36,14 @@ export default function ExpeditionLogScreen() {
   const { getPartyById } = usePartyService()
   const { dungeons } = useDungeonProgress()
 
-  const party = useMemo(() => {
-    if (!partyId) return null
-    return getPartyById(parseInt(partyId, 10))
+  const [party, setParty] = useState<Awaited<ReturnType<typeof getPartyById>> | null>(null)
+
+  useEffect(() => {
+    if (!partyId) {
+      setParty(null)
+      return
+    }
+    void getPartyById(parseInt(partyId, 10)).then(p => setParty(p)).catch(() => setParty(null))
   }, [partyId, getPartyById])
 
   const dungeon = useMemo(() => {

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -11,7 +11,7 @@ import { useBaseState } from '@/presentation/hooks/useBaseState'
 import { CompleteExpeditionUseCase } from '@/core/usecases'
 import { GoblinBirthService } from '@/core/services'
 import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
-import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason } from '@/shared/types'
+import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason, Party } from '@/shared/types'
 import type { BattleLogEntry } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
@@ -42,14 +42,23 @@ export default function ExpeditionPlaybackScreen() {
     isLoading: isExpeditionLoading,
   } = useExpeditionService()
 
-  const expeditionRecord = useMemo<ExpeditionRecord | null>(() => {
-    if (expeditionId) {
-      return getExpeditionById(expeditionId)
-    }
-    const numericPartyId = partyId ? Number.parseInt(partyId, 10) : NaN
-    if (Number.isNaN(numericPartyId)) return null
-    const history = getPartyExpeditionHistory(numericPartyId, 1)
-    return history[0] ?? null
+  const [expeditionRecord, setExpeditionRecord] = useState<ExpeditionRecord | null>(null)
+
+  useEffect(() => {
+    void (async () => {
+      if (expeditionId) {
+        const record = await getExpeditionById(expeditionId)
+        setExpeditionRecord(record)
+        return
+      }
+      const numericPartyId = partyId ? Number.parseInt(partyId, 10) : NaN
+      if (Number.isNaN(numericPartyId)) {
+        setExpeditionRecord(null)
+        return
+      }
+      const history = await getPartyExpeditionHistory(numericPartyId, 1)
+      setExpeditionRecord(history[0] ?? null)
+    })()
   }, [expeditionId, partyId, getExpeditionById, getPartyExpeditionHistory, expeditionRecords])
 
   const resolvedPartyId = useMemo(() => {
@@ -58,13 +67,14 @@ export default function ExpeditionPlaybackScreen() {
     return Number.isNaN(numericPartyId) ? null : numericPartyId
   }, [expeditionRecord, partyId])
 
-  const party = useMemo(() => {
-    if (!resolvedPartyId || isPartyLoading) return null
-    try {
-      return getPartyById(resolvedPartyId)
-    } catch {
-      return null
+  const [party, setParty] = useState<Party | null>(null)
+
+  useEffect(() => {
+    if (!resolvedPartyId || isPartyLoading) {
+      setParty(null)
+      return
     }
+    void getPartyById(resolvedPartyId).then(p => setParty(p)).catch(() => setParty(null))
   }, [resolvedPartyId, getPartyById, isPartyLoading])
 
   const dungeon = useMemo(() => {
@@ -91,7 +101,7 @@ export default function ExpeditionPlaybackScreen() {
     return new CompleteExpeditionUseCase(goblinRepository, partyRepository, baseStateRepository, SQLiteEquipmentRepository.getInstance())
   }, [goblinRepository, partyRepository, baseStateRepository])
 
-  const addPendingGoblinOnClear = useCallback(() => {
+  const addPendingGoblinOnClear = useCallback(async () => {
     if (!expeditionRecord || !replay || isPendingLoading || isBaseLoading) return
     const targetDungeon = dungeon ?? dungeons.find(area => area.id === expeditionRecord.dungeonId)
     if (!targetDungeon) return
@@ -103,11 +113,11 @@ export default function ExpeditionPlaybackScreen() {
     const maxPending = rank * 5
     if (pendingGoblins.length >= maxPending) return
 
-    const nextId = getNextGoblinId()
+    const nextId = await getNextGoblinId()
     const areaLevel = Math.min(64, targetDungeon.areaLevel ?? 1)
     const goblinBirthService = new GoblinBirthService()
     const newGoblin = goblinBirthService.createNewGoblin(nextId, undefined, goblins, areaLevel, rank)
-    addPendingGoblin(newGoblin)
+    await addPendingGoblin(newGoblin)
   }, [
     addPendingGoblin,
     dungeons,
@@ -246,8 +256,8 @@ export default function ExpeditionPlaybackScreen() {
 
     try {
       await completeExpeditionUseCase.execute(expeditionRecord.partyId, replay)
-      addPendingGoblinOnClear()
-      completeExpeditionRecord(expeditionRecord.id, replay)
+      await addPendingGoblinOnClear()
+      await completeExpeditionRecord(expeditionRecord.id, replay)
     } catch (error) {
       console.warn('[Playback] Failed to complete expedition', error)
     }

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -7,7 +7,7 @@ import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
-import type { ExpeditionRequest, Goblin, Dungeon } from '@/shared/types'
+import type { ExpeditionRequest, Goblin, Dungeon, Party } from '@/shared/types'
 
 type ReturnPolicy = ExpeditionRequest['returnPolicy']
 
@@ -66,14 +66,14 @@ export default function ExpeditionPreparationScreen() {
   const { dungeons, isLoading: dungeonsLoading } = useDungeonProgress()
   const { startExpedition, estimateExplorationTime } = useExpeditionFlow()
   const [retryCount, setRetryCount] = useState(0)
+  const [party, setParty] = useState<Party | null>(null)
 
-  const party = useMemo(() => {
-    if (!partyId) return null
-    try {
-      return getPartyById(parseInt(partyId, 10))
-    } catch {
-      return null
+  useEffect(() => {
+    if (!partyId) {
+      setParty(null)
+      return
     }
+    void getPartyById(parseInt(partyId, 10)).then(p => setParty(p)).catch(() => setParty(null))
   }, [partyId, parties, getPartyById])
 
   // パーティが見つからない場合にリトライ
@@ -91,7 +91,7 @@ export default function ExpeditionPreparationScreen() {
   useFocusEffect(
     useCallback(() => {
       void refreshParties()
-      refreshGoblins()
+      void refreshGoblins()
     }, [refreshParties, refreshGoblins])
   )
 
@@ -140,14 +140,14 @@ export default function ExpeditionPreparationScreen() {
   const handleSelectDungeon = useCallback((dungeon: Dungeon) => {
     setSelectedDungeonId(dungeon.id)
     if (partyId) {
-      setDungeon(parseInt(partyId, 10), dungeon.id)
+      void setDungeon(parseInt(partyId, 10), dungeon.id)
     }
   }, [partyId, setDungeon])
 
   const handleSelectReturnPolicy = useCallback((policy: ReturnPolicy) => {
     setSelectedReturnPolicy(policy)
     if (partyId) {
-      setReturnPolicy(parseInt(partyId, 10), policy)
+      void setReturnPolicy(parseInt(partyId, 10), policy)
     }
   }, [partyId, setReturnPolicy])
 

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -9,7 +9,7 @@ import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { areasData } from '@/shared/data'
-import type { Goblin } from '@/shared/types'
+import type { Goblin, ExpeditionRecord, Party } from '@/shared/types'
 
 export default function ExpeditionResultScreen() {
   const { partyId, dungeonId, success, xpGained, maxFloor, expeditionId } = useLocalSearchParams<{
@@ -31,26 +31,41 @@ export default function ExpeditionResultScreen() {
     isLoading: isExpeditionLoading,
   } = useExpeditionService()
   const [hasRetriedLoad, setHasRetriedLoad] = useState(false)
+  const [expeditionRecord, setExpeditionRecord] = useState<ExpeditionRecord | null>(null)
 
-  const expeditionRecord = useMemo(() => {
-    if (!expeditionId) return null
-    const byId = getExpeditionById(expeditionId)
-    if (byId) return byId
-    return expeditionRecords.find(record => record.id === expeditionId) ?? null
+  useEffect(() => {
+    if (!expeditionId) {
+      setExpeditionRecord(null)
+      return
+    }
+    void (async () => {
+      const byId = await getExpeditionById(expeditionId)
+      if (byId) {
+        setExpeditionRecord(byId)
+      } else {
+        const fromList = expeditionRecords.find(record => record.id === expeditionId) ?? null
+        setExpeditionRecord(fromList)
+      }
+    })()
   }, [expeditionId, getExpeditionById, expeditionRecords])
 
   useEffect(() => {
     if (!expeditionId || isExpeditionLoading || expeditionRecord || hasRetriedLoad) return
-    refreshExpeditions()
+    void refreshExpeditions()
     setHasRetriedLoad(true)
   }, [expeditionId, expeditionRecord, hasRetriedLoad, isExpeditionLoading, refreshExpeditions])
 
   const replay = expeditionRecord?.replay ?? null
   const resolvedPartyId = expeditionRecord?.partyId ?? (partyId ? parseInt(partyId, 10) : null)
 
-  const party = useMemo(() => {
-    if (!resolvedPartyId) return null
-    return getPartyById(resolvedPartyId)
+  const [party, setParty] = useState<Party | null>(null)
+
+  useEffect(() => {
+    if (!resolvedPartyId) {
+      setParty(null)
+      return
+    }
+    void getPartyById(resolvedPartyId).then(p => setParty(p)).catch(() => setParty(null))
   }, [resolvedPartyId, getPartyById])
 
   const dungeon = useMemo(() => {
@@ -108,7 +123,7 @@ export default function ExpeditionResultScreen() {
     if (!replay || !dungeon) return
     const cleared = replay.summary.success && replay.summary.maxFloorReached >= dungeon.floors
     if (cleared && !dungeon.cleared) {
-      markDungeonCleared(dungeon, true)
+      void markDungeonCleared(dungeon, true)
     }
   }, [dungeon, markDungeonCleared, replay])
 
@@ -129,7 +144,7 @@ export default function ExpeditionResultScreen() {
     if (!nextProgress || !nextProgress.unlocked) return
     if (nextProgress.unlockNotified) return
     setShowUnlockNotice(true)
-    markUnlockNotified(unlockNext)
+    void markUnlockNotified(unlockNext)
   }, [unlockNext, isSuccess, progress, markUnlockNotified])
 
   if (expeditionId && (isExpeditionLoading || (!expeditionRecord && !hasRetriedLoad))) {

--- a/goblin_native/src/core/repositories/IBaseStateRepository.ts
+++ b/goblin_native/src/core/repositories/IBaseStateRepository.ts
@@ -1,7 +1,7 @@
 import type { BaseState } from '../../shared/types'
 
 export interface IBaseStateRepository {
-  initialize(): Promise<void>
-  getBaseState(): BaseState | null
-  saveBaseState(state: BaseState): void
+  getBaseState(): Promise<BaseState | null>
+  saveBaseState(state: BaseState): Promise<void>
+  getAndIncrementNextGoblinId(): Promise<number>
 }

--- a/goblin_native/src/core/repositories/IEquipmentRepository.ts
+++ b/goblin_native/src/core/repositories/IEquipmentRepository.ts
@@ -1,9 +1,9 @@
 import type { EquipmentInstance } from '../../shared/types'
 
 export interface IEquipmentRepository {
-  getAll(): EquipmentInstance[]
-  getByGoblinId(goblinId: number): EquipmentInstance[]
-  getUnequipped(): EquipmentInstance[]
-  save(equipment: EquipmentInstance): void
-  delete(id: string): void
+  getAll(): Promise<EquipmentInstance[]>
+  getByGoblinId(goblinId: number): Promise<EquipmentInstance[]>
+  getUnequipped(): Promise<EquipmentInstance[]>
+  save(equipment: EquipmentInstance): Promise<void>
+  delete(id: string): Promise<void>
 }

--- a/goblin_native/src/core/repositories/IGoblinRepository.ts
+++ b/goblin_native/src/core/repositories/IGoblinRepository.ts
@@ -1,10 +1,10 @@
 import type { Goblin } from '../../shared/types'
 
 export interface IGoblinRepository {
-  getGoblins(): Goblin[]
-  getGoblin(id: number): Goblin | null
-  saveGoblin(goblin: Goblin): void
-  deleteGoblin(id: number): void
-  updateGoblinStats(id: number, stats: Goblin['stats']): void
-  updateGoblinLevel(id: number, level: number): void
+  getGoblins(): Promise<Goblin[]>
+  getGoblin(id: number): Promise<Goblin | null>
+  saveGoblin(goblin: Goblin): Promise<void>
+  deleteGoblin(id: number): Promise<void>
+  updateGoblinStats(id: number, stats: Goblin['stats']): Promise<void>
+  updateGoblinLevel(id: number, level: number): Promise<void>
 }

--- a/goblin_native/src/core/repositories/IPartyRepository.ts
+++ b/goblin_native/src/core/repositories/IPartyRepository.ts
@@ -1,13 +1,13 @@
 import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
 
 export interface IPartyRepository {
-  getParties(): Party[]
-  getParty(id: number): Party | null
-  saveParty(party: Party): void
-  deleteParty(id: number): void
-  updatePartyStatus(id: number, status: PartyStatus): void
-  getPartiesByStatus(status: PartyStatus): Party[]
-  updateDungeonSettings(id: number, dungeonId: string): void
-  updateFloorTarget(id: number, targetFloor: number | null): void
-  updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): void
+  getParties(): Promise<Party[]>
+  getParty(id: number): Promise<Party | null>
+  saveParty(party: Party): Promise<void>
+  deleteParty(id: number): Promise<void>
+  updatePartyStatus(id: number, status: PartyStatus): Promise<void>
+  getPartiesByStatus(status: PartyStatus): Promise<Party[]>
+  updateDungeonSettings(id: number, dungeonId: string): Promise<void>
+  updateFloorTarget(id: number, targetFloor: number | null): Promise<void>
+  updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): Promise<void>
 }

--- a/goblin_native/src/core/repositories/IPendingGoblinRepository.ts
+++ b/goblin_native/src/core/repositories/IPendingGoblinRepository.ts
@@ -1,9 +1,8 @@
 import type { Goblin } from '../../shared/types'
 
 export interface IPendingGoblinRepository {
-  initialize(): Promise<void>
-  getPendingGoblins(): Goblin[]
-  addPendingGoblin(goblin: Goblin): void
-  removePendingGoblin(id: number): void
-  clearPendingGoblins(): void
+  getPendingGoblins(): Promise<Goblin[]>
+  addPendingGoblin(goblin: Goblin): Promise<void>
+  removePendingGoblin(id: number): Promise<void>
+  clearPendingGoblins(): Promise<void>
 }

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -10,17 +10,12 @@ import { captureDungeon } from '../services/BaseRankSystem'
 export interface ExpeditionCompletionResult {
   levelUps: Map<number, LevelUpResult>
   updatedGoblinIds: number[]
-  factorAcquisitions: Map<number, string[]>  // ゴブリンID -> 獲得因子ID[]
-  newDungeonCaptured?: string  // 新しく制圧したダンジョンID
-  goldGained: number  // 獲得したゴールド
-  treasureDrops?: TreasureDrop[]  // 宝箱から獲得した装備
+  factorAcquisitions: Map<number, string[]>
+  newDungeonCaptured?: string
+  goldGained: number
+  treasureDrops?: TreasureDrop[]
 }
 
-/**
- * 遠征完了時の処理を行うUseCase
- * - 経験値の付与とレベルアップ
- * - パーティステータスの更新
- */
 export class CompleteExpeditionUseCase {
   private readonly goblinRepository: IGoblinRepository
   private readonly partyRepository: IPartyRepository
@@ -43,34 +38,30 @@ export class CompleteExpeditionUseCase {
     partyId: number,
     replay: ExpeditionReplay
   ): Promise<ExpeditionCompletionResult> {
-    const party = this.partyRepository.getParty(partyId)
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error('パーティが見つかりません')
     }
 
-    // 遠征に参加したゴブリンを取得
     const participantIds = replay.meta.party.map(id => Number.parseInt(id, 10))
-    const goblins = participantIds
-      .map(id => this.goblinRepository.getGoblin(id))
-      .filter((g): g is NonNullable<typeof g> => g !== null)
+    const goblins = (
+      await Promise.all(participantIds.map(id => this.goblinRepository.getGoblin(id)))
+    ).filter((g): g is NonNullable<typeof g> => g !== null)
 
     if (goblins.length === 0) {
       throw new Error('遠征メンバーが見つかりません')
     }
 
-    // 各ゴブリンに経験値を付与
     const levelUps = new Map<number, LevelUpResult>()
     const updatedGoblinIds: number[] = []
 
     for (const goblin of goblins) {
       const entity = new GoblinEntity(goblin)
 
-      // 死亡者には経験値を付与しない
       if (replay.summary.casualties.includes(goblin.id.toString())) {
         continue
       }
 
-      // 負傷者は経験値50%
       const expMultiplier = replay.summary.injuries.includes(goblin.id.toString()) ? 0.5 : 1.0
       const expToGain = Math.floor(replay.summary.xpGained * expMultiplier)
 
@@ -78,25 +69,21 @@ export class CompleteExpeditionUseCase {
         const levelUpResult = entity.gainExperience(expToGain)
         levelUps.set(goblin.id, levelUpResult)
 
-        // ゴブリンデータを更新
         const updatedGoblin = entity.toSnapshot()
         await this.goblinRepository.saveGoblin(updatedGoblin)
         updatedGoblinIds.push(goblin.id)
       }
     }
 
-    // 因子獲得処理
     const factorAcquisitions = new Map<number, string[]>()
     const bossEvent = replay.events.find(
       (e): e is Extract<TimelineEvent, { type: 'boss' }> => e.type === 'boss'
     )
 
     if (bossEvent && bossEvent.combat.outcome === 'win') {
-      // 敵データを取得してボスの因子ドロップを取得
       const enemyDatabase = getEnemyDatabase(replay.meta.areaId)
 
       if (enemyDatabase) {
-        // ボスパターンの敵の中からfactorDropsを持つ敵を全て取得
         const bossPattern = enemyDatabase.patterns.find(p => p.isBoss)
         const bossEnemyIds = bossPattern?.enemies.flat() ?? [bossEvent.enemy.id]
         const enemiesWithFactorDrops = enemyDatabase.enemies.filter(
@@ -104,12 +91,9 @@ export class CompleteExpeditionUseCase {
         )
 
         if (enemiesWithFactorDrops.length > 0) {
-          // 全ての敵のfactorDropsを結合
           const allFactorDrops = enemiesWithFactorDrops.flatMap(e => e.factorDrops!)
 
-          // 生存しているゴブリンごとに因子獲得判定
           for (const goblin of goblins) {
-            // 死亡者はスキップ
             if (replay.summary.casualties.includes(goblin.id.toString())) {
               continue
             }
@@ -136,15 +120,14 @@ export class CompleteExpeditionUseCase {
       }
     }
 
-    // 宝箱装備をインベントリに保存
     const treasureDrops = replay.summary.treasureDrops ?? []
     if (treasureDrops.length > 0 && this.equipmentRepository) {
       for (const drop of treasureDrops) {
         const equipmentId = `eq_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-        this.equipmentRepository.save({
+        await this.equipmentRepository.save({
           id: equipmentId,
           templateId: drop.templateId,
-          slotIndex: -1,    // 在庫
+          slotIndex: -1,
           goblinId: null,
           titleId: drop.titleId,
           titleName: drop.titleName,
@@ -152,35 +135,29 @@ export class CompleteExpeditionUseCase {
       }
     }
 
-    // ゴールド付与とダンジョン制圧記録
     let newDungeonCaptured: string | undefined
     const goldGained = replay.summary.goldGained || 0
 
-    const currentBaseState = this.baseStateRepository.getBaseState()
+    const currentBaseState = await this.baseStateRepository.getBaseState()
     if (currentBaseState) {
-      // ゴールドを追加
       let updatedBaseState = {
         ...currentBaseState,
         gold: currentBaseState.gold + goldGained,
       }
 
-      // 遠征成功時にダンジョン制圧を記録
       if (replay.summary.success) {
         const wasCaptured = currentBaseState.capturedDungeons.includes(replay.meta.areaId)
         updatedBaseState = captureDungeon(replay.meta.areaId, updatedBaseState)
 
-        // 新しく制圧した場合
         if (!wasCaptured) {
           newDungeonCaptured = replay.meta.areaId
         }
       }
 
-      // 拠点状態を保存
-      this.baseStateRepository.saveBaseState(updatedBaseState)
+      await this.baseStateRepository.saveBaseState(updatedBaseState)
     }
 
-    // パーティステータスを待機中に戻す
-    this.partyRepository.updatePartyStatus(partyId, 'idle')
+    await this.partyRepository.updatePartyStatus(partyId, 'idle')
 
     return {
       levelUps,

--- a/goblin_native/src/core/usecases/ConfigurePartyUseCase.ts
+++ b/goblin_native/src/core/usecases/ConfigurePartyUseCase.ts
@@ -8,26 +8,26 @@ export class ConfigurePartyUseCase {
     this.partyRepository = partyRepository
   }
 
-  public setDungeon(partyId: number, dungeonId: string): Party {
-    this.partyRepository.updateDungeonSettings(partyId, dungeonId)
+  public async setDungeon(partyId: number, dungeonId: string): Promise<Party> {
+    await this.partyRepository.updateDungeonSettings(partyId, dungeonId)
     return this.requireParty(partyId)
   }
 
-  public setTargetFloor(partyId: number, targetFloor: number | null): Party {
-    this.partyRepository.updateFloorTarget(partyId, targetFloor)
+  public async setTargetFloor(partyId: number, targetFloor: number | null): Promise<Party> {
+    await this.partyRepository.updateFloorTarget(partyId, targetFloor)
     return this.requireParty(partyId)
   }
 
-  public setReturnPolicy(
+  public async setReturnPolicy(
     partyId: number,
     returnPolicy: ExpeditionRequest['returnPolicy']
-  ): Party {
-    this.partyRepository.updateReturnPolicy(partyId, returnPolicy)
+  ): Promise<Party> {
+    await this.partyRepository.updateReturnPolicy(partyId, returnPolicy)
     return this.requireParty(partyId)
   }
 
-  private requireParty(partyId: number): Party {
-    const party = this.partyRepository.getParty(partyId)
+  private async requireParty(partyId: number): Promise<Party> {
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error(`ID ${partyId} のパーティが見つかりません`)
     }

--- a/goblin_native/src/core/usecases/CreatePartyUseCase.ts
+++ b/goblin_native/src/core/usecases/CreatePartyUseCase.ts
@@ -15,8 +15,8 @@ export class CreatePartyUseCase {
     this.partyRepository = partyRepository
   }
 
-  public execute(input: CreatePartyInput): Party {
-    const parties = this.partyRepository.getParties()
+  public async execute(input: CreatePartyInput): Promise<Party> {
+    const parties = await this.partyRepository.getParties()
     const nextId =
       parties.length === 0 ? 1 : Math.max(...parties.map(existing => existing.id)) + 1
 
@@ -31,7 +31,7 @@ export class CreatePartyUseCase {
       returnPolicy: input.returnPolicy,
     }
 
-    this.partyRepository.saveParty(party)
+    await this.partyRepository.saveParty(party)
     return party
   }
 }

--- a/goblin_native/src/core/usecases/GetGoblinByIdUseCase.ts
+++ b/goblin_native/src/core/usecases/GetGoblinByIdUseCase.ts
@@ -8,8 +8,8 @@ export class GetGoblinByIdUseCase {
     this.goblinRepository = goblinRepository
   }
 
-  public execute(goblinId: number): Goblin {
-    const goblin = this.goblinRepository.getGoblin(goblinId)
+  public async execute(goblinId: number): Promise<Goblin> {
+    const goblin = await this.goblinRepository.getGoblin(goblinId)
     if (!goblin) {
       throw new Error(`ID ${goblinId} のゴブリンが見つかりません`)
     }

--- a/goblin_native/src/core/usecases/GetGoblinListUseCase.ts
+++ b/goblin_native/src/core/usecases/GetGoblinListUseCase.ts
@@ -8,7 +8,7 @@ export class GetGoblinListUseCase {
     this.goblinRepository = goblinRepository
   }
 
-  public execute(): Goblin[] {
+  public async execute(): Promise<Goblin[]> {
     return this.goblinRepository.getGoblins()
   }
 }

--- a/goblin_native/src/core/usecases/GetPartyByIdUseCase.ts
+++ b/goblin_native/src/core/usecases/GetPartyByIdUseCase.ts
@@ -8,8 +8,8 @@ export class GetPartyByIdUseCase {
     this.partyRepository = partyRepository
   }
 
-  public execute(partyId: number): Party {
-    const party = this.partyRepository.getParty(partyId)
+  public async execute(partyId: number): Promise<Party> {
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error(`ID ${partyId} のパーティが見つかりません`)
     }

--- a/goblin_native/src/core/usecases/GetPartyListUseCase.ts
+++ b/goblin_native/src/core/usecases/GetPartyListUseCase.ts
@@ -8,7 +8,7 @@ export class GetPartyListUseCase {
     this.partyRepository = partyRepository
   }
 
-  public execute(): Party[] {
+  public async execute(): Promise<Party[]> {
     return this.partyRepository.getParties()
   }
 }

--- a/goblin_native/src/core/usecases/ManagePartyUseCase.ts
+++ b/goblin_native/src/core/usecases/ManagePartyUseCase.ts
@@ -9,34 +9,34 @@ export class ManagePartyUseCase {
     this.partyRepository = partyRepository
   }
 
-  public addMember(partyId: number, goblinId: string): Party {
-    const party = this.requireParty(partyId)
+  public async addMember(partyId: number, goblinId: string): Promise<Party> {
+    const party = await this.requireParty(partyId)
     const partyEntity = new PartyEntity(party)
     partyEntity.addMember(goblinId)
     const updated = partyEntity.toSnapshot()
-    this.partyRepository.saveParty(updated)
+    await this.partyRepository.saveParty(updated)
     return updated
   }
 
-  public removeMember(partyId: number, goblinId: string): Party {
-    const party = this.requireParty(partyId)
+  public async removeMember(partyId: number, goblinId: string): Promise<Party> {
+    const party = await this.requireParty(partyId)
     const partyEntity = new PartyEntity(party)
     partyEntity.removeMember(goblinId)
     const updated = partyEntity.toSnapshot()
-    this.partyRepository.saveParty(updated)
+    await this.partyRepository.saveParty(updated)
     return updated
   }
 
-  public markIdle(partyId: number): void {
-    this.partyRepository.updatePartyStatus(partyId, 'idle')
+  public async markIdle(partyId: number): Promise<void> {
+    await this.partyRepository.updatePartyStatus(partyId, 'idle')
   }
 
-  public markExpedition(partyId: number): void {
-    this.partyRepository.updatePartyStatus(partyId, 'expedition')
+  public async markExpedition(partyId: number): Promise<void> {
+    await this.partyRepository.updatePartyStatus(partyId, 'expedition')
   }
 
-  private requireParty(partyId: number): Party {
-    const party = this.partyRepository.getParty(partyId)
+  private async requireParty(partyId: number): Promise<Party> {
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error(`ID ${partyId} のパーティが見つかりません`)
     }

--- a/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
@@ -29,7 +29,7 @@ export class StartExpeditionUseCase {
       throw new Error('パーティIDが不正です')
     }
 
-    const party = this.partyRepository.getParty(partyId)
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error('パーティが見つかりません')
     }
@@ -39,20 +39,24 @@ export class StartExpeditionUseCase {
       throw new Error('パーティが遠征可能な状態ではありません')
     }
 
-    const goblins = this.loadPartyMembers(party)
+    const goblins = await this.loadPartyMembers(party)
     if (goblins.length === 0) {
       throw new Error('遠征可能なメンバーがいません')
     }
 
     const replay = await this.expeditionEngine.generateExpedition(request, goblins)
-    this.partyRepository.updatePartyStatus(partyId, 'expedition')
+    await this.partyRepository.updatePartyStatus(partyId, 'expedition')
     return replay
   }
 
-  private loadPartyMembers(party: Party): Goblin[] {
-    return party.memberIds
-      .map(id => this.goblinRepository.getGoblin(id))
-      .filter((goblin): goblin is Goblin => Boolean(goblin))
-      .map(goblin => new GoblinEntity(goblin).toSnapshot())
+  private async loadPartyMembers(party: Party): Promise<Goblin[]> {
+    const goblins: Goblin[] = []
+    for (const id of party.memberIds) {
+      const goblin = await this.goblinRepository.getGoblin(id)
+      if (goblin) {
+        goblins.push(new GoblinEntity(goblin).toSnapshot())
+      }
+    }
+    return goblins
   }
 }

--- a/goblin_native/src/core/usecases/UpdatePartyMembersUseCase.ts
+++ b/goblin_native/src/core/usecases/UpdatePartyMembersUseCase.ts
@@ -10,8 +10,8 @@ export class UpdatePartyMembersUseCase {
     this.partyRepository = partyRepository
   }
 
-  public execute(partyId: number, memberIds: number[]): Party {
-    const party = this.partyRepository.getParty(partyId)
+  public async execute(partyId: number, memberIds: number[]): Promise<Party> {
+    const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error('パーティが見つかりません')
     }
@@ -26,7 +26,7 @@ export class UpdatePartyMembersUseCase {
       memberIds: uniqueMembers,
     }
 
-    this.partyRepository.saveParty(updated)
+    await this.partyRepository.saveParty(updated)
     return updated
   }
 }

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -7,9 +7,10 @@ import { migrateV1 } from './migrations/v1'
 import { migrateV2 } from './migrations/v2'
 import { migrateV3 } from './migrations/v3'
 import { migrateV4 } from './migrations/v4'
+import { migrateV5 } from './migrations/v5'
 
 const DB_NAME = 'goblin_kingdom.db'
-const CURRENT_SCHEMA_VERSION = 4
+const CURRENT_SCHEMA_VERSION = 5
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -99,6 +100,13 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
     await migrateV4(database)
     await setSchemaVersion(database, 4)
     console.log('[DB] Migration v4 completed')
+  }
+
+  if (currentVersion < 5) {
+    console.log('[DB] Running migration v5...')
+    await migrateV5(database)
+    await setSchemaVersion(database, 5)
+    console.log('[DB] Migration v5 completed')
   }
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v5.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v5.ts
@@ -1,0 +1,29 @@
+import type * as SQLite from 'expo-sqlite'
+
+/**
+ * v5: base_state に next_goblin_id カラムを追加
+ * キャッシュ削除後もアトミックなID採番を行うため
+ */
+export const migrateV5 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  // next_goblin_id カラムを追加
+  await database.execAsync(`
+    ALTER TABLE base_state ADD COLUMN next_goblin_id INTEGER NOT NULL DEFAULT 1
+  `)
+
+  // 現在の MAX(id)+1 で初期化
+  const goblinMax = await database.getFirstAsync<{ max_id: number | null }>(
+    'SELECT MAX(id) as max_id FROM goblins'
+  )
+  const pendingMax = await database.getFirstAsync<{ max_id: number | null }>(
+    'SELECT MAX(id) as max_id FROM pending_goblins'
+  )
+
+  const maxGoblin = goblinMax?.max_id ?? 0
+  const maxPending = pendingMax?.max_id ?? 0
+  const nextId = Math.max(maxGoblin, maxPending) + 1
+
+  await database.runAsync(
+    'UPDATE base_state SET next_goblin_id = ? WHERE id = 1',
+    [nextId]
+  )
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -98,6 +98,7 @@ export const SCHEMA = {
       current_max_goblins INTEGER NOT NULL DEFAULT 10,
       current_iv_bonus INTEGER NOT NULL DEFAULT 0,
       gold INTEGER NOT NULL DEFAULT 0,
+      next_goblin_id INTEGER NOT NULL DEFAULT 1,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `,

--- a/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteBaseStateRepository.ts
@@ -1,11 +1,10 @@
 /**
  * SQLiteを使用した拠点状態リポジトリ実装
- * シングルトンテーブルで拠点の状態を管理
+ * DBから直接読み書きする設計
  */
 import type { BaseState } from '../../shared/types'
 import type { IBaseStateRepository } from '../../core/repositories/IBaseStateRepository'
 import { getDatabase } from '../database'
-import { BASE_RANK_CONFIGS } from '../../core/services/BaseRankSystem'
 
 interface BaseStateRow {
   id: number
@@ -16,6 +15,7 @@ interface BaseStateRow {
   current_max_goblins: number
   current_iv_bonus: number
   gold: number
+  next_goblin_id: number
   updated_at: string
 }
 
@@ -32,12 +32,7 @@ const DEFAULT_BASE_STATE: BaseState = {
 
 export class SQLiteBaseStateRepository implements IBaseStateRepository {
   private static instance: SQLiteBaseStateRepository | null = null
-  private cache: BaseState | null = null
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLiteBaseStateRepository {
     if (!SQLiteBaseStateRepository.instance) {
       SQLiteBaseStateRepository.instance = new SQLiteBaseStateRepository()
@@ -45,104 +40,36 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
     return SQLiteBaseStateRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getBaseState(): Promise<BaseState | null> {
     const db = await getDatabase()
     const row = await db.getFirstAsync<BaseStateRow>(
       'SELECT * FROM base_state WHERE id = 1'
     )
 
-    if (row) {
-      this.cache = {
-        capacity: row.capacity,
-        rank: row.rank,
-        nextGoblinId: await this.getNextGoblinId(),
-        capturedDungeons: JSON.parse(row.captured_dungeons_json || '[]'),
-        currentMaxParties: row.current_max_parties,
-        currentMaxGoblins: row.current_max_goblins,
-        currentIVBonus: row.current_iv_bonus,
-        gold: row.gold,
-      }
-    } else {
-      // 初期データがない場合は作成
-      this.cache = DEFAULT_BASE_STATE
-      await this.saveAsync(this.cache)
+    if (!row) return null
+
+    return {
+      capacity: row.capacity,
+      rank: row.rank,
+      nextGoblinId: row.next_goblin_id,
+      capturedDungeons: JSON.parse(row.captured_dungeons_json || '[]'),
+      currentMaxParties: row.current_max_parties,
+      currentMaxGoblins: row.current_max_goblins,
+      currentIVBonus: row.current_iv_bonus,
+      gold: row.gold,
     }
-
-    this.initialized = true
   }
 
-  /**
-   * 拠点状態を取得
-   */
-  getBaseState(): BaseState | null {
-    return this.cache
-  }
-
-  /**
-   * 拠点状態を保存
-   */
-  saveBaseState(state: BaseState): void {
-    this.cache = state
-
-    this.saveAsync(state).catch(err => {
-      console.error('[SQLiteBaseStateRepository] Failed to save:', err)
-    })
-  }
-
-  /**
-   * 拠点のランクを上げる
-   * @deprecated 代わりに BaseRankSystem.captureDungeon を使用してください
-   */
-  upgradeRank(): void {
-    if (!this.cache) return
-
-    const nextRank = this.cache.rank + 1
-    const nextConfig = BASE_RANK_CONFIGS.find((c) => c.rank === nextRank)
-
-    if (!nextConfig) {
-      console.warn('[SQLiteBaseStateRepository] Cannot upgrade: max rank reached')
-      return
-    }
-
-    const newState: BaseState = {
-      ...this.cache,
-      rank: nextRank,
-      capacity: nextConfig.maxGoblins,
-      currentMaxParties: nextConfig.maxParties,
-      currentMaxGoblins: nextConfig.maxGoblins,
-      currentIVBonus: nextConfig.ivBonus,
-    }
-
-    this.saveBaseState(newState)
-  }
-
-  /**
-   * 次のゴブリンIDを取得して更新
-   */
-  getAndIncrementNextGoblinId(): number {
-    if (!this.cache) return 1
-
-    const nextId = this.cache.nextGoblinId ?? 1
-    this.cache.nextGoblinId = nextId + 1
-    this.saveBaseState(this.cache)
-    return nextId
-  }
-
-  // --- Private methods ---
-
-  private async saveAsync(state: BaseState): Promise<void> {
+  async saveBaseState(state: BaseState): Promise<void> {
     const db = await getDatabase()
+    // next_goblin_id はカウンター専用カラムなので、ここでは触らない
+    // getAndIncrementNextGoblinId() のみがアトミックに更新する
     await db.runAsync(
-      `INSERT OR REPLACE INTO base_state (
-        id, capacity, rank, captured_dungeons_json,
-        current_max_parties, current_max_goblins, current_iv_bonus, gold, updated_at
-      )
-       VALUES (1, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      `UPDATE base_state SET
+        capacity = ?, rank = ?, captured_dungeons_json = ?,
+        current_max_parties = ?, current_max_goblins = ?,
+        current_iv_bonus = ?, gold = ?, updated_at = datetime('now')
+       WHERE id = 1`,
       [
         state.capacity,
         state.rank,
@@ -155,20 +82,49 @@ export class SQLiteBaseStateRepository implements IBaseStateRepository {
     )
   }
 
-  private async getNextGoblinId(): Promise<number> {
+  async ensureInitialized(): Promise<void> {
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<{ id: number }>(
+      'SELECT id FROM base_state WHERE id = 1'
+    )
+    if (!row) {
+      await db.runAsync(
+        `INSERT INTO base_state (
+          id, capacity, rank, captured_dungeons_json,
+          current_max_parties, current_max_goblins, current_iv_bonus, gold,
+          next_goblin_id
+        ) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          DEFAULT_BASE_STATE.capacity,
+          DEFAULT_BASE_STATE.rank,
+          JSON.stringify(DEFAULT_BASE_STATE.capturedDungeons),
+          DEFAULT_BASE_STATE.currentMaxParties,
+          DEFAULT_BASE_STATE.currentMaxGoblins,
+          DEFAULT_BASE_STATE.currentIVBonus,
+          DEFAULT_BASE_STATE.gold,
+          DEFAULT_BASE_STATE.nextGoblinId ?? 1,
+        ]
+      )
+    }
+  }
+
+  /**
+   * 次のゴブリンIDをアトミックにインクリメントして返す
+   * UPDATE で +1 した後、更新後の値-1 を返す（採番された値）
+   */
+  async getAndIncrementNextGoblinId(): Promise<number> {
     const db = await getDatabase()
 
-    // goblins と pending_goblins の最大IDを取得
-    const goblinMax = await db.getFirstAsync<{ max_id: number | null }>(
-      'SELECT MAX(id) as max_id FROM goblins'
-    )
-    const pendingMax = await db.getFirstAsync<{ max_id: number | null }>(
-      'SELECT MAX(id) as max_id FROM pending_goblins'
+    // アトミックにインクリメント
+    await db.runAsync(
+      'UPDATE base_state SET next_goblin_id = next_goblin_id + 1 WHERE id = 1'
     )
 
-    const maxGoblin = goblinMax?.max_id ?? 0
-    const maxPending = pendingMax?.max_id ?? 0
+    // インクリメント後の値を取得（採番されたIDは -1 した値）
+    const row = await db.getFirstAsync<{ next_goblin_id: number }>(
+      'SELECT next_goblin_id FROM base_state WHERE id = 1'
+    )
 
-    return Math.max(maxGoblin, maxPending) + 1
+    return (row?.next_goblin_id ?? 2) - 1
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -1,6 +1,6 @@
 /**
  * SQLiteを使用したダンジョン進行状況リポジトリ実装
- * 内部キャッシュを使用して同期的なインターフェースを提供
+ * DBから直接読み書きする設計
  */
 import type { DungeonProgressState } from '../../shared/types'
 import { getDatabase } from '../database'
@@ -20,21 +20,16 @@ interface DungeonProgress {
 }
 
 export interface IDungeonProgressRepository {
-  getAll(): DungeonProgressState
-  get(dungeonId: string): DungeonProgress | null
-  save(dungeonId: string, progress: DungeonProgress): void
-  unlock(dungeonId: string): void
-  markCleared(dungeonId: string): void
+  getAll(): Promise<DungeonProgressState>
+  get(dungeonId: string): Promise<DungeonProgress | null>
+  save(dungeonId: string, progress: DungeonProgress): Promise<void>
+  unlock(dungeonId: string): Promise<void>
+  markCleared(dungeonId: string): Promise<void>
 }
 
 export class SQLiteDungeonProgressRepository implements IDungeonProgressRepository {
   private static instance: SQLiteDungeonProgressRepository | null = null
-  private cache: Map<string, DungeonProgress> = new Map()
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLiteDungeonProgressRepository {
     if (!SQLiteDungeonProgressRepository.instance) {
       SQLiteDungeonProgressRepository.instance = new SQLiteDungeonProgressRepository()
@@ -42,75 +37,38 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
     return SQLiteDungeonProgressRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getAll(): Promise<DungeonProgressState> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<DungeonProgressRow>('SELECT * FROM dungeon_progress')
 
-    this.cache.clear()
+    const result: DungeonProgressState = {}
     for (const row of rows) {
-      this.cache.set(row.dungeon_id, {
+      result[row.dungeon_id] = {
         unlocked: row.unlocked === 1,
         cleared: row.cleared === 1,
         unlockNotified: row.unlock_notified === 1,
-      })
+      }
     }
-
-    this.initialized = true
-  }
-
-  /**
-   * 全ダンジョンの進行状況を取得
-   */
-  getAll(): DungeonProgressState {
-    const result: DungeonProgressState = {}
-    this.cache.forEach((progress, dungeonId) => {
-      result[dungeonId] = progress
-    })
     return result
   }
 
-  /**
-   * 指定ダンジョンの進行状況を取得
-   */
-  get(dungeonId: string): DungeonProgress | null {
-    return this.cache.get(dungeonId) ?? null
+  async get(dungeonId: string): Promise<DungeonProgress | null> {
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<DungeonProgressRow>(
+      'SELECT * FROM dungeon_progress WHERE dungeon_id = ?',
+      [dungeonId]
+    )
+
+    if (!row) return null
+
+    return {
+      unlocked: row.unlocked === 1,
+      cleared: row.cleared === 1,
+      unlockNotified: row.unlock_notified === 1,
+    }
   }
 
-  /**
-   * 進行状況を保存
-   */
-  save(dungeonId: string, progress: DungeonProgress): void {
-    this.cache.set(dungeonId, progress)
-
-    this.saveAsync(dungeonId, progress).catch(err => {
-      console.error('[SQLiteDungeonProgressRepository] Failed to save:', err)
-    })
-  }
-
-  /**
-   * ダンジョンを解放済みにする
-   */
-  unlock(dungeonId: string): void {
-    const current = this.cache.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false }
-    this.save(dungeonId, { ...current, unlocked: true })
-  }
-
-  /**
-   * ダンジョンをクリア済みにする
-   */
-  markCleared(dungeonId: string): void {
-    const current = this.cache.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false }
-    this.save(dungeonId, { ...current, unlocked: true, cleared: true })
-  }
-
-  // --- Private methods ---
-
-  private async saveAsync(dungeonId: string, progress: DungeonProgress): Promise<void> {
+  async save(dungeonId: string, progress: DungeonProgress): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO dungeon_progress
@@ -123,5 +81,15 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
         progress.unlockNotified ? 1 : 0,
       ]
     )
+  }
+
+  async unlock(dungeonId: string): Promise<void> {
+    const current = await this.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false }
+    await this.save(dungeonId, { ...current, unlocked: true })
+  }
+
+  async markCleared(dungeonId: string): Promise<void> {
+    const current = await this.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false }
+    await this.save(dungeonId, { ...current, unlocked: true, cleared: true })
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLiteEquipmentRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteEquipmentRepository.ts
@@ -1,6 +1,6 @@
 /**
  * SQLiteを使用した装備リポジトリ実装
- * SQLiteGoblinRepository と同じシングルトン+キャッシュパターン
+ * DBから直接読み書きする設計
  */
 import type { EquipmentInstance } from '../../shared/types'
 import type { IEquipmentRepository } from '../../core/repositories/IEquipmentRepository'
@@ -18,8 +18,6 @@ interface EquipmentRow {
 
 export class SQLiteEquipmentRepository implements IEquipmentRepository {
   private static instance: SQLiteEquipmentRepository | null = null
-  private cache: Map<string, EquipmentInstance> = new Map()
-  private initialized = false
 
   static getInstance(): SQLiteEquipmentRepository {
     if (!SQLiteEquipmentRepository.instance) {
@@ -28,56 +26,30 @@ export class SQLiteEquipmentRepository implements IEquipmentRepository {
     return SQLiteEquipmentRepository.instance
   }
 
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getAll(): Promise<EquipmentInstance[]> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<EquipmentRow>('SELECT * FROM equipment')
-
-    this.cache.clear()
-    for (const row of rows) {
-      const eq = this.rowToEquipment(row)
-      this.cache.set(eq.id, eq)
-    }
-
-    this.initialized = true
+    return rows.map(row => this.rowToEquipment(row))
   }
 
-  getAll(): EquipmentInstance[] {
-    return Array.from(this.cache.values())
-  }
-
-  getByGoblinId(goblinId: number): EquipmentInstance[] {
-    return Array.from(this.cache.values()).filter(
-      (eq) => eq.goblinId === goblinId && eq.slotIndex >= 0
+  async getByGoblinId(goblinId: number): Promise<EquipmentInstance[]> {
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<EquipmentRow>(
+      'SELECT * FROM equipment WHERE goblin_id = ? AND slot_index >= 0',
+      [goblinId]
     )
+    return rows.map(row => this.rowToEquipment(row))
   }
 
-  getUnequipped(): EquipmentInstance[] {
-    return Array.from(this.cache.values()).filter(
-      (eq) => eq.goblinId === null || eq.slotIndex < 0
+  async getUnequipped(): Promise<EquipmentInstance[]> {
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<EquipmentRow>(
+      'SELECT * FROM equipment WHERE goblin_id IS NULL OR slot_index < 0'
     )
+    return rows.map(row => this.rowToEquipment(row))
   }
 
-  save(equipment: EquipmentInstance): void {
-    this.cache.set(equipment.id, equipment)
-
-    this.saveAsync(equipment).catch((err) => {
-      console.error('[SQLiteEquipmentRepository] Failed to save equipment:', err)
-    })
-  }
-
-  delete(id: string): void {
-    this.cache.delete(id)
-
-    this.deleteAsync(id).catch((err) => {
-      console.error('[SQLiteEquipmentRepository] Failed to delete equipment:', err)
-    })
-  }
-
-  // --- Private methods ---
-
-  private async saveAsync(equipment: EquipmentInstance): Promise<void> {
+  async save(equipment: EquipmentInstance): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO equipment (id, template_id, slot_index, goblin_id, title_id, title_name)
@@ -93,7 +65,7 @@ export class SQLiteEquipmentRepository implements IEquipmentRepository {
     )
   }
 
-  private async deleteAsync(id: string): Promise<void> {
+  async delete(id: string): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM equipment WHERE id = ?', [id])
   }

--- a/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
@@ -1,6 +1,6 @@
 /**
  * SQLiteを使用した遠征記録リポジトリ実装
- * 内部キャッシュを使用して同期的なインターフェースを提供
+ * DBから直接読み書きする設計
  */
 import type { ExpeditionRecord, ExpeditionReplay, ExpeditionRequest } from '../../shared/types'
 import { getDatabase } from '../database'
@@ -21,23 +21,18 @@ interface ExpeditionRow {
 }
 
 export interface IExpeditionRepository {
-  getAll(): ExpeditionRecord[]
-  getById(id: string): ExpeditionRecord | null
-  getByPartyId(partyId: number): ExpeditionRecord[]
-  getOngoing(): ExpeditionRecord[]
-  save(record: ExpeditionRecord): void
-  delete(id: string): void
-  complete(id: string, replay: ExpeditionReplay): void
+  getAll(): Promise<ExpeditionRecord[]>
+  getById(id: string): Promise<ExpeditionRecord | null>
+  getByPartyId(partyId: number): Promise<ExpeditionRecord[]>
+  getOngoing(): Promise<ExpeditionRecord[]>
+  save(record: ExpeditionRecord): Promise<void>
+  delete(id: string): Promise<void>
+  complete(id: string, replay: ExpeditionReplay): Promise<void>
 }
 
 export class SQLiteExpeditionRepository implements IExpeditionRepository {
   private static instance: SQLiteExpeditionRepository | null = null
-  private cache: Map<string, ExpeditionRecord> = new Map()
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLiteExpeditionRepository {
     if (!SQLiteExpeditionRepository.instance) {
       SQLiteExpeditionRepository.instance = new SQLiteExpeditionRepository()
@@ -45,101 +40,41 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     return SQLiteExpeditionRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getAll(): Promise<ExpeditionRecord[]> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<ExpeditionRow>(
       'SELECT * FROM expeditions ORDER BY created_at DESC'
     )
-
-    this.cache.clear()
-    for (const row of rows) {
-      const record = this.rowToRecord(row)
-      this.cache.set(record.id, record)
-    }
-
-    this.initialized = true
+    return rows.map(row => this.rowToRecord(row))
   }
 
-  /**
-   * 全遠征記録を取得
-   */
-  getAll(): ExpeditionRecord[] {
-    return Array.from(this.cache.values()).sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  async getById(id: string): Promise<ExpeditionRecord | null> {
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<ExpeditionRow>(
+      'SELECT * FROM expeditions WHERE id = ?',
+      [id]
     )
+    return row ? this.rowToRecord(row) : null
   }
 
-  /**
-   * 指定IDの遠征記録を取得
-   */
-  getById(id: string): ExpeditionRecord | null {
-    return this.cache.get(id) ?? null
+  async getByPartyId(partyId: number): Promise<ExpeditionRecord[]> {
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<ExpeditionRow>(
+      'SELECT * FROM expeditions WHERE party_id = ? ORDER BY created_at DESC',
+      [partyId]
+    )
+    return rows.map(row => this.rowToRecord(row))
   }
 
-  /**
-   * 指定パーティの遠征記録を取得
-   */
-  getByPartyId(partyId: number): ExpeditionRecord[] {
-    return Array.from(this.cache.values())
-      .filter(r => r.partyId === partyId)
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  async getOngoing(): Promise<ExpeditionRecord[]> {
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<ExpeditionRow>(
+      "SELECT * FROM expeditions WHERE status = 'ongoing' ORDER BY created_at DESC"
+    )
+    return rows.map(row => this.rowToRecord(row))
   }
 
-  /**
-   * 進行中の遠征記録を取得
-   */
-  getOngoing(): ExpeditionRecord[] {
-    return Array.from(this.cache.values()).filter(r => r.status === 'ongoing')
-  }
-
-  /**
-   * 遠征記録を保存
-   */
-  save(record: ExpeditionRecord): void {
-    this.cache.set(record.id, record)
-
-    this.saveAsync(record).catch(err => {
-      console.error('[SQLiteExpeditionRepository] Failed to save:', err)
-    })
-  }
-
-  /**
-   * 遠征記録を削除
-   */
-  delete(id: string): void {
-    this.cache.delete(id)
-
-    this.deleteAsync(id).catch(err => {
-      console.error('[SQLiteExpeditionRepository] Failed to delete:', err)
-    })
-  }
-
-  /**
-   * 遠征を完了状態にする
-   */
-  complete(id: string, replay: ExpeditionReplay): void {
-    const record = this.cache.get(id)
-    if (!record) return
-
-    const updated: ExpeditionRecord = {
-      ...record,
-      status: replay.summary.success ? 'completed' : 'failed',
-      returnTime: new Date(),
-      replay,
-      updatedAt: new Date(),
-    }
-
-    this.save(updated)
-  }
-
-  // --- Private methods ---
-
-  private async saveAsync(record: ExpeditionRecord): Promise<void> {
+  async save(record: ExpeditionRecord): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT INTO expeditions
@@ -172,15 +107,30 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     )
   }
 
-  private async deleteAsync(id: string): Promise<void> {
+  async delete(id: string): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM expeditions WHERE id = ?', [id])
+  }
+
+  async complete(id: string, replay: ExpeditionReplay): Promise<void> {
+    const record = await this.getById(id)
+    if (!record) return
+
+    const updated: ExpeditionRecord = {
+      ...record,
+      status: replay.summary.success ? 'completed' : 'failed',
+      returnTime: new Date(),
+      replay,
+      updatedAt: new Date(),
+    }
+
+    await this.save(updated)
   }
 
   private rowToRecord(row: ExpeditionRow): ExpeditionRecord {
     return {
       id: row.id,
-      userId: '', // SQLite版ではローカルユーザーのみ
+      userId: '',
       partyId: row.party_id,
       partyName: row.party_name,
       dungeonId: row.dungeon_id,

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -1,6 +1,6 @@
 /**
  * SQLiteを使用したゴブリンリポジトリ実装
- * 内部キャッシュを使用して同期的なインターフェースを提供
+ * DBから直接読み書きする設計
  */
 import type { Goblin, GoblinStats } from '../../shared/types'
 import type { IGoblinRepository } from '../../core/repositories/IGoblinRepository'
@@ -25,12 +25,7 @@ interface GoblinRow {
 
 export class SQLiteGoblinRepository implements IGoblinRepository {
   private static instance: SQLiteGoblinRepository | null = null
-  private cache: Map<number, Goblin> = new Map()
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLiteGoblinRepository {
     if (!SQLiteGoblinRepository.instance) {
       SQLiteGoblinRepository.instance = new SQLiteGoblinRepository()
@@ -38,87 +33,19 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     return SQLiteGoblinRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getGoblins(): Promise<Goblin[]> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<GoblinRow>('SELECT * FROM goblins ORDER BY id')
-
-    this.cache.clear()
-    for (const row of rows) {
-      const goblin = this.rowToGoblin(row)
-      this.cache.set(goblin.id, goblin)
-    }
-
-    this.initialized = true
+    return rows.map(row => this.rowToGoblin(row))
   }
 
-  /**
-   * 全ゴブリンを取得
-   */
-  getGoblins(): Goblin[] {
-    return Array.from(this.cache.values())
+  async getGoblin(id: number): Promise<Goblin | null> {
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<GoblinRow>('SELECT * FROM goblins WHERE id = ?', [id])
+    return row ? this.rowToGoblin(row) : null
   }
 
-  /**
-   * 指定IDのゴブリンを取得
-   */
-  getGoblin(id: number): Goblin | null {
-    return this.cache.get(id) ?? null
-  }
-
-  /**
-   * ゴブリンを保存（新規作成または更新）
-   */
-  saveGoblin(goblin: Goblin): void {
-    // キャッシュを即座に更新
-    this.cache.set(goblin.id, goblin)
-
-    // DBへの保存は非同期で実行
-    this.saveGoblinAsync(goblin).catch(err => {
-      console.error('[SQLiteGoblinRepository] Failed to save goblin:', err)
-    })
-  }
-
-  /**
-   * ゴブリンを削除
-   */
-  deleteGoblin(id: number): void {
-    this.cache.delete(id)
-
-    this.deleteGoblinAsync(id).catch(err => {
-      console.error('[SQLiteGoblinRepository] Failed to delete goblin:', err)
-    })
-  }
-
-  /**
-   * ゴブリンのステータスを更新
-   */
-  updateGoblinStats(id: number, stats: GoblinStats): void {
-    const goblin = this.cache.get(id)
-    if (!goblin) return
-
-    const updated = { ...goblin, stats }
-    this.saveGoblin(updated)
-  }
-
-  /**
-   * ゴブリンのレベルを更新
-   */
-  updateGoblinLevel(id: number, level: number): void {
-    const goblin = this.cache.get(id)
-    if (!goblin) return
-
-    const updated = { ...goblin, level }
-    this.saveGoblin(updated)
-  }
-
-  // --- Private methods ---
-
-  private async saveGoblinAsync(goblin: Goblin): Promise<void> {
+  async saveGoblin(goblin: Goblin): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO goblins
@@ -143,9 +70,23 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     )
   }
 
-  private async deleteGoblinAsync(id: number): Promise<void> {
+  async deleteGoblin(id: number): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM goblins WHERE id = ?', [id])
+  }
+
+  async updateGoblinStats(id: number, stats: GoblinStats): Promise<void> {
+    const goblin = await this.getGoblin(id)
+    if (!goblin) return
+
+    await this.saveGoblin({ ...goblin, stats })
+  }
+
+  async updateGoblinLevel(id: number, level: number): Promise<void> {
+    const goblin = await this.getGoblin(id)
+    if (!goblin) return
+
+    await this.saveGoblin({ ...goblin, level })
   }
 
   private rowToGoblin(row: GoblinRow): Goblin {

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -1,6 +1,6 @@
 /**
  * SQLiteを使用したパーティリポジトリ実装
- * 内部キャッシュを使用して同期的なインターフェースを提供
+ * DBから直接読み書きする設計
  */
 import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
 import type { IPartyRepository } from '../../core/repositories/IPartyRepository'
@@ -20,12 +20,7 @@ interface PartyRow {
 
 export class SQLitePartyRepository implements IPartyRepository {
   private static instance: SQLitePartyRepository | null = null
-  private cache: Map<number, Party> = new Map()
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLitePartyRepository {
     if (!SQLitePartyRepository.instance) {
       SQLitePartyRepository.instance = new SQLitePartyRepository()
@@ -33,127 +28,19 @@ export class SQLitePartyRepository implements IPartyRepository {
     return SQLitePartyRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
-    await this.loadFromDatabase()
-    this.initialized = true
-  }
-
-  /**
-   * DBからデータを再読み込み
-   */
-  async reload(): Promise<void> {
-    await this.loadFromDatabase()
-  }
-
-  /**
-   * DBからデータをロードしてキャッシュを更新
-   */
-  private async loadFromDatabase(): Promise<void> {
+  async getParties(): Promise<Party[]> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<PartyRow>('SELECT * FROM parties ORDER BY id')
-
-    this.cache.clear()
-    for (const row of rows) {
-      const party = this.rowToParty(row)
-      this.cache.set(party.id, party)
-    }
+    return rows.map(row => this.rowToParty(row))
   }
 
-  /**
-   * 全パーティを取得
-   */
-  getParties(): Party[] {
-    return Array.from(this.cache.values())
+  async getParty(id: number): Promise<Party | null> {
+    const db = await getDatabase()
+    const row = await db.getFirstAsync<PartyRow>('SELECT * FROM parties WHERE id = ?', [id])
+    return row ? this.rowToParty(row) : null
   }
 
-  /**
-   * 指定IDのパーティを取得
-   */
-  getParty(id: number): Party | null {
-    return this.cache.get(id) ?? null
-  }
-
-  /**
-   * パーティを保存（新規作成または更新）
-   */
-  saveParty(party: Party): void {
-    this.cache.set(party.id, party)
-
-    this.savePartyAsync(party).catch(err => {
-      console.error('[SQLitePartyRepository] Failed to save party:', err)
-    })
-  }
-
-  /**
-   * パーティを削除
-   */
-  deleteParty(id: number): void {
-    this.cache.delete(id)
-
-    this.deletePartyAsync(id).catch(err => {
-      console.error('[SQLitePartyRepository] Failed to delete party:', err)
-    })
-  }
-
-  /**
-   * パーティのステータスを更新
-   */
-  updatePartyStatus(id: number, status: PartyStatus): void {
-    const party = this.cache.get(id)
-    if (!party) return
-
-    const updated = { ...party, status }
-    this.saveParty(updated)
-  }
-
-  /**
-   * 指定ステータスのパーティ一覧を取得
-   */
-  getPartiesByStatus(status: PartyStatus): Party[] {
-    return Array.from(this.cache.values()).filter(p => p.status === status)
-  }
-
-  /**
-   * ダンジョン設定を更新
-   */
-  updateDungeonSettings(id: number, dungeonId: string): void {
-    const party = this.cache.get(id)
-    if (!party) return
-
-    const updated = { ...party, dungeonId }
-    this.saveParty(updated)
-  }
-
-  /**
-   * 目標階層を更新
-   */
-  updateFloorTarget(id: number, targetFloor: number | null): void {
-    const party = this.cache.get(id)
-    if (!party) return
-
-    const updated = { ...party, targetFloor }
-    this.saveParty(updated)
-  }
-
-  /**
-   * 帰還ポリシーを更新
-   */
-  updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): void {
-    const party = this.cache.get(id)
-    if (!party) return
-
-    const updated = { ...party, returnPolicy }
-    this.saveParty(updated)
-  }
-
-  // --- Private methods ---
-
-  private async savePartyAsync(party: Party): Promise<void> {
+  async saveParty(party: Party): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO parties
@@ -171,9 +58,47 @@ export class SQLitePartyRepository implements IPartyRepository {
     )
   }
 
-  private async deletePartyAsync(id: number): Promise<void> {
+  async deleteParty(id: number): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM parties WHERE id = ?', [id])
+  }
+
+  async updatePartyStatus(id: number, status: PartyStatus): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      "UPDATE parties SET status = ?, updated_at = datetime('now') WHERE id = ?",
+      [status, id]
+    )
+  }
+
+  async getPartiesByStatus(status: PartyStatus): Promise<Party[]> {
+    const db = await getDatabase()
+    const rows = await db.getAllAsync<PartyRow>('SELECT * FROM parties WHERE status = ? ORDER BY id', [status])
+    return rows.map(row => this.rowToParty(row))
+  }
+
+  async updateDungeonSettings(id: number, dungeonId: string): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      "UPDATE parties SET dungeon_id = ?, updated_at = datetime('now') WHERE id = ?",
+      [dungeonId, id]
+    )
+  }
+
+  async updateFloorTarget(id: number, targetFloor: number | null): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      "UPDATE parties SET target_floor = ?, updated_at = datetime('now') WHERE id = ?",
+      [targetFloor, id]
+    )
+  }
+
+  async updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      "UPDATE parties SET return_policy = ?, updated_at = datetime('now') WHERE id = ?",
+      [returnPolicy, id]
+    )
   }
 
   private rowToParty(row: PartyRow): Party {

--- a/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePendingGoblinRepository.ts
@@ -24,12 +24,7 @@ interface PendingGoblinRow {
 
 export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
   private static instance: SQLitePendingGoblinRepository | null = null
-  private cache: Map<number, Goblin> = new Map()
-  private initialized = false
 
-  /**
-   * シングルトンインスタンスを取得
-   */
   static getInstance(): SQLitePendingGoblinRepository {
     if (!SQLitePendingGoblinRepository.instance) {
       SQLitePendingGoblinRepository.instance = new SQLitePendingGoblinRepository()
@@ -37,69 +32,15 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
     return SQLitePendingGoblinRepository.instance
   }
 
-  /**
-   * リポジトリを初期化し、DBからデータをロード
-   */
-  async initialize(): Promise<void> {
-    if (this.initialized) return
-
+  async getPendingGoblins(): Promise<Goblin[]> {
     const db = await getDatabase()
     const rows = await db.getAllAsync<PendingGoblinRow>(
       'SELECT * FROM pending_goblins ORDER BY created_at DESC'
     )
-
-    this.cache.clear()
-    for (const row of rows) {
-      const goblin = this.rowToGoblin(row)
-      this.cache.set(goblin.id, goblin)
-    }
-
-    this.initialized = true
+    return rows.map(row => this.rowToGoblin(row))
   }
 
-  /**
-   * 待機中の全ゴブリンを取得
-   */
-  getPendingGoblins(): Goblin[] {
-    return Array.from(this.cache.values())
-  }
-
-  /**
-   * 待機中ゴブリンを追加
-   */
-  addPendingGoblin(goblin: Goblin): void {
-    this.cache.set(goblin.id, goblin)
-
-    this.addAsync(goblin).catch(err => {
-      console.error('[SQLitePendingGoblinRepository] Failed to add:', err)
-    })
-  }
-
-  /**
-   * 待機中ゴブリンを削除（受け入れ時）
-   */
-  removePendingGoblin(id: number): void {
-    this.cache.delete(id)
-
-    this.removeAsync(id).catch(err => {
-      console.error('[SQLitePendingGoblinRepository] Failed to remove:', err)
-    })
-  }
-
-  /**
-   * 全待機中ゴブリンをクリア
-   */
-  clearPendingGoblins(): void {
-    this.cache.clear()
-
-    this.clearAsync().catch(err => {
-      console.error('[SQLitePendingGoblinRepository] Failed to clear:', err)
-    })
-  }
-
-  // --- Private methods ---
-
-  private async addAsync(goblin: Goblin): Promise<void> {
+  async addPendingGoblin(goblin: Goblin): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO pending_goblins
@@ -124,12 +65,12 @@ export class SQLitePendingGoblinRepository implements IPendingGoblinRepository {
     )
   }
 
-  private async removeAsync(id: number): Promise<void> {
+  async removePendingGoblin(id: number): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM pending_goblins WHERE id = ?', [id])
   }
 
-  private async clearAsync(): Promise<void> {
+  async clearPendingGoblins(): Promise<void> {
     const db = await getDatabase()
     await db.runAsync('DELETE FROM pending_goblins')
   }

--- a/goblin_native/src/presentation/hooks/useBaseState.ts
+++ b/goblin_native/src/presentation/hooks/useBaseState.ts
@@ -16,33 +16,34 @@ export function useBaseState() {
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLiteBaseStateRepository | null>(null)
 
-  // リポジトリからデータを取得（アプリ起動時に既に初期化済み）
   useEffect(() => {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    // 初回のデータ取得
-    setBaseState(repository.getBaseState())
-    setIsLoading(false)
+    void repository.getBaseState().then(state => {
+      setBaseState(state)
+      setIsLoading(false)
+    })
   }, [])
 
-  // 拠点ランクアップ
-  const upgradeRank = useCallback(() => {
-    if (!repositoryRef.current) return
+  const upgradeRank = useCallback(async () => {
+    if (!repositoryRef.current || !baseState) return
 
-    repositoryRef.current.upgradeRank()
-    setBaseState(repositoryRef.current.getBaseState())
-  }, [])
+    // upgradeRank はもう BaseRankSystem 経由で行うため、ここでは performRankUp を使う
+    const result = executeRankUp(baseState)
+    if (result.success) {
+      await repositoryRef.current.saveBaseState(result.state)
+      setBaseState(result.state)
+    }
+  }, [baseState])
 
-  // 次のゴブリンIDを取得して更新
-  const getNextGoblinId = useCallback((): number => {
+  const getNextGoblinId = useCallback(async (): Promise<number> => {
     if (!repositoryRef.current) return 1
 
     return repositoryRef.current.getAndIncrementNextGoblinId()
   }, [])
 
-  // 拠点状態を更新
-  const updateBaseState = useCallback((updates: Partial<BaseState>) => {
+  const updateBaseState = useCallback(async (updates: Partial<BaseState>) => {
     if (!repositoryRef.current || !baseState) return
 
     const newState: BaseState = {
@@ -50,19 +51,18 @@ export function useBaseState() {
       ...updates,
     }
 
-    repositoryRef.current.saveBaseState(newState)
+    await repositoryRef.current.saveBaseState(newState)
     setBaseState(newState)
   }, [baseState])
 
-  // ランクアップを実行
-  const performRankUp = useCallback(() => {
+  const performRankUp = useCallback(async () => {
     if (!repositoryRef.current || !baseState) {
       return { success: false, error: '拠点状態が読み込まれていません' }
     }
 
     const result = executeRankUp(baseState)
     if (result.success) {
-      repositoryRef.current.saveBaseState(result.state)
+      await repositoryRef.current.saveBaseState(result.state)
       setBaseState(result.state)
     }
 

--- a/goblin_native/src/presentation/hooks/useDatabaseInit.ts
+++ b/goblin_native/src/presentation/hooks/useDatabaseInit.ts
@@ -1,36 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getDatabase, resetDatabase } from '@/infrastructure/database'
 import { SQLiteDungeonProgressRepository } from '@/infrastructure/repositories/SQLiteDungeonProgressRepository'
-import { SQLiteGoblinRepository } from '@/infrastructure/repositories/SQLiteGoblinRepository'
-import { SQLitePartyRepository } from '@/infrastructure/repositories/SQLitePartyRepository'
 import { SQLiteBaseStateRepository } from '@/infrastructure/repositories/SQLiteBaseStateRepository'
-import { SQLiteExpeditionRepository } from '@/infrastructure/repositories/SQLiteExpeditionRepository'
-import { SQLitePendingGoblinRepository } from '@/infrastructure/repositories/SQLitePendingGoblinRepository'
 import { areasData } from '@/shared/data'
 
-async function initializeRepositories(): Promise<void> {
+async function ensureDefaults(): Promise<void> {
   await getDatabase()
 
-  await Promise.all([
-    SQLiteGoblinRepository.getInstance().initialize(),
-    SQLitePartyRepository.getInstance().initialize(),
-    SQLiteBaseStateRepository.getInstance().initialize(),
-    SQLiteExpeditionRepository.getInstance().initialize(),
-    SQLitePendingGoblinRepository.getInstance().initialize(),
-    SQLiteDungeonProgressRepository.getInstance().initialize(),
-  ])
+  // 拠点状態がなければデフォルト値を作成
+  await SQLiteBaseStateRepository.getInstance().ensureInitialized()
 
+  // ダンジョンプログレス初期値設定
   const dungeonProgressRepo = SQLiteDungeonProgressRepository.getInstance()
-  const storedProgress = dungeonProgressRepo.getAll()
-  areasData.forEach((dungeon, index) => {
+  const storedProgress = await dungeonProgressRepo.getAll()
+  for (let index = 0; index < areasData.length; index++) {
+    const dungeon = areasData[index]
     if (!storedProgress[dungeon.id]) {
-      dungeonProgressRepo.save(dungeon.id, {
+      await dungeonProgressRepo.save(dungeon.id, {
         unlocked: dungeon.unlocked ?? index === 0,
         cleared: dungeon.cleared ?? false,
         unlockNotified: false,
       })
     }
-  })
+  }
 }
 
 export const useDatabaseInit = () => {
@@ -42,7 +34,7 @@ export const useDatabaseInit = () => {
     mountedRef.current = true
     const run = async () => {
       try {
-        await initializeRepositories()
+        await ensureDefaults()
         if (mountedRef.current) setReady(true)
       } catch (e) {
         if (mountedRef.current) {
@@ -59,7 +51,7 @@ export const useDatabaseInit = () => {
     setError(null)
     try {
       await resetDatabase()
-      await initializeRepositories()
+      await ensureDefaults()
       setReady(true)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Database reset failed')

--- a/goblin_native/src/presentation/hooks/useDungeonProgress.ts
+++ b/goblin_native/src/presentation/hooks/useDungeonProgress.ts
@@ -28,36 +28,34 @@ export const useDungeonProgress = () => {
     return SQLiteDungeonProgressRepository.getInstance()
   }, [])
 
-  const refreshProgress = useCallback(() => {
-    const storedProgress = repository.getAll()
+  const refreshProgress = useCallback(async () => {
+    const storedProgress = await repository.getAll()
     const mergedProgress = { ...buildDefaultProgress(), ...storedProgress }
     setProgress(mergedProgress)
   }, [repository])
 
   useEffect(() => {
-    // アプリ起動時に既に初期化されているので、データを読み込むだけ
-    refreshProgress()
-    setIsLoading(false)
+    void refreshProgress().then(() => setIsLoading(false))
   }, [refreshProgress])
 
   const updateProgress = useCallback(
-    (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
-      const currentProgress = { ...buildDefaultProgress(), ...repository.getAll() }
+    async (updater: (prev: DungeonProgressState) => DungeonProgressState) => {
+      const storedProgress = await repository.getAll()
+      const currentProgress = { ...buildDefaultProgress(), ...storedProgress }
       const nextProgress = updater(currentProgress)
 
-      // 変更された項目のみ保存
       for (const [dungeonId, state] of Object.entries(nextProgress)) {
-        repository.save(dungeonId, state)
+        await repository.save(dungeonId, state)
       }
 
-      refreshProgress()
+      await refreshProgress()
     },
     [repository, refreshProgress]
   )
 
   const markDungeonCleared = useCallback(
-    (dungeon: Dungeon, cleared: boolean) => {
-      updateProgress(prev => {
+    async (dungeon: Dungeon, cleared: boolean) => {
+      await updateProgress(prev => {
         const nextProgress: DungeonProgressState = { ...prev }
         const current = nextProgress[dungeon.id] ?? {
           unlocked: dungeon.unlocked ?? false,
@@ -72,7 +70,6 @@ export const useDungeonProgress = () => {
 
         if (cleared && dungeon.unlockNext) {
           const target = nextProgress[dungeon.unlockNext]
-          // 既にアンロック済みの場合は状態を変更しない（unlockNotifiedフラグを保持）
           if (!target || !target.unlocked) {
             nextProgress[dungeon.unlockNext] = {
               ...(target ?? { cleared: false, unlockNotified: false }),
@@ -88,8 +85,8 @@ export const useDungeonProgress = () => {
   )
 
   const markUnlockNotified = useCallback(
-    (dungeonId: string) => {
-      updateProgress(prev => {
+    async (dungeonId: string) => {
+      await updateProgress(prev => {
         const nextProgress: DungeonProgressState = { ...prev }
         const current = nextProgress[dungeonId] ?? {
           unlocked: false,

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -76,7 +76,7 @@ export const useExpeditionFlow = ({
     return new CompleteExpeditionUseCase(goblinRepository, partyRepository, baseStateRepository, SQLiteEquipmentRepository.getInstance())
   }, [goblinRepository, partyRepository, baseStateRepository])
 
-  const handleDungeonClear = useCallback((record: ExpeditionRecord) => {
+  const handleDungeonClear = useCallback(async (record: ExpeditionRecord) => {
     if (!record.replay || isPendingLoading || isBaseLoading) return
 
     const dungeon = areasData.find(area => area.id === record.dungeonId)
@@ -86,23 +86,22 @@ export const useExpeditionFlow = ({
       record.replay.summary.maxFloorReached >= dungeon.floors
     if (!cleared) return
 
-    markDungeonCleared(dungeon, true)
+    await markDungeonCleared(dungeon, true)
 
     const maxPending = rank * 5
     if (pendingGoblins.length >= maxPending) return
 
-    const nextId = getNextGoblinId()
+    const nextId = await getNextGoblinId()
     const areaLevel = dungeon.areaLevel ?? 1
     const goblinBirthService = new GoblinBirthService()
-    // 個体値は自動計算される（areaLevel + 拠点ランクボーナス）
     const newGoblin = goblinBirthService.createNewGoblin(
       nextId,
-      undefined,  // individualValueは指定しない（自動計算）
-      goblins,    // baseGoblins（因子継承用）
-      areaLevel,  // エリアレベル
-      rank        // 拠点ランク
+      undefined,
+      goblins,
+      areaLevel,
+      rank
     )
-    addPendingGoblin(newGoblin)
+    await addPendingGoblin(newGoblin)
   }, [
     addPendingGoblin,
     getNextGoblinId,
@@ -202,7 +201,7 @@ export const useExpeditionFlow = ({
           updatedAt: startTime,
         }
 
-        saveExpeditionRecord(record)
+        await saveExpeditionRecord(record)
 
         return { replay, record }
       } finally {
@@ -226,7 +225,6 @@ export const useExpeditionFlow = ({
       try {
         const result = await completeExpeditionUseCase.execute(record.partyId, record.replay!)
 
-        // 新しくダンジョンを制圧した場合の通知
         if (result.newDungeonCaptured) {
           const dungeon = areasData.find(d => d.id === result.newDungeonCaptured)
           if (dungeon?.isBaseCapture) {
@@ -238,11 +236,11 @@ export const useExpeditionFlow = ({
           }
         }
 
-        handleDungeonClear(record)
-        completeExpeditionRecord(record.id, record.replay!)
+        await handleDungeonClear(record)
+        await completeExpeditionRecord(record.id, record.replay!)
         processedExpeditionsRef.current.add(record.id)
         if (refreshParties) {
-          refreshParties()
+          await refreshParties()
         }
       } catch (error) {
         console.warn('[useExpeditionFlow] Failed to complete expedition', error)
@@ -257,14 +255,24 @@ export const useExpeditionFlow = ({
     refreshParties,
   ])
 
-  const partyHistories = useMemo(() => {
-    return (parties ?? []).reduce<Record<number, ExpeditionRecord[]>>((acc, party) => {
-      const history = getPartyExpeditionHistory(party.id, 2)
-      if (history.length > 0) {
-        acc[party.id] = history
+  const [partyHistories, setPartyHistories] = useState<Record<number, ExpeditionRecord[]>>({})
+
+  useEffect(() => {
+    if (!parties || parties.length === 0) {
+      setPartyHistories({})
+      return
+    }
+    const loadHistories = async () => {
+      const result: Record<number, ExpeditionRecord[]> = {}
+      for (const party of parties) {
+        const history = await getPartyExpeditionHistory(party.id, 2)
+        if (history.length > 0) {
+          result[party.id] = history
+        }
       }
-      return acc
-    }, {})
+      setPartyHistories(result)
+    }
+    void loadHistories()
   }, [parties, expeditionRecords, getPartyExpeditionHistory])
 
   const partyHistoryDisplays = useMemo(() => {

--- a/goblin_native/src/presentation/hooks/useExpeditionService.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionService.ts
@@ -11,53 +11,55 @@ export const useExpeditionService = () => {
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLiteExpeditionRepository | null>(null)
 
-  const refreshExpeditions = useCallback(() => {
+  const refreshExpeditions = useCallback(async () => {
     if (!repositoryRef.current) return
-    setExpeditionRecords(repositoryRef.current.getAll())
+    const records = await repositoryRef.current.getAll()
+    setExpeditionRecords(records)
   }, [])
 
   useEffect(() => {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    // 初回のデータ取得
-    setExpeditionRecords(repository.getAll())
-    setIsLoading(false)
+    void repository.getAll().then(records => {
+      setExpeditionRecords(records)
+      setIsLoading(false)
+    })
   }, [])
 
-  const getExpeditionById = useCallback((id: string): ExpeditionRecord | null => {
+  const getExpeditionById = useCallback(async (id: string): Promise<ExpeditionRecord | null> => {
     if (!repositoryRef.current) return null
     return repositoryRef.current.getById(id)
   }, [])
 
-  const getPartyExpeditionHistory = useCallback((partyId: number, limit = 2): ExpeditionRecord[] => {
+  const getPartyExpeditionHistory = useCallback(async (partyId: number, limit = 2): Promise<ExpeditionRecord[]> => {
     if (!repositoryRef.current) return []
-    const records = repositoryRef.current.getByPartyId(partyId)
+    const records = await repositoryRef.current.getByPartyId(partyId)
     return records.slice(0, limit)
   }, [])
 
-  const saveExpeditionRecord = useCallback((record: ExpeditionRecord) => {
+  const saveExpeditionRecord = useCallback(async (record: ExpeditionRecord) => {
     if (!repositoryRef.current) return
-    repositoryRef.current.save(record)
-    refreshExpeditions()
+    await repositoryRef.current.save(record)
+    await refreshExpeditions()
   }, [refreshExpeditions])
 
-  const updateExpeditionReplay = useCallback((id: string, replay: ExpeditionReplay) => {
+  const updateExpeditionReplay = useCallback(async (id: string, replay: ExpeditionReplay) => {
     if (!repositoryRef.current) return
-    const record = repositoryRef.current.getById(id)
+    const record = await repositoryRef.current.getById(id)
     if (!record) return
-    repositoryRef.current.save({
+    await repositoryRef.current.save({
       ...record,
       replay,
       updatedAt: new Date(),
     })
-    refreshExpeditions()
+    await refreshExpeditions()
   }, [refreshExpeditions])
 
-  const completeExpeditionRecord = useCallback((id: string, replay: ExpeditionReplay) => {
+  const completeExpeditionRecord = useCallback(async (id: string, replay: ExpeditionReplay) => {
     if (!repositoryRef.current) return
-    repositoryRef.current.complete(id, replay)
-    refreshExpeditions()
+    await repositoryRef.current.complete(id, replay)
+    await refreshExpeditions()
   }, [refreshExpeditions])
 
   return {

--- a/goblin_native/src/presentation/hooks/useGoblinService.ts
+++ b/goblin_native/src/presentation/hooks/useGoblinService.ts
@@ -5,8 +5,8 @@ import type { IGoblinRepository } from '../../core/repositories'
 import { GetGoblinListUseCase } from '../../core/usecases'
 
 export const useGoblinService = () => {
-  const [repositoryInitialized, setRepositoryInitialized] = useState(false)
   const [goblins, setGoblins] = useState<Goblin[]>([])
+  const [isLoading, setIsLoading] = useState(true)
 
   const goblinRepository = useMemo<IGoblinRepository>(() => {
     return SQLiteGoblinRepository.getInstance()
@@ -17,19 +17,18 @@ export const useGoblinService = () => {
     [goblinRepository],
   )
 
-  const refreshGoblins = useCallback(() => {
-    setGoblins(getGoblinListUseCase.execute())
+  const refreshGoblins = useCallback(async () => {
+    const list = await getGoblinListUseCase.execute()
+    setGoblins(list)
   }, [getGoblinListUseCase])
 
   useEffect(() => {
-    // 初回のデータ取得
-    refreshGoblins()
-    setRepositoryInitialized(true)
+    void refreshGoblins().then(() => setIsLoading(false))
   }, [refreshGoblins])
 
   const getGoblinById = useCallback(
-    (goblinId: number): Goblin => {
-      const goblin = goblinRepository.getGoblin(goblinId)
+    async (goblinId: number): Promise<Goblin> => {
+      const goblin = await goblinRepository.getGoblin(goblinId)
       if (!goblin) {
         throw new Error(`ID ${goblinId} のゴブリンが見つかりません`)
       }
@@ -39,25 +38,25 @@ export const useGoblinService = () => {
   )
 
   const saveGoblin = useCallback(
-    (goblin: Goblin) => {
-      goblinRepository.saveGoblin(goblin)
-      refreshGoblins()
+    async (goblin: Goblin) => {
+      await goblinRepository.saveGoblin(goblin)
+      await refreshGoblins()
     },
     [goblinRepository, refreshGoblins],
   )
 
   const deleteGoblin = useCallback(
-    (goblinId: number) => {
-      goblinRepository.deleteGoblin(goblinId)
-      refreshGoblins()
+    async (goblinId: number) => {
+      await goblinRepository.deleteGoblin(goblinId)
+      await refreshGoblins()
     },
     [goblinRepository, refreshGoblins],
   )
 
   const updateGoblinLevel = useCallback(
-    (goblinId: number, level: number) => {
-      goblinRepository.updateGoblinLevel(goblinId, level)
-      refreshGoblins()
+    async (goblinId: number, level: number) => {
+      await goblinRepository.updateGoblinLevel(goblinId, level)
+      await refreshGoblins()
     },
     [goblinRepository, refreshGoblins],
   )
@@ -65,7 +64,7 @@ export const useGoblinService = () => {
   return {
     goblinRepository,
     goblins,
-    isLoading: !repositoryInitialized,
+    isLoading,
     refreshGoblins,
     getGoblinById,
     saveGoblin,

--- a/goblin_native/src/presentation/hooks/usePartyService.ts
+++ b/goblin_native/src/presentation/hooks/usePartyService.ts
@@ -12,8 +12,8 @@ import {
 } from '../../core/usecases'
 
 export const usePartyService = () => {
-  const [repositoryInitialized, setRepositoryInitialized] = useState(false)
   const [parties, setParties] = useState<Party[]>([])
+  const [isLoading, setIsLoading] = useState(true)
 
   const partyRepository = useMemo<IPartyRepository>(() => {
     return SQLitePartyRepository.getInstance()
@@ -44,17 +44,14 @@ export const usePartyService = () => {
     [partyRepository],
   )
 
-  const refreshParties = useCallback(() => {
-    const currentParties = getPartyListUseCase.execute()
+  const refreshParties = useCallback(async () => {
+    const currentParties = await getPartyListUseCase.execute()
     setParties(currentParties)
   }, [getPartyListUseCase])
 
   useEffect(() => {
-    // 既に初期化済みなのでデータを取得
-    const currentParties = getPartyListUseCase.execute()
-    setParties(currentParties)
-    setRepositoryInitialized(true)
-  }, [getPartyListUseCase])
+    void refreshParties().then(() => setIsLoading(false))
+  }, [refreshParties])
 
   const getPartyById = useCallback(
     (partyId: number) => getPartyByIdUseCase.execute(partyId),
@@ -62,79 +59,79 @@ export const usePartyService = () => {
   )
 
   const addMember = useCallback(
-    (partyId: number, goblinId: number) => {
-      const updated = managePartyUseCase.addMember(partyId, goblinId.toString())
-      refreshParties()
+    async (partyId: number, goblinId: number) => {
+      const updated = await managePartyUseCase.addMember(partyId, goblinId.toString())
+      await refreshParties()
       return updated
     },
     [managePartyUseCase, refreshParties],
   )
 
   const removeMember = useCallback(
-    (partyId: number, goblinId: number) => {
-      const updated = managePartyUseCase.removeMember(partyId, goblinId.toString())
-      refreshParties()
+    async (partyId: number, goblinId: number) => {
+      const updated = await managePartyUseCase.removeMember(partyId, goblinId.toString())
+      await refreshParties()
       return updated
     },
     [managePartyUseCase, refreshParties],
   )
 
   const updateMembers = useCallback(
-    (partyId: number, memberIds: number[]) => {
-      const updated = updatePartyMembersUseCase.execute(partyId, memberIds)
-      refreshParties()
+    async (partyId: number, memberIds: number[]) => {
+      const updated = await updatePartyMembersUseCase.execute(partyId, memberIds)
+      await refreshParties()
       return updated
     },
     [updatePartyMembersUseCase, refreshParties],
   )
 
   const createParty = useCallback(
-    (input: Parameters<CreatePartyUseCase['execute']>[0]) => {
-      const created = createPartyUseCase.execute(input)
-      refreshParties()
+    async (input: Parameters<CreatePartyUseCase['execute']>[0]) => {
+      const created = await createPartyUseCase.execute(input)
+      await refreshParties()
       return created
     },
     [createPartyUseCase, refreshParties],
   )
 
   const markExpedition = useCallback(
-    (partyId: number) => {
-      managePartyUseCase.markExpedition(partyId)
-      refreshParties()
+    async (partyId: number) => {
+      await managePartyUseCase.markExpedition(partyId)
+      await refreshParties()
     },
     [managePartyUseCase, refreshParties],
   )
 
   const markIdle = useCallback(
-    (partyId: number) => {
-      managePartyUseCase.markIdle(partyId)
-      refreshParties()
+    async (partyId: number) => {
+      await managePartyUseCase.markIdle(partyId)
+      await refreshParties()
     },
     [managePartyUseCase, refreshParties],
   )
 
   const setDungeon = useCallback(
-    (partyId: number, dungeonId: string) => {
-      const updated = configurePartyUseCase.setDungeon(partyId, dungeonId)
-      refreshParties()
+    async (partyId: number, dungeonId: string) => {
+      const updated = await configurePartyUseCase.setDungeon(partyId, dungeonId)
+      await refreshParties()
       return updated
     },
     [configurePartyUseCase, refreshParties],
   )
 
   const setTargetFloor = useCallback(
-    (partyId: number, targetFloor: number | null) => {
-      const updated = configurePartyUseCase.setTargetFloor(partyId, targetFloor)
-      refreshParties()
+    async (partyId: number, targetFloor: number | null) => {
+      const updated = await configurePartyUseCase.setTargetFloor(partyId, targetFloor)
+      await refreshParties()
       return updated
     },
     [configurePartyUseCase, refreshParties],
   )
 
   const setReturnPolicy = useCallback(
-    (partyId: number, returnPolicy: Parameters<ConfigurePartyUseCase['setReturnPolicy']>[1]) => {
-      const updated = configurePartyUseCase.setReturnPolicy(partyId, returnPolicy)
-      refreshParties()
+    async (partyId: number, returnPolicy: Parameters<ConfigurePartyUseCase['setReturnPolicy']>[1]) => {
+      const updated = await configurePartyUseCase.setReturnPolicy(partyId, returnPolicy)
+      await refreshParties()
       return updated
     },
     [configurePartyUseCase, refreshParties],
@@ -143,7 +140,7 @@ export const usePartyService = () => {
   return {
     partyRepository,
     parties,
-    isLoading: !repositoryInitialized,
+    isLoading,
     refreshParties,
     getPartyById,
     createParty,

--- a/goblin_native/src/presentation/hooks/usePendingGoblins.ts
+++ b/goblin_native/src/presentation/hooks/usePendingGoblins.ts
@@ -15,48 +15,47 @@ export function usePendingGoblins() {
   const [isLoading, setIsLoading] = useState(true)
   const repositoryRef = useRef<SQLitePendingGoblinRepository | null>(null)
 
-  // リポジトリからデータを取得（アプリ起動時に既に初期化済み）
   useEffect(() => {
     const repository = getRepository()
     repositoryRef.current = repository
 
-    // 初回のデータ取得
-    setPendingGoblins(repository.getPendingGoblins())
-    setIsLoading(false)
+    void repository.getPendingGoblins().then(goblins => {
+      setPendingGoblins(goblins)
+      setIsLoading(false)
+    })
   }, [])
 
-  // 待機中ゴブリンを追加
-  const addPendingGoblin = useCallback((goblin: Goblin) => {
+  const addPendingGoblin = useCallback(async (goblin: Goblin) => {
     if (!repositoryRef.current) return
 
-    repositoryRef.current.addPendingGoblin(goblin)
-    setPendingGoblins(repositoryRef.current.getPendingGoblins())
+    await repositoryRef.current.addPendingGoblin(goblin)
+    const goblins = await repositoryRef.current.getPendingGoblins()
+    setPendingGoblins(goblins)
   }, [])
 
-  // 待機中ゴブリンを削除（受け入れ時）
-  const removePendingGoblin = useCallback((id: number) => {
+  const removePendingGoblin = useCallback(async (id: number) => {
     if (!repositoryRef.current) return
 
-    repositoryRef.current.removePendingGoblin(id)
-    setPendingGoblins(repositoryRef.current.getPendingGoblins())
+    await repositoryRef.current.removePendingGoblin(id)
+    const goblins = await repositoryRef.current.getPendingGoblins()
+    setPendingGoblins(goblins)
   }, [])
 
-  // 全待機中ゴブリンをクリア
-  const clearPendingGoblins = useCallback(() => {
+  const clearPendingGoblins = useCallback(async () => {
     if (!repositoryRef.current) return
 
-    repositoryRef.current.clearPendingGoblins()
+    await repositoryRef.current.clearPendingGoblins()
     setPendingGoblins([])
   }, [])
 
-  // 指定IDの待機中ゴブリンを取得
   const getPendingGoblinById = useCallback((id: number): Goblin | undefined => {
     return pendingGoblins.find(g => g.id === id)
   }, [pendingGoblins])
 
-  const refreshPendingGoblins = useCallback(() => {
+  const refreshPendingGoblins = useCallback(async () => {
     if (!repositoryRef.current) return
-    setPendingGoblins(repositoryRef.current.getPendingGoblins())
+    const goblins = await repositoryRef.current.getPendingGoblins()
+    setPendingGoblins(goblins)
   }, [])
 
   return {


### PR DESCRIPTION
## Summary
- 全7リポジトリからメモリキャッシュを削除し、SQLiteから直接��み書きする設計に変更
- キャッシュ起因の「DBは更新されたのにUIに反映されない」問題を解消
- パーティ個別フィールド更新を直接SQL UPDATEに変更し並行更新の安全性を確保
- next_goblin_idカラム追加（v5マイグレーション）によるアトミックなID採番を実装

## 変更内容
- **インターフェース (5ファイル)**: 全メソッドを `Promise<T>` に変更、`initialize()` 削除
- **リポジトリ実装 (7ファイル)**: cache/initializedフィールド削除、全メソッドasync化
- **ユースケース (8ファイル)**: async/await対応
- **フック (8ファイル)**: async対応、useDatabaseInitからinitialize()呼び出し削除
- **画面コンポーネント (7ファイル)**: useMemo+同期パターンをuseState+useEffect+asyncに変更
- **DB**: v5マイグレーション追加（next_goblin_idカラム）、スキーマ定義更新

## Test plan
- [x] TypeScript型チェック通過
- [x] 全91テストパス
- [ ] アプリ起動確認（ゴブリン一覧表示）
- [ ] 遠征開始→完��→結果表示の動作確認
- [ ] パーティ作成・メンバー編��・設定変更の動作確認
- [ ] 拠点管理（ゴブリン受け入れ・ランクアップ）の動作確認
- [ ] DBリセット後の再初期化確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)