### PR TITLE
fix: 命中率計算のaccuracyスケール修正と乱数統一

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -268,7 +268,7 @@ export class BattleSystem {
 
   /**
    * 命中率を計算
-   * 命中率 = 命中精度 × 命中精度補正(n) × 乱数A − 回避能力 × 残りHP補正 × 乱数B
+   * 命中率 = 乱数A × (命中精度 × 攻撃回数補正 − 回避能力 × 残りHP補正)
    * clamp(5, 95)
    */
   private calculateHitRate(
@@ -278,14 +278,13 @@ export class BattleSystem {
     rng: () => number,
   ): number {
     const accMod = getAccuracyModifier(attackNumber)
-    const randA = rng()
-    const randB = rng()
+    const rand = rng()
 
     // 残りHP補正 = 0.5 * (1 + 残りHP / 最大HP)
     const hpRatio = defender.maxHP > 0 ? defender.currentHP / defender.maxHP : 0
     const hpMod = 0.5 * (1 + hpRatio)
 
-    const hitRate = attacker.accuracy * accMod * randA - defender.evasion * randB * hpMod
+    const hitRate = rand * (attacker.accuracy * accMod - defender.evasion * hpMod)
 
     // 限界値補正: 5% 〜 95%
     return Math.max(5, Math.min(95, hitRate))

--- a/goblin_native/src/core/services/GoblinBirthService.ts
+++ b/goblin_native/src/core/services/GoblinBirthService.ts
@@ -12,7 +12,7 @@ const STAT_RANGES: Record<Exclude<keyof GoblinStats, 'attackCount'>, { min: numb
   sp: { min: 7, max: 13 },
   spd: { min: 8, max: 14 },
   def: { min: 8, max: 14 },
-  accuracy: { min: 15, max: 25 },
+  accuracy: { min: 120, max: 200 },
   evasion: { min: 10, max: 20 },
 }
 

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -163,14 +163,14 @@ describe('GoblinBirthService — 戦闘ステータス生成', () => {
     expect(goblin.stats.attackCount).toBe(2)
   })
 
-  it('accuracyは15〜25の範囲に収まる', () => {
+  it('accuracyは120〜200の範囲に収まる', () => {
     for (let i = 0; i < 100; i++) {
       const rng = createSeededRng(i * 7)
       const service = new GoblinBirthService(rng)
       const goblin = service.createNewGoblin(i)
 
-      expect(goblin.stats.accuracy).toBeGreaterThanOrEqual(15)
-      expect(goblin.stats.accuracy).toBeLessThanOrEqual(25)
+      expect(goblin.stats.accuracy).toBeGreaterThanOrEqual(120)
+      expect(goblin.stats.accuracy).toBeLessThanOrEqual(200)
     }
   })
 

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -8,9 +8,10 @@ import { migrateV2 } from './migrations/v2'
 import { migrateV3 } from './migrations/v3'
 import { migrateV4 } from './migrations/v4'
 import { migrateV5 } from './migrations/v5'
+import { migrateV6 } from './migrations/v6'
 
 const DB_NAME = 'goblin_kingdom.db'
-const CURRENT_SCHEMA_VERSION = 5
+const CURRENT_SCHEMA_VERSION = 6
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -107,6 +108,13 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
     await migrateV5(database)
     await setSchemaVersion(database, 5)
     console.log('[DB] Migration v5 completed')
+  }
+
+  if (currentVersion < 6) {
+    console.log('[DB] Running migration v6...')
+    await migrateV6(database)
+    await setSchemaVersion(database, 6)
+    console.log('[DB] Migration v6 completed')
   }
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v6.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v6.ts
@@ -1,0 +1,39 @@
+import type * as SQLite from 'expo-sqlite'
+
+/**
+ * v6: 全ゴブリンのaccuracyを×8にスケールアップ
+ * 命中率計算式とaccuracy値のスケール不一致を修正
+ */
+export const migrateV6 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  // goblinsテーブルの全レコードを取得してaccuracyを×8
+  const goblins = await database.getAllAsync<{ id: number; stats_json: string }>(
+    'SELECT id, stats_json FROM goblins'
+  )
+
+  for (const goblin of goblins) {
+    const stats = JSON.parse(goblin.stats_json)
+    if (stats.accuracy !== undefined && stats.accuracy < 100) {
+      stats.accuracy = stats.accuracy * 8
+      await database.runAsync(
+        'UPDATE goblins SET stats_json = ? WHERE id = ?',
+        [JSON.stringify(stats), goblin.id]
+      )
+    }
+  }
+
+  // pending_goblinsテーブルも同様に更新
+  const pendingGoblins = await database.getAllAsync<{ id: number; stats_json: string }>(
+    'SELECT id, stats_json FROM pending_goblins'
+  )
+
+  for (const goblin of pendingGoblins) {
+    const stats = JSON.parse(goblin.stats_json)
+    if (stats.accuracy !== undefined && stats.accuracy < 100) {
+      stats.accuracy = stats.accuracy * 8
+      await database.runAsync(
+        'UPDATE pending_goblins SET stats_json = ? WHERE id = ?',
+        [JSON.stringify(stats), goblin.id]
+      )
+    }
+  }
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -151,6 +151,6 @@ export const SCHEMA = {
   goblinsInit: `
     INSERT OR IGNORE INTO goblins (id, name, race, level, experience, avatar, stats_json)
     VALUES
-      (0, 'グラッシュ', 'ゴブリン', 15, 0, '/src/assets/goblin/goblin.png', '{"hp":100,"atk":70,"sp":45,"spd":60,"def":65,"attackCount":2,"accuracy":20,"evasion":15}')
+      (0, 'グラッシュ', 'ゴブリン', 15, 0, '/src/assets/goblin/goblin.png', '{"hp":100,"atk":70,"sp":45,"spd":60,"def":65,"attackCount":2,"accuracy":160,"evasion":15}')
   `,
 }

--- a/goblin_native/src/shared/data/enemy/forest_outskirts.json
+++ b/goblin_native/src/shared/data/enemy/forest_outskirts.json
@@ -13,7 +13,7 @@
       "spd": 2,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 17,
+      "accuracy": 136,
       "evasion": 9,
       "exp": 4,
       "gold": 5
@@ -31,7 +31,7 @@
       "spd": 8,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 19,
+      "accuracy": 152,
       "evasion": 10,
       "exp": 6,
       "gold": 6
@@ -49,7 +49,7 @@
       "spd": 8,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 21,
+      "accuracy": 168,
       "evasion": 11,
       "exp": 10,
       "gold": 9
@@ -67,7 +67,7 @@
       "spd": 8,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 23,
+      "accuracy": 184,
       "evasion": 12,
       "exp": 12,
       "gold": 10
@@ -85,7 +85,7 @@
       "spd": 15,
       "sp": 0,
       "attackCount": 2,
-      "accuracy": 31,
+      "accuracy": 248,
       "evasion": 16,
       "exp": 50,
       "gold": 50,

--- a/goblin_native/src/shared/data/enemy/goblin_village.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village.json
@@ -13,7 +13,7 @@
       "spd": 5,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 21,
+      "accuracy": 168,
       "evasion": 11,
       "exp": 8,
       "gold": 6
@@ -31,7 +31,7 @@
       "spd": 9,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 23,
+      "accuracy": 184,
       "evasion": 12,
       "exp": 12,
       "gold": 10
@@ -49,7 +49,7 @@
       "spd": 4,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 25,
+      "accuracy": 200,
       "evasion": 13,
       "exp": 15,
       "gold": 12
@@ -67,7 +67,7 @@
       "spd": 5,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 25,
+      "accuracy": 200,
       "evasion": 13,
       "exp": 18,
       "gold": 15
@@ -85,7 +85,7 @@
       "spd": 3,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 27,
+      "accuracy": 216,
       "evasion": 14,
       "exp": 20,
       "gold": 18
@@ -104,7 +104,7 @@
       "spd": 8,
       "sp": 0,
       "attackCount": 2,
-      "accuracy": 35,
+      "accuracy": 280,
       "evasion": 18,
       "exp": 80,
       "gold": 70,

--- a/goblin_native/src/shared/data/enemy/orc_camp.json
+++ b/goblin_native/src/shared/data/enemy/orc_camp.json
@@ -13,7 +13,7 @@
       "spd": 7,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 23,
+      "accuracy": 184,
       "evasion": 12,
       "exp": 15,
       "gold": 12
@@ -31,7 +31,7 @@
       "spd": 4,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 25,
+      "accuracy": 200,
       "evasion": 13,
       "exp": 20,
       "gold": 15
@@ -49,7 +49,7 @@
       "spd": 6,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 27,
+      "accuracy": 216,
       "evasion": 14,
       "exp": 22,
       "gold": 18
@@ -67,7 +67,7 @@
       "spd": 5,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 27,
+      "accuracy": 216,
       "evasion": 14,
       "exp": 25,
       "gold": 20
@@ -85,7 +85,7 @@
       "spd": 3,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 29,
+      "accuracy": 232,
       "evasion": 15,
       "exp": 30,
       "gold": 25
@@ -103,7 +103,7 @@
       "spd": 6,
       "sp": 0,
       "attackCount": 2,
-      "accuracy": 39,
+      "accuracy": 312,
       "evasion": 20,
       "exp": 120,
       "gold": 100,

--- a/goblin_native/src/shared/data/enemy/slime_cave.json
+++ b/goblin_native/src/shared/data/enemy/slime_cave.json
@@ -13,7 +13,7 @@
       "spd": 2,
       "sp": 0,
       "attackCount": 1,
-      "accuracy": 17,
+      "accuracy": 136,
       "evasion": 9,
       "exp": 3,
       "gold": 3
@@ -31,7 +31,7 @@
       "spd": 3,
       "sp": 0,
       "attackCount": 2,
-      "accuracy": 21,
+      "accuracy": 168,
       "evasion": 11,
       "exp": 12,
       "gold": 10,

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -13,7 +13,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 2 }
       ],
-      "weaponStats": { "accuracy": 1, "attackCountModifier": 0 },
+      "weaponStats": { "accuracy": 8, "attackCountModifier": 0 },
       "range": "melee",
       "price": 5,
       "unlockRank": 1,
@@ -31,7 +31,7 @@
         { "stat": "atk_flat", "value": 5 },
         { "stat": "def_flat", "value": 1 }
       ],
-      "weaponStats": { "accuracy": 2, "attackCountModifier": -0.1 },
+      "weaponStats": { "accuracy": 16, "attackCountModifier": -0.1 },
       "range": "melee",
       "price": 15,
       "unlockRank": 1,
@@ -49,7 +49,7 @@
         { "stat": "atk_flat", "value": 8 },
         { "stat": "def_flat", "value": 2 }
       ],
-      "weaponStats": { "accuracy": 3, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 24, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 1 }],
       "range": "melee",
       "price": 30,
@@ -68,7 +68,7 @@
         { "stat": "atk_flat", "value": 12 },
         { "stat": "def_flat", "value": 3 }
       ],
-      "weaponStats": { "accuracy": 4, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 32, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 2 }],
       "range": "melee",
       "price": 60,
@@ -87,7 +87,7 @@
         { "stat": "atk_flat", "value": 16 },
         { "stat": "def_flat", "value": 4 }
       ],
-      "weaponStats": { "accuracy": 6, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 48, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 3 }],
       "range": "melee",
       "price": 100,
@@ -106,7 +106,7 @@
         { "stat": "atk_flat", "value": 24 },
         { "stat": "def_flat", "value": 6 }
       ],
-      "weaponStats": { "accuracy": 9, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 72, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 4 }],
       "range": "melee",
       "price": 500,
@@ -124,7 +124,7 @@
         { "stat": "atk_flat", "value": 32 },
         { "stat": "def_flat", "value": 8 }
       ],
-      "weaponStats": { "accuracy": 12, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 96, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 5 }],
       "range": "melee",
       "price": 2500,
@@ -142,7 +142,7 @@
         { "stat": "atk_flat", "value": 48 },
         { "stat": "def_flat", "value": 10 }
       ],
-      "weaponStats": { "accuracy": 18, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 144, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 6 }],
       "range": "melee",
       "price": 12500,
@@ -161,7 +161,7 @@
         { "stat": "atk_flat", "value": 64 },
         { "stat": "def_flat", "value": 12 }
       ],
-      "weaponStats": { "accuracy": 24, "attackCountModifier": -0.2 },
+      "weaponStats": { "accuracy": 192, "attackCountModifier": -0.2 },
       "effects": [{ "type": "def_to_hp", "value": 7 }],
       "range": "melee",
       "price": 60000,
@@ -180,7 +180,7 @@
         { "stat": "atk_flat", "value": 96 },
         { "stat": "def_flat", "value": 24 }
       ],
-      "weaponStats": { "accuracy": 36, "attackCountModifier": -0.4 },
+      "weaponStats": { "accuracy": 288, "attackCountModifier": -0.4 },
       "effects": [{ "type": "def_to_hp", "value": 8 }],
       "range": "melee",
       "price": 240000,
@@ -198,7 +198,7 @@
         { "stat": "atk_flat", "value": 128 },
         { "stat": "def_flat", "value": 36 }
       ],
-      "weaponStats": { "accuracy": 48, "attackCountModifier": -0.6 },
+      "weaponStats": { "accuracy": 384, "attackCountModifier": -0.6 },
       "effects": [{ "type": "def_to_hp", "value": 9 }],
       "range": "melee",
       "price": 720000,
@@ -218,7 +218,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 3 }
       ],
-      "weaponStats": { "accuracy": 2, "attackCountModifier": 0 },
+      "weaponStats": { "accuracy": 16, "attackCountModifier": 0 },
       "range": "ranged",
       "price": 10,
       "unlockRank": 1,
@@ -235,7 +235,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 6 }
       ],
-      "weaponStats": { "accuracy": 4, "attackCountModifier": -0.1 },
+      "weaponStats": { "accuracy": 32, "attackCountModifier": -0.1 },
       "range": "ranged",
       "price": 40,
       "unlockRank": 1,
@@ -252,7 +252,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 20 }
       ],
-      "weaponStats": { "accuracy": 8, "attackCountModifier": -0.6, "evasionModifier": -8 },
+      "weaponStats": { "accuracy": 64, "attackCountModifier": -0.6, "evasionModifier": -8 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 6 },
         { "type": "accuracy_boost", "value": 30 }
@@ -273,7 +273,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 30 }
       ],
-      "weaponStats": { "accuracy": 12, "attackCountModifier": -0.6, "evasionModifier": -12 },
+      "weaponStats": { "accuracy": 96, "attackCountModifier": -0.6, "evasionModifier": -12 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 7 },
         { "type": "accuracy_boost", "value": 50 }
@@ -293,7 +293,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 45 }
       ],
-      "weaponStats": { "accuracy": 16, "attackCountModifier": -0.6, "evasionModifier": -16 },
+      "weaponStats": { "accuracy": 128, "attackCountModifier": -0.6, "evasionModifier": -16 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 8 },
         { "type": "accuracy_boost", "value": 70 }
@@ -313,7 +313,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 60 }
       ],
-      "weaponStats": { "accuracy": 24, "attackCountModifier": -0.6, "evasionModifier": -24 },
+      "weaponStats": { "accuracy": 192, "attackCountModifier": -0.6, "evasionModifier": -24 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 9 },
         { "type": "accuracy_boost", "value": 90 }
@@ -334,7 +334,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 90 }
       ],
-      "weaponStats": { "accuracy": 32, "attackCountModifier": -0.6, "evasionModifier": -32 },
+      "weaponStats": { "accuracy": 256, "attackCountModifier": -0.6, "evasionModifier": -32 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 10 },
         { "type": "accuracy_boost", "value": 110 }
@@ -355,7 +355,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 120 }
       ],
-      "weaponStats": { "accuracy": 40, "attackCountModifier": -0.6, "evasionModifier": -40 },
+      "weaponStats": { "accuracy": 320, "attackCountModifier": -0.6, "evasionModifier": -40 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 11 },
         { "type": "accuracy_boost", "value": 130 }
@@ -375,7 +375,7 @@
       "statBonuses": [
         { "stat": "atk_flat", "value": 160 }
       ],
-      "weaponStats": { "accuracy": 50, "attackCountModifier": -0.6, "evasionModifier": -50 },
+      "weaponStats": { "accuracy": 400, "attackCountModifier": -0.6, "evasionModifier": -50 },
       "effects": [
         { "type": "critical_damage_bonus", "value": 12 },
         { "type": "accuracy_boost", "value": 150 }


### PR DESCRIPTION
## Summary
- 命中率計算のaccuracy値がスケール不足で実質5〜20%しか命中しなかった問題を修正
- 命中率計算の乱数をrandA/randBの2つから仕様通り1つ(rand)に統一
- 全accuracy値を×8に引き上げ（ゴブリン/敵/装備/DB）、既存データ用のマイグレーションv6を追加

## Test plan
- [x] CombatStats テスト全50件通過
- [x] TypeScript型チェック通過
- [ ] スライムの洞窟でグラッシュの攻撃が命中することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)