### PR TITLE
refactor: 戦闘ログを集約形式に変更

### DIFF
--- a/goblin_native/docs/battle_system.md
+++ b/goblin_native/docs/battle_system.md
@@ -1,0 +1,423 @@
+# 戦闘システム仕様書
+
+## 概要
+
+ゴブリンキングダムの戦闘システムは**ターン制・全自動戦闘**を採用しています。味方ゴブリンと敵ユニットが素早さ順に行動し、攻撃回数分の通常攻撃を行います。シード付き乱数（LCG）による決定論的な戦闘で、リプレイの完全再現が可能です。
+
+## 主要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `src/core/services/BattleSystem.ts` | 戦闘メインループ・命中判定 |
+| `src/core/services/DamageCalculator.ts` | ダメージ計算 |
+| `src/core/services/ModStatCalculator.ts` | 実効ステータス計算（因子・Mod・装備） |
+| `src/core/services/CombatantManager.ts` | 戦闘参加者管理 |
+| `src/core/services/ExpeditionEngine.ts` | 遠征エンジン（戦闘を呼び出す） |
+| `src/shared/types/Battle.ts` | 戦闘関連の型定義 |
+| `src/shared/types/Goblin.ts` | ゴブリンの型定義 |
+| `src/shared/types/Enemy.ts` | 敵の型定義 |
+| `src/core/services/__tests__/CombatStats.test.ts` | 戦闘ステータスのテスト |
+
+---
+
+## ターンの流れ
+
+```
+while (currentTurn < maxTurns) {
+  1. ターン開始ログ記録（HP状態スナップショット）
+  2. 生存ユニットをSpeed順にソート（高い順）
+  3. 各ユニットが行動:
+     a. 攻撃回数分ループ（attackCount回）
+     b. ターゲット選択（隊列に基づく）
+     c. 命中判定
+     d. ダメージ計算＆適用
+     e. ログ記録
+  4. 勝敗判定:
+     - 敵全滅 → 'win'
+     - 味方全滅 → 'lose'
+     - maxTurns到達 → 'retreat'
+}
+```
+
+### 行動順序
+
+全ユニット（味方+敵）を `spd`（素早さ）の降順でソートし、高い順に行動します。
+
+---
+
+## ステータスシステム
+
+### ゴブリンのステータス（`GoblinStats`）
+
+| ステータス | 説明 | 生成時の範囲（ゴブリン族） |
+|-----------|------|------------------------|
+| `hp` | 最大HP | 55 - 80 |
+| `atk` | 攻撃力 | 10 - 16 |
+| `def` | 防御力 | 8 - 14 |
+| `sp` | スペシャル（未実装） | 7 - 13 |
+| `spd` | 素早さ | 8 - 14 |
+| `attackCount` | 攻撃回数 | 血統で決定 |
+| `accuracy` | 命中精度（×8スケール） | 120 - 200 |
+| `evasion` | 回避能力 | 10 - 20 |
+
+### 血統別の戦闘ステータス初期値
+
+| 血統 | 攻撃回数 | 命中精度基準値 | 回避基準値 |
+|------|---------|-------------|----------|
+| ゴブリン | 2 | 20 | 15 |
+| スライムゴブリン | 2 | 20 | 15 |
+| ウルフゴブリン | **3** | 20 | 15 |
+| オークゴブリン | 2 | 20 | 15 |
+| ホブゴブリン | 2 | 20 | 15 |
+
+### 実効ステータスの計算
+
+`ModStatCalculator.calculate()` で基本値から実効値を算出します。
+
+```
+最終ステータス = (基本値 + 因子ボーナス + Modフラット + 装備フラット) × (1 + (Mod% + 装備%) / 100)
+```
+
+適用順序:
+1. **基本ステータス**: ゴブリン生成時に決定
+2. **因子ボーナス**: 継承した因子による加算
+3. **Modフラット加算**: `ModInstance[]` のフラット値
+4. **装備フラット加算**: `EquipmentStatBonus` のフラット値
+5. **乗算処理**: `(1 + (Mod% + 装備%) / 100)`
+
+---
+
+## 命中判定
+
+### 命中率公式
+
+```
+hitRate = rand × (attacker.accuracy × accMod − defender.evasion × hpMod)
+hitRate = clamp(hitRate, 5, 95)
+
+判定: rng() × 100 < hitRate → 命中
+```
+
+### 攻撃回数補正（accMod）
+
+```typescript
+function getAccuracyModifier(attackNumber: number): number {
+  if (attackNumber <= 1) return 1.0
+  return 0.6 * Math.pow(0.9, attackNumber - 2)
+}
+```
+
+| 攻撃回目 | 補正値 |
+|---------|--------|
+| 1回目 | 1.0 |
+| 2回目 | 0.6 |
+| 3回目 | 0.54 |
+| 4回目 | 0.486 |
+| n回目 (n≥2) | 0.6 × 0.9^(n-2) |
+
+### 残りHP補正（hpMod）
+
+```
+hpRatio = defender.currentHP / defender.maxHP
+hpMod = 0.5 × (1 + hpRatio)
+```
+
+| HP割合 | hpMod | 効果 |
+|--------|-------|------|
+| 100% | 1.0 | 通常の回避率 |
+| 50% | 0.75 | 回避率低下 |
+| 瀕死 | ≈0.5 | 回避率半減 |
+
+HPが低いほど回避率が下がるため、集中砲火を受けたユニットは命中されやすくなります。
+
+### 命中率の上下限
+
+- **最低**: 5%（どんなに回避が高くても5%は当たる）
+- **最高**: 95%（どんなに命中が高くても5%は外れる）
+
+### 計算例
+
+ゴブリン（accuracy=150, 1回目攻撃） vs スライム（evasion=10, HP50%）:
+```
+accMod = 1.0
+hpMod = 0.5 × (1 + 0.5) = 0.75
+hitRate = 0.5 × (150 × 1.0 − 10 × 0.75) = 0.5 × 142.5 = 71.25%
+```
+
+---
+
+## ダメージ計算
+
+### ダメージ公式
+
+```
+ダメージ = floor(base × defMitigate × raceFactor × takenFactor × critFactor × rand)
+最小値: 1
+```
+
+### 各要素の詳細
+
+#### 基本攻撃力
+
+```
+base = attacker.atk × skill.power
+```
+※ 通常攻撃の `skill.power` = 1.0
+
+#### 防御軽減率
+
+```
+defMitigate = 1 − defender.def / (defender.def + 100)
+```
+
+| 防御値 | ダメージ通過率 |
+|--------|-------------|
+| 0 | 100% |
+| 50 | 67% |
+| 100 | 50% |
+| 200 | 33% |
+| 300 | 25% |
+
+#### 種族ボーナス
+
+- **攻撃側**: スキルに定義された `raceBonus` が、対象の `raceTags` に該当する場合に適用
+- **防御側**: 装備に定義された `raceTakenBonus` が、攻撃者の `raceTags` に該当する場合に適用
+
+#### クリティカル
+
+```
+判定: rng() < critRate
+critFactor = 1.5（クリティカル時）/ 1.0（通常時）
+```
+※ デフォルトの `critRate` = 0
+
+#### ランダム変動
+
+```
+rand = 0.95 + rng() × 0.10  // ±5%
+```
+
+### 攻撃回数によるダメージ補正
+
+```typescript
+function getDamageModifier(attackNumber: number): number {
+  if (attackNumber <= 2) return 1.0
+  return Math.pow(0.9, attackNumber - 2)
+}
+```
+
+| 攻撃回目 | 補正値 |
+|---------|--------|
+| 1回目 | 1.0 |
+| 2回目 | 1.0 |
+| 3回目 | 0.9 |
+| 4回目 | 0.81 |
+| 5回目 | 0.729 |
+
+→ 3回目以降は指数関数的にダメージが低下します。
+
+### 被ダメージ軽減（damage_reduction）
+
+Modや装備から`damage_reduction`ステータスを集計し、上限付きで適用:
+
+```
+reductionFactor = 1 − damageReduction / 100
+finalDamage = max(1, floor(baseDamage × dmgMod × reductionFactor))
+```
+
+---
+
+## 隊列システム
+
+### 敵の配置
+
+敵は2次元配列 `Enemy[][]` で表現されます:
+
+```
+row 0: [敵A, 敵B, 敵C]  ← 最も狙われやすい
+row 1: [敵D, 敵E]
+row 2: [敵F]             ← 最も狙われにくい
+```
+
+### 味方の配置
+
+味方は1列1ユニット。パーティ内の配列インデックスがそのまま列番号になります。
+
+### ターゲット選択アルゴリズム
+
+1. 生存ユニットを列でグループ化
+2. 前列が全滅した場合、次の列を新しい列0として詰め直し
+3. 列の狙われ率を重み付き抽選で決定
+4. 選択された列内のユニットも同じロジックで抽選
+
+### 列の狙われ率
+
+```typescript
+function getRowWeight(row: number, totalRows: number): number {
+  if (totalRows <= 1) return 1
+  const effectiveRow = Math.min(row, totalRows - 2)
+  return Math.pow(0.5, effectiveRow + 1)
+}
+```
+
+| 生存列数 | 列0 | 列1 | 列2 | 列3 | 列4 |
+|---------|-----|-----|-----|-----|-----|
+| 1 | 100% | - | - | - | - |
+| 2 | 50% | 50% | - | - | - |
+| 3 | 50% | 25% | 25% | - | - |
+| 4 | 50% | 25% | 12.5% | 12.5% | - |
+| 5 | 50% | 25% | 12.5% | 6.25% | 6.25% |
+
+※ 最後の2列は常に同率になります。
+
+---
+
+## 乱数生成（シード付きRNG）
+
+LCG（Linear Congruential Generator）を使用:
+
+```typescript
+function createSeededRandom(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1664525 + 1013904223) % 0x100000000
+    return (state >>> 0) / 0x100000000
+  }
+}
+```
+
+- **範囲**: [0.0, 1.0)
+- **用途**: 同じシードで同じ戦闘結果を再現（リプレイ機能）
+- 遠征全体で1つのシードからRNGを生成し、全イベントで共有
+
+---
+
+## 装備システムとの連携
+
+### 装備によるステータス効果
+
+| 効果タイプ | 例 |
+|-----------|-----|
+| `atk_flat` / `atk_percent` | 攻撃力の加算・乗算 |
+| `def_flat` / `def_percent` | 防御力の加算・乗算 |
+| `hp_flat` / `hp_percent` | HPの加算・乗算 |
+| `accuracy_flat` / `accuracy_percent` | 命中精度の加算・乗算 |
+| `evasion_flat` / `evasion_percent` | 回避の加算・乗算 |
+| `attackCount_flat` | 攻撃回数の追加 |
+| `damage_reduction` | 被ダメージ軽減 |
+
+### 装備スロット数（血統別）
+
+```
+スロット数 = min(baseSlots + floor(level / slotsPerLevel), maxSlots)
+```
+
+| 血統 | 初期スロット | レベル毎 | 最大スロット |
+|------|-----------|---------|-----------|
+| ゴブリン | 2 | 5Lvごとに+1 | 6 |
+| 魔獣 | 1 | 7Lvごとに+1 | 4 |
+
+---
+
+## バトル実行インターフェース
+
+### 入力
+
+```typescript
+executeBattle(
+  allies: Goblin[],         // 味方ゴブリン配列
+  initialAllyHP: number[],  // 各ゴブリンの初期HP
+  enemies: Enemy[][],       // 敵の2D配列 [row][slot]
+  rng: () => number,        // シード付き乱数関数
+  maxTurns: number = 20     // 最大ターン数
+): BattleResult
+```
+
+### 出力（`BattleResult`）
+
+```typescript
+interface BattleResult {
+  rounds: number                    // 戦闘ターン数
+  outcome: 'win' | 'lose' | 'retreat'  // 戦闘結果
+  allyHPDelta: number[]             // 各ゴブリンのHP変動
+  enemyDefeated: number             // 倒した敵の数
+  detailedLog: BattleLogEntry[]     // 全ターンの詳細ログ
+}
+```
+
+### バトルログエントリ
+
+```typescript
+interface BattleLogEntry {
+  turn: number
+  actorId: string
+  actorName: string
+  action: string            // '通常攻撃' など
+  targetId?: string
+  targetName?: string
+  damage?: number
+  missed?: boolean          // ミス判定
+  attackIndex?: number      // 複数攻撃時の回数（1-based）
+  isAlly: boolean
+  targetDefeated?: boolean
+  actorHP?: number
+  targetHP?: number
+  turnState?: {             // ターン開始時のHP状態
+    allies: Array<{ id, name, currentHP, maxHP }>
+    enemies: Array<{ id, name, currentHP, maxHP }>
+  }
+}
+```
+
+---
+
+## 遠征エンジンでの利用
+
+`ExpeditionEngine.resolveCombat()` が戦闘を呼び出します:
+
+1. `PartyState` から `Goblin[]` を再構築
+2. `BattleSystem.executeBattle()` を実行
+3. 結果の `allyHPDelta` をパーティに反映
+4. HP 0 のメンバーに `isKO = true`, `isDead = true` を設定
+
+---
+
+## 敵配置パターンの例
+
+各ダンジョンのJSONファイル（`src/shared/data/enemy/`）でパターンを定義:
+
+```json
+{
+  "patterns": [
+    {
+      "id": "P001",
+      "floors": [1, 2, 3],
+      "enemies": [
+        ["E001", "E001", "E001"]
+      ]
+    },
+    {
+      "id": "BOSS",
+      "floors": [3],
+      "enemies": [
+        ["E003", "E003", "E003", "E003", "E003"],
+        ["E004", "E004", "E004"],
+        ["B001"]
+      ],
+      "isBoss": true
+    }
+  ]
+}
+```
+
+ボス戦では複数列の敵配置となり、隊列システムが重要な役割を果たします。
+
+---
+
+## 設計上のポイント
+
+- **全自動戦闘**: プレイヤーの操作は不要。パーティ編成と装備選択が戦略の中心
+- **決定論的**: シード値で全ての乱数が決まるため、リプレイ再現が可能
+- **隊列の重要性**: 前列は狙われやすいが後列を守る壁役として機能
+- **複数回攻撃の減衰**: 高攻撃回数の血統（ウルフゴブリン等）は手数で勝るが、後半の攻撃は命中・ダメージ共に減衰
+- **HP依存の回避**: 瀕死のユニットは回避しにくく、集中砲火が有効

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -1,4 +1,4 @@
-import type { BattleLogEntry, Enemy, Goblin } from '../../shared/types'
+import type { AttackTargetDetail, BattleLogEntry, Enemy, Goblin } from '../../shared/types'
 import { CombatantManager } from './CombatantManager'
 import { DamageCalculator } from './DamageCalculator'
 import { ModStatCalculator } from './ModStatCalculator'
@@ -180,7 +180,10 @@ export class BattleSystem {
       for (const unit of actingUnits) {
         if (unit.currentHP <= 0) continue
 
-        // 攻撃回数分ループ
+        // 攻撃回数分ループ（結果を集約して1つのログにする）
+        const targetDetails: Map<string, AttackTargetDetail> = new Map()
+        let totalHitCount = 0
+
         for (let atkIdx = 0; atkIdx < unit.attackCount; atkIdx++) {
           if (unit.currentHP <= 0) break
 
@@ -194,25 +197,9 @@ export class BattleSystem {
           const hitRate = this.calculateHitRate(unit, target, atkIdx + 1, rng)
           const isHit = rng() * 100 < hitRate
 
-          if (!isHit) {
-            // ミス
-            detailedLog.push({
-              turn: currentTurn,
-              actorId: unit.combatant.id,
-              actorName: unit.combatant.name,
-              action: BASIC_ATTACK_SKILL.name,
-              targetId: target.combatant.id,
-              targetName: target.combatant.name,
-              damage: 0,
-              isAlly: unit.isAlly,
-              targetDefeated: false,
-              actorHP: unit.currentHP,
-              targetHP: target.currentHP,
-              missed: true,
-              attackIndex: atkIdx + 1,
-            })
-            continue
-          }
+          if (!isHit) continue
+
+          totalHitCount++
 
           // ダメージ計算
           const baseDamage = this.damageCalculator.calcDamage(
@@ -232,23 +219,41 @@ export class BattleSystem {
           const damage = Math.max(1, Math.floor(baseDamage * dmgMod * reductionFactor))
 
           target.currentHP = Math.max(0, target.currentHP - damage)
-          const targetDefeated = target.currentHP <= 0
 
-          detailedLog.push({
-            turn: currentTurn,
-            actorId: unit.combatant.id,
-            actorName: unit.combatant.name,
-            action: BASIC_ATTACK_SKILL.name,
-            targetId: target.combatant.id,
-            targetName: target.combatant.name,
-            damage,
-            isAlly: unit.isAlly,
-            targetDefeated,
-            actorHP: unit.currentHP,
-            targetHP: target.currentHP,
-            attackIndex: atkIdx + 1,
-          })
+          // ターゲットごとの結果を集約
+          const existing = targetDetails.get(target.combatant.id)
+          if (existing) {
+            existing.totalDamage += damage
+            existing.hitCount++
+            existing.defeated = target.currentHP <= 0
+            existing.targetHP = target.currentHP
+          } else {
+            targetDetails.set(target.combatant.id, {
+              targetId: target.combatant.id,
+              targetName: target.combatant.name,
+              targetRow: target.row + 1,
+              totalDamage: damage,
+              hitCount: 1,
+              defeated: target.currentHP <= 0,
+              targetHP: target.currentHP,
+            })
+          }
         }
+
+        // 1ユニットにつき1つのログエントリを生成
+        detailedLog.push({
+          turn: currentTurn,
+          actorId: unit.combatant.id,
+          actorName: unit.combatant.name,
+          actorRow: unit.row + 1,
+          action: BASIC_ATTACK_SKILL.name,
+          attackCount: unit.attackCount,
+          hitCount: totalHitCount,
+          actorHP: unit.currentHP,
+          actorMaxHP: unit.maxHP,
+          isAlly: unit.isAlly,
+          targets: [...targetDetails.values()],
+        })
       }
 
       const allyAlive = allyUnits.some(unit => unit.currentHP > 0)
@@ -341,14 +346,14 @@ export class BattleSystem {
       turn: currentTurn,
       actorId: 'system',
       actorName: 'ターン開始',
+      actorRow: -1,
       action: 'turn_start',
-      targetId: '',
-      targetName: '',
-      damage: 0,
-      isAlly: true,
-      targetDefeated: false,
+      attackCount: 0,
+      hitCount: 0,
       actorHP: 0,
-      targetHP: 0,
+      actorMaxHP: 0,
+      isAlly: true,
+      targets: [],
       turnState: {
         allies: allyUnits.map(unit => ({
           id: unit.combatant.id,

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -250,11 +250,10 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
 })
 
 // =========================================================================
-// BattleSystem — 命中判定と複数回攻撃
+// BattleSystem — 命中判定と複数回攻撃（集約ログ）
 // =========================================================================
 describe('BattleSystem — 命中判定と複数回攻撃', () => {
-  it('攻撃回数分のログが生成される', () => {
-    // 高命中・低回避で全ヒットさせる
+  it('攻撃回数3の場合、1つのログエントリにまとまる', () => {
     const allies = [createTestGoblin({
       stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 3, accuracy: 999, evasion: 10 },
     })]
@@ -264,12 +263,13 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const battle = new BattleSystem()
     const result = battle.executeBattle(allies, [100], enemies, rng, 1)
 
-    // 味方の攻撃ログのみ抽出
     const allyAttackLogs = result.detailedLog.filter(log => log.action === '通常攻撃' && log.isAlly)
-    expect(allyAttackLogs.length).toBe(3) // attackCount=3
+    // 1ユニットにつき1ログ
+    expect(allyAttackLogs.length).toBe(1)
+    expect(allyAttackLogs[0].attackCount).toBe(3)
   })
 
-  it('attackIndexが1から始まり攻撃回数分まで振られる', () => {
+  it('集約ログにattackCount, hitCount, targetsが含まれる', () => {
     const allies = [createTestGoblin({
       stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 3, accuracy: 999, evasion: 10 },
     })]
@@ -279,9 +279,12 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const battle = new BattleSystem()
     const result = battle.executeBattle(allies, [100], enemies, rng, 1)
 
-    const allyAttackLogs = result.detailedLog.filter(log => log.action === '通常攻撃' && log.isAlly)
-    const indices = allyAttackLogs.map(log => log.attackIndex)
-    expect(indices).toEqual([1, 2, 3])
+    const log = result.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    expect(log.attackCount).toBe(3)
+    expect(log.hitCount).toBeGreaterThan(0)
+    expect(log.targets.length).toBeGreaterThan(0)
+    expect(log.targets[0].totalDamage).toBeGreaterThan(0)
+    expect(log.targets[0].hitCount).toBeGreaterThan(0)
   })
 
   it('命中精度0・回避極大でほぼ全ミスになる', () => {
@@ -290,16 +293,16 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     })]
     const enemies = [[createTestEnemy({ hp: 9999, spd: 1, evasion: 999 })]]
 
-    // 100ターン戦って、ミス率を確認
     const rng = createSeededRng(1)
     const battle = new BattleSystem()
     const result = battle.executeBattle(allies, [100], enemies, rng, 100)
 
-    const attackLogs = result.detailedLog.filter(log => log.action === '通常攻撃')
-    const missedLogs = attackLogs.filter(log => log.missed === true)
+    const allyAttackLogs = result.detailedLog.filter(log => log.action === '通常攻撃' && log.isAlly)
+    const totalAttacks = allyAttackLogs.reduce((sum, log) => sum + log.attackCount, 0)
+    const totalHits = allyAttackLogs.reduce((sum, log) => sum + log.hitCount, 0)
 
     // 命中率下限5%なので、ほとんどがミスになるはず（90%以上ミス）
-    expect(missedLogs.length / attackLogs.length).toBeGreaterThan(0.8)
+    expect((totalAttacks - totalHits) / totalAttacks).toBeGreaterThan(0.8)
   })
 
   it('命中精度極大・回避0でほぼ全ヒットになる', () => {
@@ -313,13 +316,15 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const result = battle.executeBattle(allies, [100], enemies, rng, 100)
 
     const allyAttackLogs = result.detailedLog.filter(log => log.action === '通常攻撃' && log.isAlly)
-    const hitLogs = allyAttackLogs.filter(log => !log.missed)
+    const totalAttacks = allyAttackLogs.reduce((sum, log) => sum + log.attackCount, 0)
+    const totalHits = allyAttackLogs.reduce((sum, log) => sum + log.hitCount, 0)
 
     // 命中率上限95%なので、ほぼ全ヒット（80%以上ヒット）
-    expect(hitLogs.length / allyAttackLogs.length).toBeGreaterThan(0.8)
+    expect(totalHits / totalAttacks).toBeGreaterThan(0.8)
   })
 
-  it('ミス時はdamage=0でmissed=trueが記録される', () => {
+  it('全ミス時はhitCount=0でtargetsが空になる', () => {
+    // accuracy=0, evasion=999で強制的に全ミス状態を作る
     const allies = [createTestGoblin({
       stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 1, accuracy: 0, evasion: 10 },
     })]
@@ -329,13 +334,14 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const battle = new BattleSystem()
     const result = battle.executeBattle(allies, [100], enemies, rng, 50)
 
-    const missedLog = result.detailedLog.find(log => log.missed === true)
+    const missedLog = result.detailedLog.find(
+      log => log.action === '通常攻撃' && log.isAlly && log.hitCount === 0
+    )
     expect(missedLog).toBeDefined()
-    expect(missedLog!.damage).toBe(0)
+    expect(missedLog!.targets.length).toBe(0)
   })
 
-  it('敵も複数回攻撃できる', () => {
-    // 敵のattackCount=3、高命中で全ヒットさせる
+  it('敵も複数回攻撃でき、1つのログにまとまる', () => {
     const allies = [createTestGoblin({
       stats: { hp: 9999, atk: 5, sp: 10, spd: 1, def: 10, attackCount: 1, accuracy: 20, evasion: 0 },
     })]
@@ -348,11 +354,12 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const enemyAttackLogs = result.detailedLog.filter(
       log => log.action === '通常攻撃' && !log.isAlly
     )
-    expect(enemyAttackLogs.length).toBe(3)
+    // 1ユニットにつき1ログ
+    expect(enemyAttackLogs.length).toBe(1)
+    expect(enemyAttackLogs[0].attackCount).toBe(3)
   })
 
   it('残りHP低下で回避率が下がる（HP1 vs 全快で比較）', () => {
-    // 同一条件で、味方のHP差だけ変えて回避率を比較
     const statsBase = { hp: 100, atk: 5, sp: 10, spd: 1, def: 10, attackCount: 1, accuracy: 20, evasion: 30 }
 
     // 全快ケース
@@ -365,8 +372,8 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
       const battle = new BattleSystem()
       const result = battle.executeBattle(allies, [100], enemies, rng, 5)
       const logs = result.detailedLog.filter(log => log.action === '通常攻撃' && !log.isAlly)
-      totalFull += logs.length
-      hitCountFull += logs.filter(log => !log.missed).length
+      totalFull += logs.reduce((sum, log) => sum + log.attackCount, 0)
+      hitCountFull += logs.reduce((sum, log) => sum + log.hitCount, 0)
     }
 
     // HP1ケース
@@ -379,8 +386,8 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
       const battle = new BattleSystem()
       const result = battle.executeBattle(allies, [1], enemies, rng, 5)
       const logs = result.detailedLog.filter(log => log.action === '通常攻撃' && !log.isAlly)
-      totalLow += logs.length
-      hitCountLow += logs.filter(log => !log.missed).length
+      totalLow += logs.reduce((sum, log) => sum + log.attackCount, 0)
+      hitCountLow += logs.reduce((sum, log) => sum + log.hitCount, 0)
     }
 
     const hitRateFull = hitCountFull / totalFull
@@ -388,6 +395,40 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
 
     // HP1だと回避率が半減するので、敵の命中率が上がるはず
     expect(hitRateLow).toBeGreaterThan(hitRateFull)
+  })
+
+  it('actorRowが正しく記録される', () => {
+    const allies = [createTestGoblin({
+      stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 10 },
+    })]
+    const enemies = [[createTestEnemy({ hp: 9999, spd: 1, evasion: 0 })]]
+
+    const rng = createSeededRng(42)
+    const battle = new BattleSystem()
+    const result = battle.executeBattle(allies, [100], enemies, rng, 1)
+
+    const allyLog = result.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    expect(allyLog.actorRow).toBe(1) // 最初の味方は列1（1-based）
+  })
+
+  it('ターゲットのtargetRowが正しく記録される', () => {
+    const allies = [createTestGoblin({
+      stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 10 },
+    })]
+    const enemies = [
+      [createTestEnemy({ id: 'E1', name: '前列敵', hp: 9999, spd: 1, evasion: 0 })],
+      [createTestEnemy({ id: 'E2', name: '後列敵', hp: 9999, spd: 1, evasion: 0 })],
+    ]
+
+    const rng = createSeededRng(42)
+    const battle = new BattleSystem()
+    const result = battle.executeBattle(allies, [100], enemies, rng, 1)
+
+    const allyLog = result.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    expect(allyLog.targets.length).toBeGreaterThan(0)
+    for (const target of allyLog.targets) {
+      expect(target.targetRow).toBeGreaterThanOrEqual(1)
+    }
   })
 })
 
@@ -680,7 +721,7 @@ describe('BattleSystem — 隊列統合テスト', () => {
 
   it('前列の敵が後列より多くダメージを受ける（統計的検証）', () => {
     // 3列の敵に攻撃して、ダメージの分布を確認
-    const damageByRow: Record<string, number> = { '前列': 0, '中列': 0, '後列': 0 }
+    const damageByName: Record<string, number> = { '前列': 0, '中列': 0, '後列': 0 }
 
     for (let seed = 0; seed < 100; seed++) {
       const allies = [createTestGoblin({
@@ -697,14 +738,16 @@ describe('BattleSystem — 隊列統合テスト', () => {
       const result = battle.executeBattle(allies, [9999], enemies, rng, 5)
 
       for (const log of result.detailedLog) {
-        if (log.action === '通常攻撃' && log.isAlly && !log.missed && log.damage) {
-          damageByRow[log.targetName!] = (damageByRow[log.targetName!] ?? 0) + log.damage
+        if (log.action === '通常攻撃' && log.isAlly) {
+          for (const target of log.targets) {
+            damageByName[target.targetName] = (damageByName[target.targetName] ?? 0) + target.totalDamage
+          }
         }
       }
     }
 
     // 3列: 1/2, 1/4, 1/4 → 前列が最もダメージを受ける
-    expect(damageByRow['前列']).toBeGreaterThan(damageByRow['中列'])
-    expect(damageByRow['前列']).toBeGreaterThan(damageByRow['後列'])
+    expect(damageByName['前列']).toBeGreaterThan(damageByName['中列'])
+    expect(damageByName['前列']).toBeGreaterThan(damageByName['後列'])
   })
 })

--- a/goblin_native/src/shared/types/Battle.ts
+++ b/goblin_native/src/shared/types/Battle.ts
@@ -1,18 +1,26 @@
+/** ターゲットごとのダメージ詳細 */
+export interface AttackTargetDetail {
+  targetId: string
+  targetName: string
+  targetRow: number       // ターゲットの隊列番号
+  totalDamage: number     // このターゲットへの合計ダメージ
+  hitCount: number        // このターゲットへの命中回数
+  defeated: boolean       // この攻撃で倒したか
+  targetHP: number        // 攻撃後の残りHP
+}
+
 export interface BattleLogEntry {
   turn: number
   actorId: string
   actorName: string
+  actorRow: number        // 攻撃者の隊列番号
   action: string
-  targetId?: string
-  targetName?: string
-  damage?: number
-  healing?: number
-  missed?: boolean        // 命中判定でミスした場合true
-  attackIndex?: number    // 複数回攻撃時の何回目か（1-based）
+  attackCount: number     // 総攻撃回数
+  hitCount: number        // 総命中回数
+  actorHP: number         // 攻撃者の現在HP
+  actorMaxHP: number      // 攻撃者の最大HP
   isAlly: boolean
-  targetDefeated?: boolean
-  actorHP?: number
-  targetHP?: number
+  targets: AttackTargetDetail[]  // ターゲットごとの結果
   turnState?: {
     allies: Array<{ id: string; name: string; currentHP: number; maxHP: number }>
     enemies: Array<{ id: string; name: string; currentHP: number; maxHP: number }>

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -47,7 +47,7 @@ export type {
 } from "./Equipment"
 
 // Battle related types
-export type { BattleLogEntry, CombatReplay } from "./Battle"
+export type { AttackTargetDetail, BattleLogEntry, CombatReplay } from "./Battle"
 
 // Expedition related types
 export type {


### PR DESCRIPTION
## Summary
- 攻撃回数分の個別ログエントリを、1ユニット1エントリの集約形式に変更
- `BattleLogEntry` に `attackCount`, `hitCount`, `actorRow`, `targets: AttackTargetDetail[]` を追加
- 隊列番号をログ上は1-based（列1始まり）で記録
- 戦闘システムの仕様ドキュメント (`docs/battle_system.md`) を新規追加

## Test plan
- [x] 全52テスト通過確認済み（`npx jest CombatStats.test.ts`）
- [ ] 集約ログのattackCount/hitCount/targetsが正しく記録されることを確認
- [ ] actorRow/targetRowが1-basedで記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)