### PR TITLE
fix: 戦闘ログUI修正・戦闘結果表示追加・DBリセットエラー修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -2,18 +2,21 @@ import { useMemo, useEffect } from 'react'
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
-import type { BattleLogEntry } from '@/shared/types'
+import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
 
 export default function BattleLogScreen() {
   const { logId } = useLocalSearchParams<{ logId?: string }>()
 
-  const battleLog = useMemo<BattleLogEntry[] | null>(() => {
+  const stored = useMemo(() => {
     if (!logId) return null
     const raw = Array.isArray(logId) ? logId[0] : logId
     if (!raw) return null
     return getBattleLog(raw)
   }, [logId])
+
+  const battleLog = stored?.log ?? null
+  const meta = stored?.meta ?? null
 
   useEffect(() => {
     const raw = Array.isArray(logId) ? logId[0] : logId
@@ -77,20 +80,56 @@ export default function BattleLogScreen() {
             return (
               <View key={`log-${index}`} style={styles.logCard}>
                 <Text style={styles.logTitle}>
-                  {entry.actorName}の攻撃 ({entry.actorHP ?? 0}HP)
+                  {entry.actorName}の{entry.attackCount}回攻撃（{entry.actorHP}/{entry.actorMaxHP}HP）
                 </Text>
-                <Text style={styles.logText}>{entry.actorName}の{entry.action}！</Text>
-                {entry.targetName && typeof entry.damage === 'number' && (
-                  <Text style={styles.logText}>
-                    {entry.targetName}に{entry.damage}ダメージを与え{entry.targetDefeated ? '倒した！' : 'た！'}
+                <Text style={styles.logText}>
+                  [列{entry.actorRow}] {entry.actorName}の攻撃！{entry.hitCount}回ヒット！
+                </Text>
+                {entry.targets?.map((target, targetIndex) => (
+                  <Text key={`target-${targetIndex}`} style={styles.logText}>
+                    [列{target.targetRow}] {target.targetName}に {target.totalDamage}ダメージ{target.defeated ? 'を与えて倒した！' : `(${target.hitCount}回)`}
                   </Text>
-                )}
+                ))}
               </View>
             )
           })}
+
+          {meta && <BattleResultSection meta={meta} />}
         </ScrollView>
       )}
     </SafeAreaView>
+  )
+}
+
+function BattleResultSection({ meta }: { meta: BattleLogMeta }) {
+  const outcomeText = meta.outcome === 'win' ? '戦いに勝利した！' : '戦いに敗北した...'
+
+  return (
+    <View style={styles.resultCard}>
+      <Text style={styles.resultTitle}>{outcomeText}</Text>
+
+      {meta.outcome === 'win' && (
+        <>
+          <Text style={styles.resultSummary}>
+            経験値 {meta.xpGained} と {meta.goldGained} gold を手に入れました。
+          </Text>
+
+          <Text style={styles.resultLabel}>＜獲得経験値＞</Text>
+          {meta.members.map((member, index) => (
+            <Text key={`xp-${index}`} style={styles.resultText}>
+              Exp +{member.xpEach} {member.name} ({member.xpEach} x {member.expMultiplier}倍)
+            </Text>
+          ))}
+        </>
+      )}
+
+      <Text style={styles.resultLabel}> </Text>
+      {meta.members.map((member, index) => (
+        <Text key={`status-${index}`} style={styles.resultText}>
+          ({member.currentHP}/{member.maxHP}) {member.name} Lv{member.level}
+        </Text>
+      ))}
+    </View>
   )
 }
 
@@ -178,6 +217,36 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   logText: {
+    fontSize: 12,
+    color: '#374151',
+    marginTop: 2,
+  },
+  resultCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+  },
+  resultTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  resultSummary: {
+    fontSize: 13,
+    color: '#374151',
+    marginBottom: 10,
+  },
+  resultLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+    marginTop: 6,
+    marginBottom: 2,
+  },
+  resultText: {
     fontSize: 12,
     color: '#374151',
     marginTop: 2,

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -12,7 +12,7 @@ import { CompleteExpeditionUseCase } from '@/core/usecases'
 import { GoblinBirthService } from '@/core/services'
 import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
 import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason, Party } from '@/shared/types'
-import type { BattleLogEntry } from '@/shared/types'
+import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
@@ -21,6 +21,7 @@ interface LogEntry {
   id: string
   text: string
   detail?: BattleLogEntry[]
+  meta?: BattleLogMeta
 }
 
 export default function ExpeditionPlaybackScreen() {
@@ -138,8 +139,8 @@ export default function ExpeditionPlaybackScreen() {
     return `${minutes}:${secs.toString().padStart(2, '0')}`
   }, [])
 
-  const openBattleLog = useCallback((detail: BattleLogEntry[]) => {
-    const logId = storeBattleLog(detail)
+  const openBattleLog = useCallback((detail: BattleLogEntry[], meta?: BattleLogMeta) => {
+    const logId = storeBattleLog(detail, meta)
     router.push(`/formation/battle-log?logId=${encodeURIComponent(logId)}` as Href)
   }, [])
 
@@ -152,9 +153,9 @@ export default function ExpeditionPlaybackScreen() {
   }, [])
 
   const buildLogEntries = useCallback((event: TimelineEvent): LogEntry[] => {
-    const createEntry = (text: string, detail?: BattleLogEntry[]) => {
+    const createEntry = (text: string, detail?: BattleLogEntry[], meta?: BattleLogMeta) => {
       logIdRef.current += 1
-      return { id: `${logIdRef.current}`, text, detail }
+      return { id: `${logIdRef.current}`, text, detail, meta }
     }
     switch (event.type) {
       case 'move_start':
@@ -167,10 +168,33 @@ export default function ExpeditionPlaybackScreen() {
       case 'boss': {
         const label = event.type === 'boss' ? 'ボス' : '戦闘'
         const result = event.combat.outcome === 'win' ? '勝利' : '敗北'
+        const partyMembers = replay?.meta.party ?? []
+        const xpPerMember = partyMembers.length > 0 ? Math.floor(event.xp / partyMembers.length) : 0
+        const meta: BattleLogMeta = {
+          outcome: event.combat.outcome,
+          xpGained: event.xp,
+          goldGained: event.enemy.gold,
+          members: partyMembers.map((memberId, idx) => {
+            const goblin = goblins.find(g => g.id === parseInt(memberId, 10))
+            const allyLog = event.combat.detailedLog?.filter(e => e.isAlly && e.action !== 'turn_start')
+            const lastEntry = allyLog?.findLast(e => e.actorId === memberId)
+            return {
+              name: goblin?.name ?? `ID:${memberId}`,
+              currentHP: lastEntry?.actorHP ?? (event.combat.allyHPDelta[idx] !== undefined
+                ? (goblin ? ModStatCalculator.calculate(goblin).hp : 100) + event.combat.allyHPDelta[idx]
+                : 0),
+              maxHP: goblin ? ModStatCalculator.calculate(goblin).hp : 100,
+              level: goblin?.level ?? 1,
+              xpEach: xpPerMember,
+              expMultiplier: 1,
+            }
+          }),
+        }
         const entries: LogEntry[] = [
           createEntry(
             `${label} ${event.enemy.name} Lv${event.enemy.lvl} ×${event.enemy.count}体と遭遇 → ${result}[詳細]`,
             event.combat.detailedLog,
+            meta,
           ),
         ]
         if (event.xp > 0) {
@@ -179,15 +203,18 @@ export default function ExpeditionPlaybackScreen() {
         return entries
       }
       case 'treasure': {
-        const itemNames = event.items.map(item => item.name).join('、')
-        return [createEntry(`宝箱を発見！ ${itemNames} を手に入れた`)]
+        const entries: LogEntry[] = [createEntry('宝箱を発見！')]
+        for (const item of event.items) {
+          entries.push(createEntry(`${item.name}が入っていた！`))
+        }
+        return entries
       }
       case 'return':
         return [createEntry(getReturnReasonText(event.reason))]
       default:
         return [createEntry('イベント発生')]
     }
-  }, [getReturnReasonText])
+  }, [getReturnReasonText, goblins, replay])
 
   const applyEvent = useCallback((event: TimelineEvent, eventTime: number) => {
     const entries = buildLogEntries(event)
@@ -477,7 +504,7 @@ export default function ExpeditionPlaybackScreen() {
                   activeOpacity={0.7}
                   accessibilityRole="button"
                   hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
-                  onPress={() => openBattleLog(entry.detail!)}
+                  onPress={() => openBattleLog(entry.detail!, entry.meta)}
                 >
                   <Text style={styles.logText}>{baseText}</Text>
                   <Text style={styles.logDetail}>詳細</Text>

--- a/goblin_native/src/infrastructure/database/migrations/v5.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v5.ts
@@ -5,10 +5,17 @@ import type * as SQLite from 'expo-sqlite'
  * キャッシュ削除後もアトミックなID採番を行うため
  */
 export const migrateV5 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
-  // next_goblin_id カラムを追加
-  await database.execAsync(`
-    ALTER TABLE base_state ADD COLUMN next_goblin_id INTEGER NOT NULL DEFAULT 1
-  `)
+  // next_goblin_id カラムが既に存在するかチェック（v1スキーマに含まれている場合はスキップ）
+  const columns = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(base_state)"
+  )
+  const hasColumn = columns.some(col => col.name === 'next_goblin_id')
+
+  if (!hasColumn) {
+    await database.execAsync(`
+      ALTER TABLE base_state ADD COLUMN next_goblin_id INTEGER NOT NULL DEFAULT 1
+    `)
+  }
 
   // 現在の MAX(id)+1 で初期化
   const goblinMax = await database.getFirstAsync<{ max_id: number | null }>(

--- a/goblin_native/src/presentation/contexts/battleLogStore.ts
+++ b/goblin_native/src/presentation/contexts/battleLogStore.ts
@@ -1,16 +1,21 @@
-import type { BattleLogEntry } from '@/shared/types'
+import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 
-const battleLogStore = new Map<string, BattleLogEntry[]>()
+interface StoredBattleLog {
+  log: BattleLogEntry[]
+  meta?: BattleLogMeta
+}
+
+const battleLogStore = new Map<string, StoredBattleLog>()
 let logCounter = 0
 
-export const storeBattleLog = (log: BattleLogEntry[]): string => {
+export const storeBattleLog = (log: BattleLogEntry[], meta?: BattleLogMeta): string => {
   logCounter += 1
   const id = `${Date.now()}-${logCounter}`
-  battleLogStore.set(id, log)
+  battleLogStore.set(id, { log, meta })
   return id
 }
 
-export const getBattleLog = (id: string): BattleLogEntry[] | null => {
+export const getBattleLog = (id: string): StoredBattleLog | null => {
   return battleLogStore.get(id) ?? null
 }
 

--- a/goblin_native/src/shared/types/Battle.ts
+++ b/goblin_native/src/shared/types/Battle.ts
@@ -27,6 +27,22 @@ export interface BattleLogEntry {
   }
 }
 
+/** 戦闘結果のメタ情報（ログ表示用） */
+export interface BattleLogMeta {
+  outcome: 'win' | 'lose' | 'escape'
+  xpGained: number
+  goldGained: number
+  /** 隊列順のパーティメンバー情報 */
+  members: Array<{
+    name: string
+    currentHP: number
+    maxHP: number
+    level: number
+    xpEach: number
+    expMultiplier: number
+  }>
+}
+
 export interface CombatReplay {
   rounds: number
   outcome: "win" | "lose" | "escape"

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -47,7 +47,7 @@ export type {
 } from "./Equipment"
 
 // Battle related types
-export type { AttackTargetDetail, BattleLogEntry, CombatReplay } from "./Battle"
+export type { AttackTargetDetail, BattleLogEntry, BattleLogMeta, CombatReplay } from "./Battle"
 
 // Expedition related types
 export type {


### PR DESCRIPTION
## Summary
- DBリセット時のnext_goblin_idカラム重複エラーを修正（v5マイグレーションにカラム存在チェック追加）
- 戦闘ログ詳細画面を集約形式のBattleLogEntryに対応（隊列番号・攻撃/命中回数表示）
- 戦闘終了時の結果セクション追加（勝敗・経験値・gold・メンバーHP/Lv表示）
- 宝箱発見時のログをアイテムごとの複数行表示に変更

## Test plan
- [ ] DBリセットボタンを押してエラーが発生しないことを確認
- [ ] 遠征再生で戦闘詳細ログを開き、隊列番号・攻撃回数・命中数が正しく表示されることを確認
- [ ] 戦闘ログ末尾に勝敗・経験値・gold・メンバー状態が表示されることを確認
- [ ] 宝箱発見時にアイテムが個別行で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)