### PR TITLE
fix: グラッシュ初期ステータスをLv1相当に変更

### DIFF
--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -151,6 +151,6 @@ export const SCHEMA = {
   goblinsInit: `
     INSERT OR IGNORE INTO goblins (id, name, race, level, experience, avatar, stats_json)
     VALUES
-      (0, 'グラッシュ', 'ゴブリン', 15, 0, '/src/assets/goblin/goblin.png', '{"hp":100,"atk":70,"sp":45,"spd":60,"def":65,"attackCount":2,"accuracy":160,"evasion":15}')
+      (0, 'グラッシュ', 'ゴブリン', 1, 0, '/src/assets/goblin/goblin.png', '{"hp":68,"atk":13,"sp":10,"spd":11,"def":11,"attackCount":1,"accuracy":160,"evasion":15}')
   `,
 }

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -151,6 +151,6 @@ export const SCHEMA = {
   goblinsInit: `
     INSERT OR IGNORE INTO goblins (id, name, race, level, experience, avatar, stats_json)
     VALUES
-      (0, 'グラッシュ', 'ゴブリン', 1, 0, '/src/assets/goblin/goblin.png', '{"hp":68,"atk":13,"sp":10,"spd":11,"def":11,"attackCount":1,"accuracy":160,"evasion":15}')
+      (0, 'グラッシュ', 'ゴブリン', 1, 0, '/src/assets/goblin/goblin.png', '{"hp":68,"atk":13,"sp":10,"spd":11,"def":11,"attackCount":2,"accuracy":160,"evasion":15}')
   `,
 }

--- a/goblin_native/src/shared/data/index.ts
+++ b/goblin_native/src/shared/data/index.ts
@@ -1,16 +1,4 @@
-import type { Goblin, Dungeon } from '../types'
+import type { Dungeon } from '../types'
 import allAreaJson from './expeditionArea/allArea.json'
-
-export const goblinsData: Goblin[] = [
-  {
-    id: 0,
-    name: 'グラッシュ',
-    race: 'ゴブリン',
-    level: 15,
-    experience: 0,
-    avatar: '/src/assets/goblin/goblin.png',
-    stats: { hp: 100, atk: 70, sp: 45, spd: 60, def: 65, attackCount: 2, accuracy: 25, evasion: 20 }
-  }
-]
 
 export const areasData: Dungeon[] = allAreaJson.areas


### PR DESCRIPTION
## Summary
- グラッシュの初期ステータスをLv15→Lv1相当に変更（GoblinBirthServiceのSTAT_RANGES中間値ベース）
- `shared/data/index.ts`の未使用`goblinsData`を削除（実際のデータソースは`schema.ts`のDB初期データ）

## Test plan
- [ ] DBリセット後、グラッシュがLv1ステータスで生成されることを確認
- [ ] `areasData`のインポートが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)