### PR TITLE
feat: ゴブリン詳細画面にスタックヘッダーを追加

### DIFF
--- a/goblin_native/app/_layout.tsx
+++ b/goblin_native/app/_layout.tsx
@@ -43,7 +43,17 @@ export default function RootLayout() {
             <ResetProvider resetAndReinitialize={resetAndReinitialize}>
               <Stack screenOptions={{ headerShown: false }}>
                 <Stack.Screen name="(tabs)" />
-                <Stack.Screen name="goblin" />
+                <Stack.Screen
+                  name="goblin"
+                  options={{
+                    headerShown: true,
+                    headerStyle: { backgroundColor: '#FFFFFF' },
+                    headerTitleStyle: { color: '#1F2937', fontWeight: 'bold' },
+                    headerTintColor: '#6B7280',
+                    headerBackTitle: '戻る',
+                    title: 'ゴブリン詳細',
+                  }}
+                />
               </Stack>
               <StatusBar style="auto" />
             </ResetProvider>

--- a/goblin_native/app/goblin/_layout.tsx
+++ b/goblin_native/app/goblin/_layout.tsx
@@ -4,23 +4,19 @@ export default function GoblinLayout() {
   return (
     <Stack
       screenOptions={{
-        headerShown: true,
-        headerStyle: { backgroundColor: '#FFFFFF' },
-        headerTitleStyle: { color: '#1F2937', fontWeight: 'bold' },
-        headerTintColor: '#6B7280',
+        headerShown: false,
       }}
     >
-      <Stack.Screen
-        name="detail"
-        options={{
-          title: 'ゴブリン詳細',
-        }}
-      />
+      <Stack.Screen name="detail" />
       <Stack.Screen
         name="equipment"
         options={{
+          headerShown: true,
           title: '装備変更',
           presentation: 'modal',
+          headerStyle: { backgroundColor: '#FFFFFF' },
+          headerTitleStyle: { color: '#1F2937', fontWeight: 'bold' },
+          headerTintColor: '#6B7280',
         }}
       />
     </Stack>

--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useEffect, useState } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useLocalSearchParams, router, Stack } from 'expo-router'
+import { useLocalSearchParams, router, useNavigation } from 'expo-router'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import type { Goblin } from '@/shared/types'
 import { getFactor } from '@/shared/data/factors'
@@ -31,6 +31,7 @@ export default function GoblinDetailScreen() {
   const { goblinId } = useLocalSearchParams<{ goblinId: string }>()
   const { getGoblinById, deleteGoblin } = useGoblinService()
   const [goblin, setGoblin] = useState<Goblin | null>(null)
+  const parentNav = useNavigation()
 
   useEffect(() => {
     if (!goblinId) return
@@ -38,6 +39,12 @@ export default function GoblinDetailScreen() {
       .then(setGoblin)
       .catch(() => setGoblin(null))
   }, [goblinId, getGoblinById])
+
+  useEffect(() => {
+    if (goblin) {
+      parentNav.getParent()?.setOptions({ title: goblin.name })
+    }
+  }, [goblin, parentNav])
 
   const effectiveStats = useMemo(
     () => goblin ? ModStatCalculator.calculate(goblin) : null,
@@ -74,7 +81,6 @@ export default function GoblinDetailScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <Stack.Screen options={{ title: goblin.name, headerShown: true }} />
       <ScrollView style={styles.content}>
         <View style={styles.profileCard}>
           <View style={styles.profileRow}>


### PR DESCRIPTION
## Summary
- ゴブリン詳細画面にスタックヘッダー（戻るボタン付き）を追加
- ルートStackでgoblinグループのヘッダーを有効化し、ゴブリン名を動的にタイトル表示
- goblin Stackのヘッダーは無効化して二重ヘッダーを防止

## Test plan
- [ ] ゴブリン一覧からゴブリンをタップして詳細画面を開き、ヘッダーが表示されることを確認
- [ ] ヘッダーにゴブリン名が表示されることを確認
- [ ] 戻るボタンで一覧に戻れることを確認
- [ ] 装備変更画面のモーダルヘッダーが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)