### PR TITLE
fix: 遠征完了処理の二重実行を修正・injuries仕様を削除

### DIFF
--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -6,11 +6,6 @@ import { usePartyService } from '@/presentation/hooks/usePartyService'
 import { useGoblinService } from '@/presentation/hooks/useGoblinService'
 import { useDungeonProgress } from '@/presentation/hooks/useDungeonProgress'
 import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
-import { usePendingGoblins } from '@/presentation/hooks/usePendingGoblins'
-import { useBaseState } from '@/presentation/hooks/useBaseState'
-import { CompleteExpeditionUseCase } from '@/core/usecases'
-import { GoblinBirthService } from '@/core/services'
-import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
 import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason, Party } from '@/shared/types'
 import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
@@ -30,16 +25,13 @@ export default function ExpeditionPlaybackScreen() {
     expeditionId?: string
   }>()
 
-  const { getPartyById, partyRepository, isLoading: isPartyLoading } = usePartyService()
-  const { goblins, goblinRepository, isLoading: isGoblinLoading } = useGoblinService()
+  const { getPartyById, isLoading: isPartyLoading } = usePartyService()
+  const { isLoading: isGoblinLoading } = useGoblinService()
   const { dungeons } = useDungeonProgress()
-  const { pendingGoblins, addPendingGoblin, isLoading: isPendingLoading } = usePendingGoblins()
-  const { rank, getNextGoblinId, isLoading: isBaseLoading, baseStateRepository } = useBaseState()
   const {
     expeditionRecords,
     getExpeditionById,
     getPartyExpeditionHistory,
-    completeExpeditionRecord,
     isLoading: isExpeditionLoading,
   } = useExpeditionService()
 
@@ -102,41 +94,6 @@ export default function ExpeditionPlaybackScreen() {
   const processedEventIndexRef = useRef(0)
   const hasCompletedRef = useRef(false)
   const logIdRef = useRef(0)
-
-  const completeExpeditionUseCase = useMemo(() => {
-    return new CompleteExpeditionUseCase(goblinRepository, partyRepository, baseStateRepository, SQLiteEquipmentRepository.getInstance())
-  }, [goblinRepository, partyRepository, baseStateRepository])
-
-  const addPendingGoblinOnClear = useCallback(async () => {
-    if (!expeditionRecord || !replay || isPendingLoading || isBaseLoading) return
-    const targetDungeon = dungeon ?? dungeons.find(area => area.id === expeditionRecord.dungeonId)
-    if (!targetDungeon) return
-
-    const cleared = replay.summary.success &&
-      replay.summary.maxFloorReached >= targetDungeon.floors
-    if (!cleared) return
-
-    const maxPending = rank * 5
-    if (pendingGoblins.length >= maxPending) return
-
-    const nextId = await getNextGoblinId()
-    const areaLevel = Math.min(64, targetDungeon.areaLevel ?? 1)
-    const goblinBirthService = new GoblinBirthService()
-    const newGoblin = goblinBirthService.createNewGoblin(nextId, undefined, goblins, areaLevel, rank)
-    await addPendingGoblin(newGoblin)
-  }, [
-    addPendingGoblin,
-    dungeons,
-    dungeon,
-    expeditionRecord,
-    getNextGoblinId,
-    goblins,
-    isBaseLoading,
-    isPendingLoading,
-    pendingGoblins.length,
-    rank,
-    replay,
-  ])
 
   const formatTime = useCallback((seconds: number): string => {
     const minutes = Math.floor(seconds / 60)
@@ -286,14 +243,9 @@ export default function ExpeditionPlaybackScreen() {
       return
     }
 
-    try {
-      await completeExpeditionUseCase.execute(expeditionRecord.partyId, replay)
-      await addPendingGoblinOnClear()
-      await completeExpeditionRecord(expeditionRecord.id, replay)
-    } catch (error) {
-      console.warn('[Playback] Failed to complete expedition', error)
-    }
-  }, [expeditionRecord, replay, completeExpeditionUseCase, completeExpeditionRecord, addPendingGoblinOnClear])
+    // 完了処理は useExpeditionFlow の completeDueExpeditions に一本化。
+    // playback側ではタイマー停止のみ行う。
+  }, [expeditionRecord, replay])
 
   useEffect(() => {
     if (isPartyLoading || isGoblinLoading || isExpeditionLoading) return

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -79,9 +79,7 @@ export default function ExpeditionResultScreen() {
       const isCasualty = replay.summary.casualties.includes(goblin.id.toString())
       if (isCasualty) continue
 
-      const isInjured = replay.summary.injuries.includes(goblin.id.toString())
-      const multiplier = isInjured ? 0.5 : 1.0
-      const expGained = Math.floor(replay.summary.xpGained * multiplier)
+      const expGained = replay.summary.xpGained
       const result = addExperience(goblin.level, goblin.experience, expGained)
       if (result.didLevelUp) {
         map.set(goblin.id, { oldLevel: goblin.level, newLevel: result.newLevel })

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -586,7 +586,6 @@ export class ExpeditionEngine {
     }
 
     const casualties = partyState.filter(member => member.isDead).map(member => member.id)
-    const injuries = partyState.filter(member => member.isKO && !member.isDead).map(member => member.id)
     const successReasons: Set<ExpeditionEndReason> = new Set([
       "completed",
       "policy_return"
@@ -603,7 +602,6 @@ export class ExpeditionEngine {
       xpGained,
       goldGained,
       casualties,
-      injuries,
       treasureDrops: treasureDrops.length > 0 ? treasureDrops : undefined,
     }
   }

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -62,8 +62,7 @@ export class CompleteExpeditionUseCase {
         continue
       }
 
-      const expMultiplier = replay.summary.injuries.includes(goblin.id.toString()) ? 0.5 : 1.0
-      const expToGain = Math.floor(replay.summary.xpGained * expMultiplier)
+      const expToGain = replay.summary.xpGained
 
       if (expToGain > 0) {
         const levelUpResult = entity.gainExperience(expToGain)

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -1,0 +1,311 @@
+import { CompleteExpeditionUseCase } from '../CompleteExpeditionUseCase'
+import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../../repositories'
+import type { Goblin, Party, BaseState, ExpeditionReplay } from '../../../shared/types'
+
+// --- テストヘルパー ---
+
+function createTestGoblin(overrides: Partial<Goblin> = {}): Goblin {
+  return {
+    id: 1,
+    name: 'テストゴブリン',
+    race: 'ゴブリン',
+    level: 1,
+    experience: 0,
+    avatar: '/test.png',
+    stats: { hp: 60, atk: 12, sp: 10, spd: 10, def: 10, attackCount: 2, accuracy: 20, evasion: 15 },
+    mods: [],
+    factors: [],
+    ...overrides,
+  }
+}
+
+function createTestParty(overrides: Partial<Party> = {}): Party {
+  return {
+    id: 1,
+    name: 'テストパーティ',
+    memberIds: [1],
+    status: 'expedition',
+    ...overrides,
+  }
+}
+
+function createTestBaseState(overrides: Partial<BaseState> = {}): BaseState {
+  return {
+    capacity: 10,
+    rank: 1,
+    capturedDungeons: [],
+    currentMaxParties: 2,
+    currentMaxGoblins: 10,
+    currentIVBonus: 0,
+    gold: 100,
+    ...overrides,
+  }
+}
+
+function createTestReplay(overrides: Partial<ExpeditionReplay> = {}): ExpeditionReplay {
+  return {
+    meta: {
+      expeditionId: 'exp-1',
+      areaId: 'dungeon_1',
+      areaName: 'テスト���ンジョン',
+      floors: 3,
+      baseDurationSec: 60,
+      party: ['1'],
+      returnPolicy: 'never',
+      seed: 12345,
+    },
+    durationSec: 60,
+    events: [
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'return', at: 60, reason: 'completed' },
+    ],
+    summary: {
+      success: true,
+      maxFloorReached: 3,
+      xpGained: 100,
+      goldGained: 50,
+      casualties: [],
+    },
+    ...overrides,
+  }
+}
+
+// --- モックリポジトリ ---
+
+function createMockGoblinRepository(goblins: Goblin[]): IGoblinRepository {
+  const store = new Map(goblins.map(g => [g.id, { ...g }]))
+  return {
+    getGoblins: jest.fn(async () => [...store.values()]),
+    getGoblin: jest.fn(async (id: number) => store.get(id) ?? null),
+    saveGoblin: jest.fn(async (goblin: Goblin) => { store.set(goblin.id, { ...goblin }) }),
+    deleteGoblin: jest.fn(async () => {}),
+    updateGoblinStats: jest.fn(async () => {}),
+    updateGoblinLevel: jest.fn(async () => {}),
+  }
+}
+
+function createMockPartyRepository(parties: Party[]): IPartyRepository {
+  const store = new Map(parties.map(p => [p.id, { ...p }]))
+  return {
+    getParties: jest.fn(async () => [...store.values()]),
+    getParty: jest.fn(async (id: number) => store.get(id) ?? null),
+    saveParty: jest.fn(async () => {}),
+    deleteParty: jest.fn(async () => {}),
+    updatePartyStatus: jest.fn(async () => {}),
+    getPartiesByStatus: jest.fn(async () => []),
+    updateDungeonSettings: jest.fn(async () => {}),
+    updateFloorTarget: jest.fn(async () => {}),
+    updateReturnPolicy: jest.fn(async () => {}),
+  }
+}
+
+function createMockBaseStateRepository(state: BaseState): IBaseStateRepository {
+  let currentState = { ...state }
+  return {
+    getBaseState: jest.fn(async () => ({ ...currentState })),
+    saveBaseState: jest.fn(async (s: BaseState) => { currentState = { ...s } }),
+    getAndIncrementNextGoblinId: jest.fn(async () => 99),
+  }
+}
+
+// --- テスト ---
+
+describe('CompleteExpeditionUseCase', () => {
+  describe('execute', () => {
+    it('成功した遠征で経験値が付与される', async () => {
+      const goblin = createTestGoblin({ id: 1, level: 1, experience: 0 })
+      const party = createTestParty({ id: 1, memberIds: [1] })
+      const baseState = createTestBaseState()
+      const replay = createTestReplay({ summary: { success: true, maxFloorReached: 3, xpGained: 100, goldGained: 50, casualties: [] } })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const partyRepo = createMockPartyRepository([party])
+      const baseRepo = createMockBaseStateRepository(baseState)
+
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, partyRepo, baseRepo)
+      const result = await usecase.execute(1, replay)
+
+      expect(result.updatedGoblinIds).toContain(1)
+      expect(goblinRepo.saveGoblin).toHaveBeenCalled()
+      const savedGoblin = (goblinRepo.saveGoblin as jest.Mock).mock.calls[0][0] as Goblin
+      expect(savedGoblin.experience).toBeGreaterThan(0)
+    })
+
+    it('戦闘不能メンバーは経験値を獲得しない', async () => {
+      const goblin1 = createTestGoblin({ id: 1 })
+      const goblin2 = createTestGoblin({ id: 2, name: '���ブリン2' })
+      const party = createTestParty({ id: 1, memberIds: [1, 2] })
+      const baseState = createTestBaseState()
+      const replay = createTestReplay({
+        meta: { expeditionId: 'exp-1', areaId: 'dungeon_1', areaName: 'テスト', floors: 3, baseDurationSec: 60, party: ['1', '2'], returnPolicy: 'never', seed: 12345 },
+        summary: { success: true, maxFloorReached: 3, xpGained: 100, goldGained: 50, casualties: ['1'] },
+      })
+
+      const goblinRepo = createMockGoblinRepository([goblin1, goblin2])
+      const partyRepo = createMockPartyRepository([party])
+      const baseRepo = createMockBaseStateRepository(baseState)
+
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, partyRepo, baseRepo)
+      const result = await usecase.execute(1, replay)
+
+      expect(result.updatedGoblinIds).not.toContain(1)
+      expect(result.updatedGoblinIds).toContain(2)
+    })
+
+    it('ゴールドが加算さ���る', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty()
+      const baseState = createTestBaseState({ gold: 100 })
+      const replay = createTestReplay({ summary: { success: true, maxFloorReached: 3, xpGained: 50, goldGained: 200, casualties: [] } })
+
+      const baseRepo = createMockBaseStateRepository(baseState)
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([goblin]),
+        createMockPartyRepository([party]),
+        baseRepo,
+      )
+      const result = await usecase.execute(1, replay)
+
+      expect(result.goldGained).toBe(200)
+      const savedState = (baseRepo.saveBaseState as jest.Mock).mock.calls[0][0] as BaseState
+      expect(savedState.gold).toBe(300)
+    })
+
+    it('成功した遠征でダンジョンが制圧��れる', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty()
+      const baseState = createTestBaseState({ capturedDungeons: [] })
+      const replay = createTestReplay({ summary: { success: true, maxFloorReached: 3, xpGained: 50, goldGained: 0, casualties: [] } })
+
+      const baseRepo = createMockBaseStateRepository(baseState)
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([goblin]),
+        createMockPartyRepository([party]),
+        baseRepo,
+      )
+      const result = await usecase.execute(1, replay)
+
+      expect(result.newDungeonCaptured).toBe('dungeon_1')
+      const savedState = (baseRepo.saveBaseState as jest.Mock).mock.calls[0][0] as BaseState
+      expect(savedState.capturedDungeons).toContain('dungeon_1')
+    })
+
+    it('既に制圧済みのダンジョンではnewDungeonCapturedがundefined', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty()
+      const baseState = createTestBaseState({ capturedDungeons: ['dungeon_1'] })
+      const replay = createTestReplay({ summary: { success: true, maxFloorReached: 3, xpGained: 50, goldGained: 0, casualties: [] } })
+
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([goblin]),
+        createMockPartyRepository([party]),
+        createMockBaseStateRepository(baseState),
+      )
+      const result = await usecase.execute(1, replay)
+
+      expect(result.newDungeonCaptured).toBeUndefined()
+    })
+
+    it('失敗した遠征ではダンジョンが制圧されない', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty()
+      const baseState = createTestBaseState({ capturedDungeons: [] })
+      const replay = createTestReplay({ summary: { success: false, maxFloorReached: 2, xpGained: 30, goldGained: 0, casualties: ['1'] } })
+
+      const baseRepo = createMockBaseStateRepository(baseState)
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([goblin]),
+        createMockPartyRepository([party]),
+        baseRepo,
+      )
+      const result = await usecase.execute(1, replay)
+
+      expect(result.newDungeonCaptured).toBeUndefined()
+    })
+
+    it('完了後にパーティステータスがidleに更新さ���る', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty({ status: 'expedition' })
+      const baseState = createTestBaseState()
+      const replay = createTestReplay()
+
+      const partyRepo = createMockPartyRepository([party])
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([goblin]),
+        partyRepo,
+        createMockBaseStateRepository(baseState),
+      )
+      await usecase.execute(1, replay)
+
+      expect(partyRepo.updatePartyStatus).toHaveBeenCalledWith(1, 'idle')
+    })
+
+    it('存在しないパーティIDでエラーが発生する', async () => {
+      const usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([]),
+        createMockPartyRepository([]),
+        createMockBaseStateRepository(createTestBaseState()),
+      )
+
+      await expect(usecase.execute(999, createTestReplay())).rejects.toThrow('パーティが見つかりません')
+    })
+
+    it('2回実行すると経験値が2重に加算される（呼び出し側でガードが必要）', async () => {
+      const goblin = createTestGoblin({ id: 1, level: 1, experience: 0 })
+      const party = createTestParty()
+      const baseState = createTestBaseState({ gold: 0 })
+      const replay = createTestReplay({ summary: { success: true, maxFloorReached: 3, xpGained: 100, goldGained: 50, casualties: [] } })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const partyRepo = createMockPartyRepository([party])
+      const baseRepo = createMockBaseStateRepository(baseState)
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, partyRepo, baseRepo)
+
+      // 1回目
+      await usecase.execute(1, replay)
+      const firstCallGoblin = (goblinRepo.saveGoblin as jest.Mock).mock.calls[0][0] as Goblin
+      const firstExp = firstCallGoblin.experience
+
+      // 2回目（ガードなしで呼ぶとさらに加算される）
+      await usecase.execute(1, replay)
+      const secondCallGoblin = (goblinRepo.saveGoblin as jest.Mock).mock.calls[1][0] as Goblin
+
+      // UseCase自体にはガードがないため、2回呼べば2回加算される
+      // → 呼び出し側（completeExpeditionRecord の戻り値）でガードする設計
+      expect(secondCallGoblin.experience).toBeGreaterThan(firstExp)
+      expect(goblinRepo.saveGoblin).toHaveBeenCalledTimes(2)
+    })
+
+    it('複数メンバーのパーティで全員に経験値が付与される', async () => {
+      const goblin1 = createTestGoblin({ id: 1, name: 'ゴブリン1' })
+      const goblin2 = createTestGoblin({ id: 2, name: 'ゴブリン2' })
+      const goblin3 = createTestGoblin({ id: 3, name: 'ゴ��リン3' })
+      const party = createTestParty({ id: 1, memberIds: [1, 2, 3] })
+      const baseState = createTestBaseState()
+      const replay = createTestReplay({
+        meta: { expeditionId: 'exp-1', areaId: 'dungeon_1', areaName: 'テスト', floors: 3, baseDurationSec: 60, party: ['1', '2', '3'], returnPolicy: 'never', seed: 12345 },
+        summary: { success: true, maxFloorReached: 3, xpGained: 100, goldGained: 0, casualties: [] },
+      })
+
+      const goblinRepo = createMockGoblinRepository([goblin1, goblin2, goblin3])
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, createMockPartyRepository([party]), createMockBaseStateRepository(baseState))
+      const result = await usecase.execute(1, replay)
+
+      expect(result.updatedGoblinIds).toEqual(expect.arrayContaining([1, 2, 3]))
+      expect(goblinRepo.saveGoblin).toHaveBeenCalledTimes(3)
+    })
+
+    it('経験値0の遠征ではゴブリンが更新されない', async () => {
+      const goblin = createTestGoblin()
+      const party = createTestParty()
+      const replay = createTestReplay({ summary: { success: false, maxFloorReached: 1, xpGained: 0, goldGained: 0, casualties: [] } })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, createMockPartyRepository([party]), createMockBaseStateRepository(createTestBaseState()))
+      const result = await usecase.execute(1, replay)
+
+      expect(result.updatedGoblinIds).toHaveLength(0)
+      expect(goblinRepo.saveGoblin).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteExpeditionRepository.ts
@@ -27,7 +27,7 @@ export interface IExpeditionRepository {
   getOngoing(): Promise<ExpeditionRecord[]>
   save(record: ExpeditionRecord): Promise<void>
   delete(id: string): Promise<void>
-  complete(id: string, replay: ExpeditionReplay): Promise<void>
+  complete(id: string, replay: ExpeditionReplay): Promise<boolean>
 }
 
 export class SQLiteExpeditionRepository implements IExpeditionRepository {
@@ -112,19 +112,16 @@ export class SQLiteExpeditionRepository implements IExpeditionRepository {
     await db.runAsync('DELETE FROM expeditions WHERE id = ?', [id])
   }
 
-  async complete(id: string, replay: ExpeditionReplay): Promise<void> {
-    const record = await this.getById(id)
-    if (!record) return
-
-    const updated: ExpeditionRecord = {
-      ...record,
-      status: replay.summary.success ? 'completed' : 'failed',
-      returnTime: new Date(),
-      replay,
-      updatedAt: new Date(),
-    }
-
-    await this.save(updated)
+  async complete(id: string, replay: ExpeditionReplay): Promise<boolean> {
+    const db = await getDatabase()
+    const status = replay.summary.success ? 'completed' : 'failed'
+    const result = await db.runAsync(
+      `UPDATE expeditions
+       SET status = ?, return_time = ?, replay_json = ?, updated_at = datetime('now')
+       WHERE id = ? AND status = 'ongoing'`,
+      [status, new Date().toISOString(), JSON.stringify(replay), id]
+    )
+    return (result.changes ?? 0) > 0
   }
 
   private rowToRecord(row: ExpeditionRow): ExpeditionRecord {

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -230,8 +230,10 @@ export const useExpeditionFlow = ({
       if (processedExpeditionsRef.current.has(record.id)) continue
       processedExpeditionsRef.current.add(record.id)
       try {
-        // 先にステータスを更新して再マウント時の二重実行を防ぐ
-        await completeExpeditionRecord(record.id, record.replay!)
+        // DBレベルで WHERE status='ongoing' を条件にアトミックに更新。
+        // 既に完了済み（playback側で処理済み等）なら false が返り、スキップ。
+        const updated = await completeExpeditionRecord(record.id, record.replay!)
+        if (!updated) continue
 
         const result = await completeExpeditionUseCase.execute(record.partyId, record.replay!)
 

--- a/goblin_native/src/presentation/hooks/useExpeditionService.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionService.ts
@@ -56,10 +56,11 @@ export const useExpeditionService = () => {
     await refreshExpeditions()
   }, [refreshExpeditions])
 
-  const completeExpeditionRecord = useCallback(async (id: string, replay: ExpeditionReplay) => {
-    if (!repositoryRef.current) return
-    await repositoryRef.current.complete(id, replay)
+  const completeExpeditionRecord = useCallback(async (id: string, replay: ExpeditionReplay): Promise<boolean> => {
+    if (!repositoryRef.current) return false
+    const updated = await repositoryRef.current.complete(id, replay)
     await refreshExpeditions()
+    return updated
   }, [refreshExpeditions])
 
   return {

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -77,7 +77,6 @@ export interface RewardSummary {
   xpGained: number
   goldGained: number
   casualties: string[]
-  injuries: string[]
   treasureDrops?: TreasureDrop[]  // 宝箱から獲得した装備
 }
 


### PR DESCRIPTION
## Summary
- 遠征ログ閲覧中に完了すると、playback側とauto-completion側の両方で完了処理が走り、経験値・ゴブリン追加が二重に実行されるバグを修正
- playbackから完了処理を完全に除去し、`completeDueExpeditions` に一本化
- SQLite `complete()` を `WHERE status='ongoing'` のアトミック更新に変更し、DBレベルで二重実行を防止
- 到達不能だった `injuries`（負傷）仕様と XP 半減ロジックを削除
- `CompleteExpeditionUseCase` のユニットテストを追加（11ケース）

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npx jest` 全105テスト通過
- [ ] 遠征ログ閲覧中に遠征が完了 → 経験値・ゴブリンが1回分のみ付与されることを確認
- [ ] 遠征ログを見ずに編成画面で完了 → 従来通り正常に完了処理が走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)