### PR TITLE
fix: 敵全滅時に即座に戦闘終了するように修正

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -254,6 +254,11 @@ export class BattleSystem {
           isAlly: unit.isAlly,
           targets: [...targetDetails.values()],
         })
+
+        // 敵または味方が全滅したら即座にターン終了
+        const allEnemiesDefeated = enemyUnits.every(u => u.currentHP <= 0)
+        const allAlliesDefeated = allyUnits.every(u => u.currentHP <= 0)
+        if (allEnemiesDefeated || allAlliesDefeated) break
       }
 
       const allyAlive = allyUnits.some(unit => unit.currentHP > 0)


### PR DESCRIPTION
## Summary
- 最後の敵を倒した後も後続キャラの攻撃動作が実行され、0ヒット攻撃がログに記録される問題を修正
- BattleSystemの各ユニット行動後に敵/味方の全滅チェックを追加し、全滅時点でターンを即終了するように変更

## Test plan
- [x] 全105テストがパス
- [ ] 遠征を実行し、最後の敵を倒した後に後続キャラの0ヒット攻撃が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)