### PR TITLE
feat: 現在時刻表示を全画面共通に移動

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -1,9 +1,11 @@
+import { useCallback } from 'react'
 import { Tabs } from 'expo-router'
 import { View, Text, StyleSheet } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import ListIcon from '../../assets/list.svg'
 import HenseiIcon from '../../assets/hensei.svg'
 import BaseIcon from '../../assets/base.svg'
+import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
 
 interface TabIconProps {
   Icon: React.FC<{ width: number; height: number; fill?: string }>
@@ -18,12 +20,25 @@ function TabIcon({ Icon, color }: TabIconProps) {
   )
 }
 
+function formatFullDateTimeWithSeconds(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+  return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
+}
+
 export default function TabLayout() {
   const insets = useSafeAreaInsets()
+  const currentTime = useCurrentTime({ enabled: true })
+  const currentTimeLabel = formatFullDateTimeWithSeconds(currentTime)
   const basePadding = 8
   const baseHeight = 60
   const safeAreaPadding = Math.max(basePadding, insets.bottom)
   return (
+    <View style={styles.rootContainer}>
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: '#3B82F6',
@@ -89,14 +104,33 @@ export default function TabLayout() {
         }}
       />
     </Tabs>
+    <View style={[styles.currentTimeBadge, { bottom: baseHeight + safeAreaPadding + 8 }]} pointerEvents="none">
+      <Text style={styles.currentTimeText}>{currentTimeLabel}</Text>
+    </View>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
+  rootContainer: {
+    flex: 1,
+  },
   iconContainer: {
     width: 24,
     height: 24,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  currentTimeBadge: {
+    position: 'absolute',
+    left: 12,
+    backgroundColor: 'rgba(17, 24, 39, 0.8)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  currentTimeText: {
+    fontSize: 11,
+    color: '#F9FAFB',
   },
 })

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -132,10 +132,8 @@ export default function FormationScreen() {
   const { rank, isLoading: baseLoading } = useBaseState()
   const {
     completeDueExpeditions,
-    currentTime,
     partyHistories,
     partyHistoryDisplays,
-    formatFullDateTimeWithSeconds,
   } = useExpeditionFlow({ refreshParties, parties, enableAutoCompletion: true })
   const { slotSize, avatarSize } = useMemo(() => {
     const slotGap = 8
@@ -238,8 +236,6 @@ export default function FormationScreen() {
     )
   }
 
-  const currentTimeLabel = formatFullDateTimeWithSeconds(currentTime)
-
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
@@ -282,10 +278,6 @@ export default function FormationScreen() {
           }
         })}
       </ScrollView>
-
-      <View style={styles.currentTimeBadge} pointerEvents="none">
-        <Text style={styles.currentTimeText}>{currentTimeLabel}</Text>
-      </View>
     </SafeAreaView>
   )
 }
@@ -336,19 +328,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
-  },
-  currentTimeBadge: {
-    position: 'absolute',
-    left: 12,
-    bottom: 8,
-    backgroundColor: 'rgba(17, 24, 39, 0.8)',
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-  },
-  currentTimeText: {
-    fontSize: 11,
-    color: '#F9FAFB',
   },
   historySection: {
     marginTop: 16,


### PR DESCRIPTION
## Summary
- 現在時刻バッジをFormationタブ専用からタブレイアウト(_layout.tsx)に移動し、全タブ画面で表示されるように変更
- タブバーの高さをSafeAreaのinsetsから動的に計算し、デバイスに依存しない正しい位置に配置
- Formation画面から不要になった時刻関連のコード・スタイルを削除

## Test plan
- [ ] 各タブ（List, Formation, Base, Settings）で左下に現在時刻が表示されることを確認
- [ ] 時刻バッジがタブバーに被らないことを確認
- [ ] 異なるデバイス（iPhone SE, iPhone 15 Pro等）で位置が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)