### PR TITLE
fix: リザルト画面のレベルアップ表示バグを修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -7,7 +7,6 @@ import { useExpeditionService } from '@/presentation/hooks/useExpeditionService'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { areasData } from '@/shared/data'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
-import { addExperience } from '@/core/services/ExperienceSystem'
 import type { ExpeditionRecord, Goblin, TimelineEvent } from '@/shared/types'
 
 export default function ExpeditionResultScreen() {
@@ -70,23 +69,16 @@ export default function ExpeditionResultScreen() {
     return map
   }, [replay, partySnapshot])
 
-  // レベルアップ計算
+  // 保存済みのレベルアップ情報を読み取り
   const levelUpMap = useMemo(() => {
-    if (!replay || partySnapshot.length === 0) return new Map<number, { oldLevel: number; newLevel: number }>()
-
     const map = new Map<number, { oldLevel: number; newLevel: number }>()
-    for (const goblin of partySnapshot) {
-      const isCasualty = replay.summary.casualties.includes(goblin.id.toString())
-      if (isCasualty) continue
+    if (!replay?.summary.memberLevelUps) return map
 
-      const expGained = replay.summary.xpGained
-      const result = addExperience(goblin.level, goblin.experience, expGained)
-      if (result.didLevelUp) {
-        map.set(goblin.id, { oldLevel: goblin.level, newLevel: result.newLevel })
-      }
+    for (const entry of replay.summary.memberLevelUps) {
+      map.set(entry.goblinId, { oldLevel: entry.oldLevel, newLevel: entry.newLevel })
     }
     return map
-  }, [replay, partySnapshot])
+  }, [replay])
 
   const getResultText = () => {
     if (!replay) return ''

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -1,4 +1,4 @@
-import type { ExpeditionReplay, TimelineEvent, TreasureDrop } from '../../shared/types'
+import type { ExpeditionReplay, MemberLevelUp, TimelineEvent, TreasureDrop } from '../../shared/types'
 import { getEnemyDatabase } from '../../shared/data/enemy'
 import { GoblinEntity } from '../domain'
 import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../repositories'
@@ -14,6 +14,7 @@ export interface ExpeditionCompletionResult {
   newDungeonCaptured?: string
   goldGained: number
   treasureDrops?: TreasureDrop[]
+  enrichedReplay: ExpeditionReplay
 }
 
 export class CompleteExpeditionUseCase {
@@ -192,6 +193,26 @@ export class CompleteExpeditionUseCase {
 
     await this.partyRepository.updatePartyStatus(partyId, 'idle')
 
+    // replayのsummaryにレベルアップ情報を書き込み
+    const memberLevelUps: MemberLevelUp[] = []
+    for (const [goblinId, levelUp] of levelUps) {
+      if (levelUp.didLevelUp) {
+        memberLevelUps.push({
+          goblinId,
+          oldLevel: levelUp.oldLevel,
+          newLevel: levelUp.newLevel,
+        })
+      }
+    }
+
+    const enrichedReplay: ExpeditionReplay = {
+      ...replay,
+      summary: {
+        ...replay.summary,
+        memberLevelUps: memberLevelUps.length > 0 ? memberLevelUps : undefined,
+      },
+    }
+
     return {
       levelUps,
       updatedGoblinIds,
@@ -199,6 +220,7 @@ export class CompleteExpeditionUseCase {
       newDungeonCaptured,
       goldGained,
       treasureDrops: treasureDrops.length > 0 ? treasureDrops : undefined,
+      enrichedReplay,
     }
   }
 }

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -230,12 +230,14 @@ export const useExpeditionFlow = ({
       if (processedExpeditionsRef.current.has(record.id)) continue
       processedExpeditionsRef.current.add(record.id)
       try {
-        // DBレベルで WHERE status='ongoing' を条件にアトミックに更新。
-        // 既に完了済み（playback側で処理済み等）なら false が返り、スキップ。
-        const updated = await completeExpeditionRecord(record.id, record.replay!)
-        if (!updated) continue
-
+        // ゲームロジックを先に実行し、レベルアップ情報を含む enrichedReplay を取得
         const result = await completeExpeditionUseCase.execute(record.partyId, record.replay!)
+
+        // DBレベルで WHERE status='ongoing' を条件にアトミックに更新。
+        // enrichedReplay（memberLevelUps含む）を一括保存。
+        // 既に完了済み（playback側で処理済み等）なら false が返り、スキップ。
+        const updated = await completeExpeditionRecord(record.id, result.enrichedReplay)
+        if (!updated) continue
 
         if (result.newDungeonCaptured) {
           const dungeon = areasData.find(d => d.id === result.newDungeonCaptured)

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -71,6 +71,12 @@ export interface ExpeditionRecord {
   updatedAt: Date
 }
 
+export interface MemberLevelUp {
+  goblinId: number
+  oldLevel: number
+  newLevel: number
+}
+
 export interface RewardSummary {
   success: boolean
   maxFloorReached: number
@@ -78,6 +84,7 @@ export interface RewardSummary {
   goldGained: number
   casualties: string[]
   treasureDrops?: TreasureDrop[]  // 宝箱から獲得した装備
+  memberLevelUps?: MemberLevelUp[]  // 遠征完了時に確定したレベルアップ情報
 }
 
 export interface AreaConfig {

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -60,6 +60,7 @@ export type {
   TreasureDrop,
   ExpeditionRecord,
   RewardSummary,
+  MemberLevelUp,
   AreaConfig,
   ExpeditionEndReason
 } from "./Expedition"


### PR DESCRIPTION
## Summary
- 遠征リザルト画面で全員が合計XPでレベルアップ判定されるバグを修正
- レベルアップ情報を`CompleteExpeditionUseCase`で計算し`RewardSummary.memberLevelUps`として一括保存する方式に変更
- `result.tsx`は保存済みデータを読み取るだけに簡素化

## Test plan
- [ ] 遠征を完了し、レベルアップしたゴブリンだけにLvUp表示が出ることを確認
- [ ] 複数回レベルアップした場合（例: Lv1→Lv3）に正しく表示されることを確認
- [ ] レベルアップしないゴブリンにLvUp表示が出ないことを確認
- [ ] 遠征履歴からリザルト画面を再表示した際にレベルアップ情報が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)