### PR TITLE
fix: 因子獲得時にレベルアップデータが上書きされるバグを修正

### DIFF
--- a/goblin_native/src/core/repositories/IGoblinRepository.ts
+++ b/goblin_native/src/core/repositories/IGoblinRepository.ts
@@ -7,4 +7,5 @@ export interface IGoblinRepository {
   deleteGoblin(id: number): Promise<void>
   updateGoblinStats(id: number, stats: Goblin['stats']): Promise<void>
   updateGoblinLevel(id: number, level: number): Promise<void>
+  updateGoblinFactors(id: number, factors: string[], effectiveStats: Goblin['stats']): Promise<void>
 }

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -96,6 +96,9 @@ export class CompleteExpeditionUseCase {
       })
     }
 
+    // レベルアップ後の最新ゴブリンを保持（因子獲得時に参照）
+    const latestGoblins = new Map(goblins.map(g => [g.id, g]))
+
     for (const goblin of goblins) {
       const expToGain = perGoblinExp.get(goblin.id) ?? 0
       if (expToGain <= 0) continue
@@ -107,6 +110,7 @@ export class CompleteExpeditionUseCase {
       const updatedGoblin = entity.toSnapshot()
       await this.goblinRepository.saveGoblin(updatedGoblin)
       updatedGoblinIds.push(goblin.id)
+      latestGoblins.set(goblin.id, updatedGoblin)
     }
 
     const factorAcquisitions = new Map<number, string[]>()
@@ -132,15 +136,17 @@ export class CompleteExpeditionUseCase {
               continue
             }
 
+            const latest = latestGoblins.get(goblin.id)!
             const acquired = FactorService.rollFactorDrops(
-              goblin,
+              latest,
               allFactorDrops,
               replay.meta.seed
             )
 
             if (acquired.length > 0) {
-              const updatedGoblin = FactorService.addFactors(goblin, acquired)
-              await this.goblinRepository.saveGoblin(updatedGoblin)
+              const withFactors = FactorService.addFactors(latest, acquired)
+              // 因子と実効ステータスだけをUPDATEし、レベルアップ等の他データを上書きしない
+              await this.goblinRepository.updateGoblinFactors(goblin.id, withFactors.factors!, withFactors.effectiveStats!)
               factorAcquisitions.set(goblin.id, acquired)
 
               if (!updatedGoblinIds.includes(goblin.id)) {

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -1,6 +1,6 @@
 import { CompleteExpeditionUseCase } from '../CompleteExpeditionUseCase'
 import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../../repositories'
-import type { Goblin, Party, BaseState, ExpeditionReplay, TimelineEvent } from '../../../shared/types'
+import type { Goblin, GoblinStats, Party, BaseState, ExpeditionReplay, TimelineEvent } from '../../../shared/types'
 
 // --- テストヘルパー ---
 
@@ -96,6 +96,10 @@ function createMockGoblinRepository(goblins: Goblin[]): IGoblinRepository {
     deleteGoblin: jest.fn(async () => {}),
     updateGoblinStats: jest.fn(async () => {}),
     updateGoblinLevel: jest.fn(async () => {}),
+    updateGoblinFactors: jest.fn(async (id: number, factors: string[], effectiveStats: GoblinStats) => {
+      const goblin = store.get(id)
+      if (goblin) store.set(id, { ...goblin, factors, effectiveStats })
+    }),
   }
 }
 

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -89,6 +89,14 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     await this.saveGoblin({ ...goblin, level })
   }
 
+  async updateGoblinFactors(id: number, factors: string[], effectiveStats: GoblinStats): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      `UPDATE goblins SET factors_json = ?, effective_stats_json = ?, updated_at = datetime('now') WHERE id = ?`,
+      [JSON.stringify(factors), JSON.stringify(effectiveStats), id]
+    )
+  }
+
   private rowToGoblin(row: GoblinRow): Goblin {
     return {
       id: row.id,


### PR DESCRIPTION
## Summary
- 遠征完了時、因子獲得処理が `saveGoblin`（INSERT OR REPLACE）でゴブリン全データを上書きしていたため、直前のレベルアップ保存が古いデータに巻き戻されていた
- 因子更新を `updateGoblinFactors`（UPDATE SET factors_json, effective_stats_json のみ）に変更し、レベル・経験値・ステータスを上書きしないようにした
- 因子獲得時にレベルアップ後の最新ゴブリンデータを参照するよう修正

## Test plan
- [ ] ボス付きダンジョン（周辺の森等）を踏破し、レベルアップ＋因子獲得が同時に発生するケースで確認
- [ ] 遠征結果画面のレベルアップ表示が正しいことを確認
- [ ] パーティ一覧画面でレベルが更新されていることを確認
- [ ] ゴブリン詳細画面で因子が正しく付与されていることを確認
- [ ] `npx jest` 全テスト通過を確認済み
- [ ] `npx tsc --noEmit` 型チェック通過を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)