### PR TITLE
fix: 出撃後のナビゲーションスタックが残る問題を修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -184,7 +184,7 @@ export default function ExpeditionPreparationScreen() {
           returnPolicy: selectedReturnPolicy,
         })
 
-        router.replace('/formation')
+        router.dismissAll()
       } catch (error) {
         console.error('[Preparation] Failed to start expedition', error)
         Alert.alert('遠征に失敗しました', '遠征開始時にエラーが発生しました')


### PR DESCRIPTION
## Summary
- 冒険準備画面から出撃後、`router.replace`ではedit画面がスタックに残り、編成画面に「パーティ編成」への戻るボタンが表示されていた
- `router.dismissAll()`に変更し、スタックを全てクリアしてルートに戻るよう修正

## Test plan
- [ ] 冒険準備画面から出撃ボタンを押す
- [ ] 編成画面に戻った際、ヘッダーに不要な戻るボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)