### PR TITLE
ui: ゴブリン一覧をコンパクトなフラットリストに変更

### DIFF
--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
@@ -7,6 +7,7 @@ import { useBaseStore, selectMaxGoblins } from '@/presentation/stores/useBaseSto
 import { GoblinCard } from '@/presentation/components/GoblinCard'
 import type { Goblin } from '@/shared/types'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
+import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 
 export default function GoblinListScreen() {
@@ -15,6 +16,14 @@ export default function GoblinListScreen() {
   const maxGoblins = useBaseStore(selectMaxGoblins)
 
   const hasCapacity = goblins.length < maxGoblins
+  const [sortKey, setSortKey] = useState<'level' | 'atk' | 'hp'>('level')
+
+  const sortedGoblins = [...goblins].sort((a, b) => {
+    if (sortKey === 'level') return b.level - a.level
+    const statsA = getEffectiveStats(a)
+    const statsB = getEffectiveStats(b)
+    return sortKey === 'atk' ? statsB.atk - statsA.atk : statsB.hp - statsA.hp
+  })
 
   const handleGoblinPress = useCallback((goblin: Goblin) => {
     router.push({ pathname: '/goblin/detail', params: { goblinId: String(goblin.id) } })
@@ -64,9 +73,28 @@ export default function GoblinListScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right', 'bottom']}>
+      <View style={styles.header}>
+        <View style={styles.headerTop}>
+          <Text style={styles.headerTitle}>ゴブリン一覧</Text>
+          <Text style={styles.headerCount}>{goblins.length} / {maxGoblins}</Text>
+        </View>
+        <View style={styles.sortRow}>
+          {(['level', 'atk', 'hp'] as const).map((key) => (
+            <TouchableOpacity
+              key={key}
+              style={[styles.sortButton, sortKey === key && styles.sortButtonActive]}
+              onPress={() => setSortKey(key)}
+            >
+              <Text style={[styles.sortButtonText, sortKey === key && styles.sortButtonTextActive]}>
+                {key === 'level' ? 'Lv' : key.toUpperCase()}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.listContent}>
-          {goblins.map((goblin) => (
+          {sortedGoblins.map((goblin) => (
             <View key={goblin.id} style={styles.cardWrapper}>
               <GoblinCard goblin={goblin} onPress={() => handleGoblinPress(goblin)} />
             </View>
@@ -160,24 +188,67 @@ const styles = StyleSheet.create({
     color: '#6B7280',
     textAlign: 'center',
   },
+  header: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 8,
+    backgroundColor: '#F9FAFB',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#D1D5DB',
+  },
+  headerTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1F2937',
+  },
+  headerCount: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  sortRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  sortButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    backgroundColor: '#E5E7EB',
+  },
+  sortButtonActive: {
+    backgroundColor: '#374151',
+  },
+  sortButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  sortButtonTextActive: {
+    color: '#FFFFFF',
+  },
   scrollContent: {
     paddingBottom: 32,
   },
   listContent: {
-    padding: 16,
   },
   cardWrapper: {
-    marginBottom: 12,
   },
   pendingSection: {
-    paddingHorizontal: 16,
     paddingTop: 8,
   },
   pendingSectionHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    marginBottom: 8,
+    marginBottom: 4,
+    paddingHorizontal: 12,
   },
   pendingSectionTitle: {
     fontSize: 16,
@@ -198,24 +269,24 @@ const styles = StyleSheet.create({
   pendingSectionDesc: {
     fontSize: 12,
     color: '#9CA3AF',
-    marginBottom: 12,
+    marginBottom: 8,
+    paddingHorizontal: 12,
   },
   pendingCard: {
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    padding: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
     backgroundColor: '#FFFFFF',
-    marginBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E7EB',
   },
   pendingRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 10,
+    gap: 8,
   },
   pendingAvatar: {
-    width: 40,
-    height: 40,
+    width: 32,
+    height: 32,
   },
   pendingInfo: {
     flex: 1,
@@ -226,29 +297,29 @@ const styles = StyleSheet.create({
     color: '#1F2937',
   },
   pendingStats: {
-    fontSize: 11,
+    fontSize: 10,
     color: '#6B7280',
-    marginTop: 2,
+    marginTop: 1,
   },
   addButton: {
     backgroundColor: '#374151',
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 4,
   },
   addButtonText: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
     color: '#FFFFFF',
   },
   dismissButton: {
     backgroundColor: '#6B7280',
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 4,
   },
   dismissButtonText: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '600',
     color: '#FFFFFF',
   },

--- a/goblin_native/src/presentation/components/GoblinCard.tsx
+++ b/goblin_native/src/presentation/components/GoblinCard.tsx
@@ -34,15 +34,17 @@ export function GoblinCard({
         <Text style={[styles.name, isAssignedElsewhere && styles.nameDisabled]}>
           {goblin.name}
         </Text>
-        <Text style={[styles.race, isAssignedElsewhere && styles.raceDisabled]}>
-          {goblin.race}
-        </Text>
-        <Text style={[styles.level, isAssignedElsewhere && styles.levelDisabled]}>
-          Lv.{goblin.level}
-        </Text>
-        <View style={styles.factorIcons}>
-          {FactorIcon1 && <FactorIcon1 width={20} height={20} />}
-          {FactorIcon2 && <FactorIcon2 width={20} height={20} />}
+        <View style={styles.subRow}>
+          <Text style={[styles.race, isAssignedElsewhere && styles.raceDisabled]}>
+            {goblin.race}
+          </Text>
+          <Text style={[styles.level, isAssignedElsewhere && styles.levelDisabled]}>
+            Lv.{goblin.level}
+          </Text>
+          <View style={styles.factorIcons}>
+            {FactorIcon1 && <FactorIcon1 width={16} height={16} />}
+            {FactorIcon2 && <FactorIcon2 width={16} height={16} />}
+          </View>
         </View>
       </View>
       <View style={styles.statsContainer}>
@@ -83,24 +85,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 8,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E5E7EB',
   },
   containerAssigned: {
     backgroundColor: '#EFF6FF',
-    borderColor: '#3B82F6',
   },
   containerDisabled: {
     backgroundColor: '#F9FAFB',
     opacity: 0.6,
   },
   avatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 8,
-    marginRight: 10,
+    width: 32,
+    height: 32,
+    borderRadius: 6,
+    marginRight: 8,
   },
   info: {
     flex: 1,
@@ -114,10 +115,14 @@ const styles = StyleSheet.create({
   nameDisabled: {
     color: '#9CA3AF',
   },
+  subRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
   race: {
     fontSize: 11,
     color: '#6B7280',
-    marginBottom: 1,
   },
   raceDisabled: {
     color: '#9CA3AF',
@@ -126,24 +131,23 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: '600',
     color: '#374151',
-    marginBottom: 2,
   },
   levelDisabled: {
     color: '#9CA3AF',
   },
   factorIcons: {
     flexDirection: 'row',
-    gap: 4,
+    gap: 3,
   },
   statsContainer: {
     alignItems: 'flex-end',
     marginRight: 8,
   },
   statText: {
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: '600',
     color: '#374151',
-    marginBottom: 2,
+    marginBottom: 1,
   },
   statTextDisabled: {
     color: '#9CA3AF',


### PR DESCRIPTION
## Summary
- GoblinCardをカードデザインからフラットデザイン（ヘアライン区切り）に変更し、カード高を削減
- 種族・レベル・因子アイコンを1行に統合、アバター・フォントサイズを縮小
- ヘッダーを追加（タイトル、ゴブリン数/最大数表示、Lv/ATK/HPソートボタン）
- 産まれたゴブリンセクションも同様にフラット化・コンパクト化

## Test plan
- [ ] ゴブリン一覧画面でフラットリスト表示を確認
- [ ] ヘッダーのソートボタン（Lv/ATK/HP）が正しく動作すること
- [ ] ゴブリン数/最大数の表示が正しいこと
- [ ] 産まれたゴブリンセクションの表示・追加/解雇ボタンが動作すること
- [ ] パーティ編成画面のGoblinCard表示に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)