### PR TITLE
fix: 遠征結果画面のメニューに戻るボタンがスタックに追加される問題を修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -131,7 +131,7 @@ export default function ExpeditionResultScreen() {
   }, [unlockNext, isSuccess, progress, markUnlockNotified])
 
   const handleBackToList = useCallback(() => {
-    router.replace('/formation')
+    router.dismissAll()
   }, [])
 
   if (expeditionId && (isExpeditionLoading || (!expeditionRecord && !hasRetriedLoad))) {


### PR DESCRIPTION
## Summary
- 遠征結果画面の「メニューに戻る」ボタンで `router.replace()` を使用していたため、スタック途中の画面（preparation → playback）が残る問題を修正
- `router.dismissAll()` に変更し、Stack内の全画面をdismissしてformation/indexに正しく戻るように修正

## Test plan
- [ ] 遠征を完了し、結果画面で「メニューに戻る」を押してパーティ一覧に戻ることを確認
- [ ] 戻った後に「← 戻る」ジェスチャーで遠征途中の画面に戻れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)