### PR TITLE
feat: 装備ドロップ確率を全エリア一律25%に変更

### DIFF
--- a/goblin_native/docs/drop_system.md
+++ b/goblin_native/docs/drop_system.md
@@ -1,0 +1,293 @@
+# ドロップシステム
+
+## 概要
+
+遠征中の戦闘勝利時に装備アイテムや因子を獲得できるシステム。
+ドロップは3種類に分類される:
+
+1. **装備ドロップ（宝箱）**: ダンジョンレベル準拠の装備プールから抽選
+2. **敵個別ドロップ**: 敵ごとに設定された固有装備ドロップ（現在未使用）
+3. **因子ドロップ**: ボス撃破時に因子を獲得
+
+すべてのドロップはシード値ベースの決定論的乱数で処理されるため、同じシードなら同じ結果が再現される。
+
+## 装備ドロップ（宝箱）
+
+### 発生条件
+
+戦闘（通常戦闘・ボス戦）に**勝利**した直後に判定される。
+
+```
+1. rng() < DROP_CHANCE（25%）で確率判定
+   └─ 失敗 → ドロップなし
+2. areaLevel に対応する装備プールを取得
+3. 同一遠征で既にドロップした装備を除外
+4. 残りの候補から均等抽選
+5. 称号を抽選して装備名に付与
+```
+
+### ドロップ確率
+
+全エリア共通で **25%**（`DROP_CHANCE = 0.25`）。`ExpeditionEngine.ts` に定数として定義。
+エリアの `areaLevel` はドロップする装備プールの選択に使用される。
+
+### 装備プール選択
+
+`getEquipmentByDungeonLevel(dungeonLevel)` でダンジョンレベルに対応する装備を取得:
+
+```
+対象 = dropLevelMin ≤ dungeonLevel ≤ dropLevelMax のテンプレート
+```
+
+### 装備テンプレート一覧
+
+#### 武器（剣系）
+
+| 名前 | dropLevelMin | dropLevelMax | ATK | DEF |
+|------|-------------|-------------|-----|-----|
+| ひのきの棒 | 1 | 2 | 2 | 0 |
+| こんぼう | 4 | 10 | 5 | 1 |
+| 銅の剣 | 8 | 15 | 8 | 2 |
+| ブロードソード | 8 | 15 | 12 | 3 |
+| ロングソード | 12 | 25 | 16 | 4 |
+| ミスリルソード | 20 | 40 | 24 | 6 |
+| ロイヤルソード | 35 | 60 | 32 | 8 |
+| カイザーソード | 50 | 80 | 48 | 10 |
+| エンシェントソード | 70 | 105 | 64 | 12 |
+| ドラゴンソード | 95 | 135 | 96 | 24 |
+| アダマントソード | 120 | 150 | 128 | 36 |
+
+#### 武器（弓系）
+
+| 名前 | dropLevelMin | dropLevelMax | ATK |
+|------|-------------|-------------|-----|
+| スリングショット | 1 | 2 | 3 |
+| ショートボウ | 4 | 10 | 6 |
+| ロングボウ | 12 | 25 | 20 |
+| ミスリルボウ | 20 | 40 | 30 |
+| ロイヤルボウ | 35 | 60 | 45 |
+| カイザーボウ | 50 | 80 | 60 |
+| エンシェントボウ | 70 | 105 | 90 |
+| ドラゴンボウ | 95 | 135 | 120 |
+| アダマントボウ | 120 | 150 | 160 |
+
+※ `areaLevel` が `dungeonLevel` として使用されるため、現状はレベル1〜8の範囲。装備テンプレートの `dropLevelMin` が9以上のものは将来のコンテンツ拡張用。
+
+### 重複制限
+
+同一遠征中に同じ `templateId` の装備は**最大1個**までしかドロップしない。
+
+```
+droppedTemplateIds: Set<string> で遠征全体を通じて追跡
+→ 既にドロップ済みの templateId は候補から除外
+```
+
+## 装備称号システム
+
+### 概要
+
+装備ドロップ時に自動的に称号が付与される。称号によって装備のステータス補正が変化する。
+
+### 称号一覧
+
+| ID | 称号名 | baseWeight | power | プラス倍率 | マイナス倍率 | 価格倍率 |
+|----|--------|-----------|-------|----------|-----------|---------|
+| worst | 最低な | 200 | 0.3 | ×0.50 | ×2.00 | ×0.50 |
+| stinky | 臭い | 300 | 0.3 | ×0.80 | ×1.25 | ×0.80 |
+| none | （なし） | 8800 | 0 | ×1.00 | ×1.00 | ×1.00 |
+| masterwork | 名工の | 400 | 1.0 | ×1.33 | ×0.75 | ×2.00 |
+| magical | 魔性の | 200 | 1.1 | ×1.58 | ×0.63 | ×3.00 |
+| imbued | 宿った | 80 | 1.25 | ×2.10 | ×0.48 | ×9.00 |
+| legendary | 伝説の | 15 | 1.55 | ×2.75 | ×0.36 | ×20.00 |
+| terrifying | 恐ろしい | 4 | 1.80 | ×3.50 | ×0.29 | ×42.00 |
+| broken | 壊れた | 1 | 1.67 | ×5.00 | ×0.20 | ×125.00 |
+
+**補正の意味:**
+- **プラス倍率**: プラス効果（ATK, DEF等の上昇値）に対する倍率
+- **マイナス倍率**: マイナス効果（ペナルティ値）に対する倍率
+- **価格倍率**: 売却価格に対する倍率
+
+### 称号の抽選ロジック
+
+```
+1. titleMultiplier を 1〜99 の範囲に制限（M）
+2. 各称号の重みを計算:
+   - power = 0 の称号（なし）: weight = baseWeight（固定）
+   - power > 0 の称号: weight = baseWeight × M^power
+3. 全重みの合計で正規化して加重抽選
+```
+
+### titleMultiplier による確率変化
+
+| 称号 | M=1 | M=10 | M=50 | M=99 |
+|------|-----|------|------|------|
+| 最低な | 2.0% | 2.0% | 1.3% | 0.9% |
+| 臭い | 3.0% | 3.0% | 2.0% | 1.4% |
+| （なし） | **88.0%** | 65.2% | 20.1% | **6.3%** |
+| 名工の | 4.0% | 4.0% | 9.1% | 8.2% |
+| 魔性の | 2.0% | 2.5% | 7.2% | 7.6% |
+| 宿った | 0.8% | 1.4% | 6.5% | 8.9% |
+| 伝説の | 0.15% | 0.5% | 5.7% | 13.4% |
+| 恐ろしい | 0.04% | 0.3% | 4.7% | 17.2% |
+| 壊れた | 0.01% | 0.05% | 2.1% | **8.3%** |
+
+※ 現在の実装では `titleMultiplier` は常に**デフォルト値1**で使用されている。
+
+### 称号の表示
+
+```
+称号なし: "ひのきの棒"
+称号あり: "伝説のひのきの棒"
+```
+
+`EquipmentTitleService.formatTitledName(titleName, baseName)` で生成。
+
+## 敵個別ドロップ
+
+### 仕組み
+
+敵データの `equipmentDrops` フィールドで個別設定:
+
+```typescript
+interface EquipmentDropConfig {
+  templateId: string   // EquipmentTemplate.id
+  probability: number  // 0.0〜1.0
+}
+```
+
+装備ドロップ（宝箱）とは**独立に**判定される。同じ重複制限（`droppedTemplateIds`）が適用される。
+
+### 現在の使用状況
+
+**実装済みだが、敵データでは未使用**。テストコードでのみ利用されている。
+将来的なレアドロップ実装用のインフラとして存在。
+
+## 因子ドロップ
+
+### 発生条件
+
+**ボス戦に勝利**した場合のみ判定される。通常戦闘では因子は獲得できない。
+
+```
+1. ボス戦の outcome が 'win' であること
+2. ボス敵の factorDrops が定義されていること
+3. 生存メンバー（casualties に含まれない）のみが対象
+4. 各メンバーごとに個別に確率判定
+```
+
+### 因子ドロップの処理
+
+```
+各生存ゴブリンについて:
+  RNG = createSeededRandom(seed + goblinId)  ← ゴブリンごとに異なる乱数列
+  各 factorDrop について:
+    既に同じ因子を持っている → スキップ
+    rng() < probability → 因子獲得
+```
+
+**重要**: `seed + goblinId` でゴブリンごとに異なる乱数列を使用するため、同じボスに対して各ゴブリンの獲得結果は独立。
+
+### ボス別因子ドロップ一覧
+
+| エリア | ボス名 | 敵ID | 獲得因子 | 確率 |
+|-------|--------|------|---------|------|
+| スライムの洞窟 | ボススライム | B_SLIME | slime | 100% |
+| 周辺の森 | グレイウルフ | B001 | wolf | 100% |
+| ゴブリンの村3 | ホブゴブリン | B_HOB | hobgoblin | 100% |
+| オーク野営地3 | オークウォーロード | B_ORC | orc | 100% |
+| アンデッド遺跡3 | 死霊術師の残骸 | B_LICH | undead | 100% |
+| 討伐隊3 | 討伐隊長 | B_CAPTAIN | （なし） | - |
+| ドワーフ鉱山3 | 鍛冶王 | B_FORGEKING | dwarf | 100% |
+| エルフの森3 | 森の番人 | B_FORESTGUARD | elf | 100% |
+| トカゲ人沼地3 | 沼王 | B_SWAMPKING | lizardman | 100% |
+| トロル峡谷3 | 峡谷の暴君 | B_TYRANT | troll | 100% |
+
+※ 全ボスの因子ドロップ確率は**100%**。ただし既に同じ因子を所持しているゴブリンはスキップされる。
+※ サブステージ `_3` のボスのみが因子ドロップを持つ（`_1`, `_2` のボスは持たない）。
+
+### 因子の永続化
+
+`CompleteExpeditionUseCase` が獲得した因子をゴブリンに保存:
+
+```
+ゴブリンの factors 配列に追加 → リポジトリで永続化
+```
+
+## 装備ドロップの永続化
+
+### 保存処理
+
+`CompleteExpeditionUseCase` が装備をDBに保存:
+
+```
+各 TreasureDrop について:
+  equipmentId = "eq_{timestamp}_{random9chars}"
+  slotIndex = -1        ← インベントリ（未装備）
+  goblinId = null       ← 誰にも装着されていない
+  titleId, titleName    ← 称号情報
+```
+
+### TreasureDrop 型
+
+```typescript
+interface TreasureDrop {
+  templateId: string          // EquipmentTemplate.id
+  name: string                // 称号付き装備名（例: "伝説のひのきの棒"）
+  titleId?: EquipmentTitleId  // 称号ID（undefinedなら称号なし）
+  titleName?: string          // 称号の表示名
+}
+```
+
+## 報酬サマリー
+
+### RewardSummary
+
+遠征完了時に全ドロップを集計:
+
+```typescript
+interface RewardSummary {
+  success: boolean              // 遠征成功フラグ
+  maxFloorReached: number       // 到達最大フロア
+  xpGained: number              // 合計経験値
+  goldGained: number            // 合計ゴールド
+  casualties: string[]          // 戦死者のゴブリンID
+  treasureDrops?: TreasureDrop[]    // 獲得装備一覧
+  memberLevelUps?: MemberLevelUp[]  // レベルアップ情報
+}
+```
+
+### TimelineEvent での記録
+
+装備ドロップは `treasure` タイプのイベントとしてタイムラインに記録:
+
+```typescript
+{ type: "treasure"; at: number; floor: number; items: TreasureDrop[] }
+```
+
+遠征ログ再生画面でいつ・どの階層で宝箱を獲得したかを確認できる。
+
+## 関連ソースコード
+
+| ファイル | 内容 |
+|---------|------|
+| `src/core/services/ExpeditionEngine.ts` | rollTreasureDrops()、ドロップ判定の呼び出し元 |
+| `src/core/services/EquipmentTitleService.ts` | 称号抽選ロジック（rollTitle） |
+| `src/core/services/FactorService.ts` | 因子ドロップ判定（rollFactorDrops） |
+| `src/core/usecases/CompleteExpeditionUseCase.ts` | ドロップの永続化処理 |
+| `src/shared/data/equipmentPool.json` | 装備テンプレート一覧 |
+| `src/shared/data/equipmentPoolLoader.ts` | ダンジョンレベル別プール取得 |
+| `src/shared/data/equipmentTitleConfig.ts` | 称号定義（重み・補正値） |
+| `src/shared/types/Equipment.ts` | EquipmentTemplate, EquipmentDropConfig 型 |
+| `src/shared/types/EquipmentTitle.ts` | EquipmentTitleId, EquipmentTitleDef 型 |
+| `src/shared/types/Expedition.ts` | TreasureDrop, RewardSummary 型 |
+| `src/shared/data/enemy/*.json` | 敵データ（factorDrops 定義） |
+| `src/shared/data/expeditionArea/*.json` | エリア定義（dropChance 定義） |
+| `src/core/services/__tests__/TreasureDrop.test.ts` | ドロップシステムのテスト |
+
+## 関連ドキュメント
+
+- [遠征システム](expedition_system.md) — 遠征の全体フロー、報酬分配
+- [戦闘システム](battle_system.md) — 戦闘勝利条件（ドロップのトリガー）
+- [因子システム](factor_system.md) — 因子の効果と継承
+- [MODシステム](mod_system.md) — 装備のMod効果
+- [拠点ランクシステム](base_rank_system.md) — 装備ショップ解放条件

--- a/goblin_native/docs/expedition_system.md
+++ b/goblin_native/docs/expedition_system.md
@@ -266,8 +266,8 @@ goldGained = Σ(各戦闘の enemy.gold)
 #### ダンジョンレベル準拠ドロップ
 
 ```
-1. dropChance（0.0〜1.0）で判定
-2. dungeonLevelに対応する装備プールから候補取得
+1. 一律25%（DROP_CHANCE定数）で判定
+2. areaLevelに対応する装備プールから候補取得
 3. 同一遠征で既にドロップした装備は除外
 4. 候補から均等抽選
 5. 称号を抽選（EquipmentTitleService.rollTitle）
@@ -307,7 +307,7 @@ goldGained = Σ(各戦闘の enemy.gold)
     xpFloor: [8, 10, 12],   // フロアごとの戦闘経験値
     xpBoss: 30               // ボス戦経験値
   },
-  dropChance: 0.15,          // 宝��ドロップ率
+  // 宝箱ドロップ率は全エリア一律25%（ExpeditionEngine.DROP_CHANCE定数）
   unlockNext: "goblin_village_1"  // 制圧時に解放されるダンジョン
 }
 ```

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -20,6 +20,9 @@ import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
 
+/** 全エリア共通の宝箱ドロップ確率（戦闘勝利ごと） */
+const DROP_CHANCE = 0.25
+
 export class ExpeditionEngine {
   private rng: () => number
   private seed: number
@@ -137,7 +140,7 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const treasureDrops = this.rollTreasureDrops(area.dropChance, area.areaLevel, enemies.flat(), droppedTemplateIds)
+            const treasureDrops = this.rollTreasureDrops(area.areaLevel, enemies.flat(), droppedTemplateIds)
             if (treasureDrops.length > 0) {
               events.push({
                 type: "treasure",
@@ -193,7 +196,7 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const defaultTreasure = this.rollTreasureDrops(area.dropChance, area.areaLevel, enemies.flat(), droppedTemplateIds)
+            const defaultTreasure = this.rollTreasureDrops(area.areaLevel, enemies.flat(), droppedTemplateIds)
             if (defaultTreasure.length > 0) {
               events.push({
                 type: "treasure",
@@ -257,7 +260,7 @@ export class ExpeditionEngine {
 
         // ボス戦勝利時の宝箱ドロップ判定
         if (bossCombat.outcome === 'win') {
-          const bossTreasure = this.rollTreasureDrops(area.dropChance, area.areaLevel, bossEnemies.flat(), droppedTemplateIds)
+          const bossTreasure = this.rollTreasureDrops(area.areaLevel, bossEnemies.flat(), droppedTemplateIds)
           if (bossTreasure.length > 0) {
             events.push({
               type: "treasure",
@@ -516,7 +519,6 @@ export class ExpeditionEngine {
    * 3. ドロップ時に称号を抽選して付与
    */
   private rollTreasureDrops(
-    dropChance: number | undefined,
     dungeonLevel: number,
     enemies: Enemy[],
     droppedIds: Set<string>,
@@ -525,7 +527,7 @@ export class ExpeditionEngine {
     const drops: TreasureDrop[] = []
 
     // ダンジョンレベルに応じた装備プールから抽選
-    if (dropChance !== undefined && this.rng() < dropChance) {
+    if (this.rng() < DROP_CHANCE) {
       const pool = getEquipmentByDungeonLevel(dungeonLevel)
       const candidates = pool.filter(t => !droppedIds.has(t.id))
 

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -13,14 +13,13 @@ function createEngine(seed: number): ExpeditionEngine {
 /** privateメソッドにアクセスするヘルパー */
 function callRollTreasureDrops(
   engine: ExpeditionEngine,
-  dropChance: number | undefined,
   dungeonLevel: number,
   enemies: Enemy[],
   droppedIds: Set<string>,
   titleMultiplier?: number
 ) {
   return (engine as any).rollTreasureDrops(
-    dropChance, dungeonLevel, enemies, droppedIds, titleMultiplier
+    dungeonLevel, enemies, droppedIds, titleMultiplier
   )
 }
 
@@ -40,44 +39,24 @@ function createDummyEnemy(overrides?: Partial<Enemy>): Enemy {
 
 describe('rollTreasureDrops', () => {
   describe('ドロップ確率の基本動作', () => {
-    it('dropChance=undefined の場合、装備プールからのドロップはない', () => {
-      const engine = createEngine(12345)
-      const result = callRollTreasureDrops(
-        engine, undefined, 1, [createDummyEnemy()], new Set()
-      )
-      expect(result).toEqual([])
-    })
-
-    it('dropChance=0 の場合、ドロップしない', () => {
-      const engine = createEngine(12345)
-      const iterations = 100
-      let dropCount = 0
-
-      for (let i = 0; i < iterations; i++) {
-        const eng = createEngine(i)
-        const result = callRollTreasureDrops(
-          eng, 0, 1, [createDummyEnemy()], new Set()
-        )
-        if (result.length > 0) dropCount++
-      }
-      expect(dropCount).toBe(0)
-    })
-
-    it('dropChance=1.0 の場合、装備プールに候補があれば必ずドロップする', () => {
+    it('一律25%のドロップ確率で装備がドロップする', () => {
       // areaLevel=1 にはひのきの棒(dropLevelMin=1,dropLevelMax=2)がある
       const pool = getEquipmentByDungeonLevel(1)
       if (pool.length === 0) return // プールが空なら skip
 
-      const iterations = 50
+      const iterations = 1000
       let dropCount = 0
       for (let i = 0; i < iterations; i++) {
         const eng = createEngine(i * 1000)
         const result = callRollTreasureDrops(
-          eng, 1.0, 1, [createDummyEnemy()], new Set()
+          eng, 1, [createDummyEnemy()], new Set()
         )
         if (result.length > 0) dropCount++
       }
-      expect(dropCount).toBe(iterations)
+      // 25%前後であることを確認（15%〜35%の範囲）
+      const rate = dropCount / iterations
+      expect(rate).toBeGreaterThan(0.15)
+      expect(rate).toBeLessThan(0.35)
     })
   })
 
@@ -86,10 +65,15 @@ describe('rollTreasureDrops', () => {
       const pool = getEquipmentByDungeonLevel(1)
       if (pool.length === 0) return
 
-      const engine = createEngine(42)
-      const result = callRollTreasureDrops(
-        engine, 1.0, 1, [createDummyEnemy()], new Set()
-      )
+      // 確実にドロップするシードを探す
+      let result: any[] = []
+      for (let seed = 0; seed < 100; seed++) {
+        const engine = createEngine(seed)
+        result = callRollTreasureDrops(
+          engine, 1, [createDummyEnemy()], new Set()
+        )
+        if (result.length > 0) break
+      }
 
       expect(result.length).toBeGreaterThan(0)
       expect(result[0]).toHaveProperty('templateId')
@@ -101,10 +85,10 @@ describe('rollTreasureDrops', () => {
     it('称号なしの場合、titleId/titleNameはundefined', () => {
       // 倍率1ではほぼ称号なし。多数試行してnoneを見つける
       let foundNone = false
-      for (let seed = 0; seed < 200; seed++) {
+      for (let seed = 0; seed < 500; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1.0, 1, [createDummyEnemy()], new Set()
+          engine, 1, [createDummyEnemy()], new Set()
         )
         if (result.length > 0 && result[0].titleId === undefined) {
           expect(result[0].titleName).toBeUndefined()
@@ -121,7 +105,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < 500; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1.0, 1, [createDummyEnemy()], new Set(), 99
+          engine, 1, [createDummyEnemy()], new Set(), 99
         )
         if (result.length > 0 && result[0].titleId !== undefined) {
           expect(typeof result[0].titleId).toBe('string')
@@ -145,11 +129,15 @@ describe('rollTreasureDrops', () => {
       // 全候補をdroppedIdsに入れる
       const droppedIds = new Set(pool.map(t => t.id))
 
-      const engine = createEngine(42)
-      const result = callRollTreasureDrops(
-        engine, 1.0, 1, [createDummyEnemy()], droppedIds
-      )
-      expect(result).toEqual([])
+      // ドロップするシードを探して実行
+      for (let seed = 0; seed < 100; seed++) {
+        const engine = createEngine(seed)
+        const result = callRollTreasureDrops(
+          engine, 1, [createDummyEnemy()], droppedIds
+        )
+        // プールからのドロップは全て除外されるため空
+        expect(result).toEqual([])
+      }
     })
 
     it('ドロップしたアイテムがdroppedIdsに追加される', () => {
@@ -157,13 +145,17 @@ describe('rollTreasureDrops', () => {
       if (pool.length === 0) return
 
       const droppedIds = new Set<string>()
-      const engine = createEngine(42)
-      const result = callRollTreasureDrops(
-        engine, 1.0, 1, [createDummyEnemy()], droppedIds
-      )
 
-      if (result.length > 0) {
-        expect(droppedIds.has(result[0].templateId)).toBe(true)
+      // ドロップするシードを探す
+      for (let seed = 0; seed < 100; seed++) {
+        const engine = createEngine(seed)
+        const result = callRollTreasureDrops(
+          engine, 1, [createDummyEnemy()], droppedIds
+        )
+        if (result.length > 0) {
+          expect(droppedIds.has(result[0].templateId)).toBe(true)
+          return
+        }
       }
     })
 
@@ -178,7 +170,7 @@ describe('rollTreasureDrops', () => {
       for (let i = 0; i < 50; i++) {
         const engine = createEngine(i * 100)
         const result = callRollTreasureDrops(
-          engine, 1.0, 1, [createDummyEnemy()], droppedIds
+          engine, 1, [createDummyEnemy()], droppedIds
         )
         for (const drop of result) {
           allDroppedTemplates.push(drop.templateId)
@@ -200,7 +192,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < iterations; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1.0, 1, [createDummyEnemy()], new Set(), 1
+          engine, 1, [createDummyEnemy()], new Set(), 1
         )
         for (const drop of result) {
           totalDrops++
@@ -221,7 +213,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < iterations; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1.0, 1, [createDummyEnemy()], new Set(), 99
+          engine, 1, [createDummyEnemy()], new Set(), 99
         )
         for (const drop of result) {
           totalDrops++
@@ -244,14 +236,21 @@ describe('rollTreasureDrops', () => {
         ],
       })
 
-      // dropChance=0（プールからはドロップしない）で敵ドロップのみ
-      const engine = createEngine(42)
-      const result = callRollTreasureDrops(
-        engine, 0, 1, [enemy], new Set()
-      )
-
-      expect(result.length).toBe(1)
-      expect(result[0].templateId).toBe('sword_cypress_stick')
+      // 敵ドロップは装備プール抽選とは独立に判定される
+      let found = false
+      for (let seed = 0; seed < 100; seed++) {
+        const engine = createEngine(seed)
+        const result = callRollTreasureDrops(
+          engine, 1, [enemy], new Set()
+        )
+        const enemyDrop = result.find((d: any) => d.templateId === 'sword_cypress_stick')
+        if (enemyDrop) {
+          expect(enemyDrop.templateId).toBe('sword_cypress_stick')
+          found = true
+          break
+        }
+      }
+      expect(found).toBe(true)
     })
 
     it('敵ドロップにも称号が付与される', () => {
@@ -266,10 +265,11 @@ describe('rollTreasureDrops', () => {
 
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 0, 1, [enemy], new Set(), 99
+          engine, 1, [enemy], new Set(), 99
         )
 
-        if (result.length > 0 && result[0].titleId !== undefined) {
+        const enemyDrop = result.find((d: any) => d.templateId === 'sword_cypress_stick')
+        if (enemyDrop && enemyDrop.titleId !== undefined) {
           foundTitle = true
           break
         }

--- a/goblin_native/src/shared/data/expeditionArea/slime_cave.json
+++ b/goblin_native/src/shared/data/expeditionArea/slime_cave.json
@@ -16,6 +16,5 @@
     "xpFloor": [4, 6],
     "xpBoss": 12
   },
-  "dropChance": 0.15,
   "unlockNext": "forest_outskirts"
 }

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -110,6 +110,5 @@ export interface AreaConfig {
     xpFloor: number[]
     xpBoss?: number
   }
-  dropChance?: number  // 戦闘勝利ごとの宝箱出現確率 (0.0〜1.0)、areaLevelに応じた装備がドロップ
   unlockNext?: string
 }


### PR DESCRIPTION
## Summary
- `AreaConfig`のエリア個別`dropChance`設定を廃止し、`ExpeditionEngine`の定数`DROP_CHANCE=0.25`で全エリア一律25%に変更
- これにより`slime_cave`以外の全ダンジョンでも装備がドロップするようになる
- ドロップシステム専用ドキュメント(`docs/drop_system.md`)を新規追加

## Test plan
- [x] TreasureDrop テスト全件通過（11 passed）
- [x] TypeScript型チェック通過（`npx tsc --noEmit`）
- [ ] 各エリアで遠征を実行し、装備ドロップが発生することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)