### PR TITLE
feat: 種族固有能力（Race Ability）システムを追加

### DIFF
--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -10,6 +10,7 @@ import { getFactorImage } from '@/shared/utils/factorImages'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 import { getExpForNextLevel, getExpProgress } from '@/core/services/ExperienceSystem'
 import { getModTemplate } from '@/shared/data/modPoolLoader'
+import { describeRaceAbility, getRaceAbilities } from '@/shared/data/raceAbilities'
 
 const STAT_LABELS: Record<string, string> = {
   hp_percent: 'HP', hp_flat: 'HP',
@@ -52,6 +53,7 @@ export default function GoblinDetailScreen() {
   )
   const expForNext = goblin ? getExpForNextLevel(goblin.level) : 0
   const expProgress = goblin ? getExpProgress(goblin.level, goblin.experience) : 0
+  const raceAbilities = useMemo(() => goblin ? getRaceAbilities(goblin.race) : [], [goblin])
 
   const handleBanish = useCallback(() => {
     if (!goblin) return
@@ -97,7 +99,7 @@ export default function GoblinDetailScreen() {
 
         <View style={styles.detailSection}>
           <Text style={styles.sectionTitle}>ステータス</Text>
-          <View style={styles.statList}>
+          <View style={styles.statGrid}>
             {([
               { key: 'hp', label: 'HP' },
               { key: 'atk', label: 'ATK' },
@@ -108,13 +110,27 @@ export default function GoblinDetailScreen() {
               { key: 'accuracy', label: '命中精度' },
               { key: 'evasion', label: '回避' },
             ] as const).map(item => (
-              <View key={item.key} style={styles.statRow}>
-                <Text style={styles.statRowLabel}>{item.label}</Text>
-                <Text style={styles.statRowValue}>{effectiveStats[item.key]}</Text>
+              <View key={item.key} style={styles.statChip}>
+                <Text style={styles.statChipLabel}>{item.label}</Text>
+                <Text style={styles.statChipValue}>{effectiveStats[item.key]}</Text>
               </View>
             ))}
           </View>
         </View>
+
+        {raceAbilities.length > 0 && (
+          <View style={styles.detailSection}>
+            <Text style={styles.sectionTitle}>種族能力</Text>
+            <View style={styles.abilityList}>
+              {raceAbilities.map((ability, idx) => (
+                <View key={`${ability.name}-${idx}`} style={styles.abilityItem}>
+                  <Text style={styles.abilityName}>{ability.name}</Text>
+                  <Text style={styles.abilityDesc}>{describeRaceAbility(ability)}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
 
         <View style={styles.detailSection}>
           <Text style={styles.sectionTitle}>経験値</Text>
@@ -133,54 +149,57 @@ export default function GoblinDetailScreen() {
         {goblin.factors && goblin.factors.length > 0 && (
           <View style={styles.detailSection}>
             <Text style={styles.sectionTitle}>因子</Text>
-            {goblin.factors.map((factorId, idx) => {
-              const factor = getFactor(factorId)
-              if (!factor) return null
-              const FactorIcon = getFactorImage(factorId)
-              return (
-                <View key={idx} style={styles.factorItem}>
-                  <View style={styles.factorIconContainer}>
-                    <FactorIcon width={24} height={24} />
+            <View style={styles.compactList}>
+              {goblin.factors.map((factorId, idx) => {
+                const factor = getFactor(factorId)
+                if (!factor) return null
+                const FactorIcon = getFactorImage(factorId)
+                return (
+                  <View key={idx} style={styles.factorItem}>
+                    <View style={styles.factorIconContainer}>
+                      <FactorIcon width={20} height={20} />
+                    </View>
+                    <View style={styles.factorInfo}>
+                      <Text style={styles.factorName}>{factor.name}</Text>
+                      {factor.effects && factor.effects.length > 0 && (
+                        <View style={styles.factorEffectRow}>
+                          {factor.effects
+                            .filter(effect => effect.type === 'stat_bonus')
+                            .map((effect, effectIndex) => (
+                              <View key={`${factorId}-${effectIndex}`} style={styles.factorEffectBadge}>
+                                <Text style={styles.factorEffectText}>
+                                  {effect.target.toUpperCase()} +{effect.value}
+                                </Text>
+                              </View>
+                            ))}
+                        </View>
+                      )}
+                    </View>
                   </View>
-                  <View style={styles.factorInfo}>
-                    <Text style={styles.factorName}>{factor.name}</Text>
-                    <Text style={styles.factorDesc}>{factor.description}</Text>
-                    {factor.effects && factor.effects.length > 0 && (
-                      <View style={styles.factorEffectRow}>
-                        {factor.effects
-                          .filter(effect => effect.type === 'stat_bonus')
-                          .map((effect, effectIndex) => (
-                            <View key={`${factorId}-${effectIndex}`} style={styles.factorEffectBadge}>
-                              <Text style={styles.factorEffectText}>
-                                {effect.target.toUpperCase()} +{effect.value}
-                              </Text>
-                            </View>
-                          ))}
-                      </View>
-                    )}
-                  </View>
-                </View>
-              )
-            })}
+                )
+              })}
+            </View>
           </View>
         )}
 
         {goblin.mods && goblin.mods.length > 0 && (
           <View style={styles.detailSection}>
             <Text style={styles.sectionTitle}>Mod</Text>
-            {goblin.mods.map((mod, idx) => {
-              const template = getModTemplate(mod.templateId)
-              if (!template) return null
-              const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
-              const label = getStatLabel(template.stat)
-              const valueText = `${mod.value > 0 ? '+' : ''}${mod.value}${isPercent ? '%' : ''}`
-              return (
-                <View key={idx} style={styles.modItem}>
-                  <Text style={styles.modName}>{label}</Text>
-                  <Text style={styles.modEffect}>{valueText}</Text>
-                </View>
-              )
-            })}
+            <View style={styles.modList}>
+              {goblin.mods.map((mod, idx) => {
+                const template = getModTemplate(mod.templateId)
+                if (!template) return null
+                const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
+                const label = getStatLabel(template.stat)
+                const valueText = `${mod.value > 0 ? '+' : ''}${mod.value}${isPercent ? '%' : ''}`
+                return (
+                  <View key={idx} style={styles.modItem}>
+                    <Text style={styles.modName}>{label}</Text>
+                    <Text style={styles.modEffect}>{valueText}</Text>
+                  </View>
+                )
+              })}
+            </View>
           </View>
         )}
 
@@ -203,119 +222,140 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    padding: 16,
+    padding: 12,
   },
   profileCard: {
     backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 16,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: '#F3F4F6',
   },
   profileRow: {
     flexDirection: 'row',
     alignItems: 'center',
   },
   profileAvatar: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    borderWidth: 2,
-    borderColor: '#9CA3AF',
+    width: 54,
+    height: 54,
+    borderRadius: 27,
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
-    marginRight: 16,
+    marginRight: 12,
     backgroundColor: '#F3F4F6',
   },
   profileAvatarImage: {
-    width: 52,
-    height: 52,
+    width: 44,
+    height: 44,
     resizeMode: 'contain',
   },
   profileInfo: {
     flex: 1,
   },
   profileName: {
-    fontSize: 20,
+    fontSize: 17,
     fontWeight: '700',
     color: '#1F2937',
-    marginBottom: 4,
-  },
-  profileRace: {
-    fontSize: 14,
-    color: '#6B7280',
     marginBottom: 2,
   },
+  profileRace: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginBottom: 1,
+  },
   profileLevel: {
-    fontSize: 16,
+    fontSize: 13,
     fontWeight: '600',
     color: '#1F2937',
   },
   detailSection: {
     backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 16,
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 6,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: '#F3F4F6',
   },
   sectionTitle: {
-    fontSize: 16,
+    fontSize: 12,
     fontWeight: 'bold',
     color: '#1F2937',
-    marginBottom: 12,
+    marginBottom: 6,
   },
-  statList: {
-    gap: 10,
-  },
-  statRow: {
+  statGrid: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderRadius: 10,
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  statChip: {
+    width: '48%',
+    paddingVertical: 7,
+    paddingHorizontal: 9,
+    borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
-    backgroundColor: '#F9FAFB',
+    borderColor: '#F3F4F6',
+    backgroundColor: '#FFFFFF',
   },
-  statRowLabel: {
-    fontSize: 14,
+  statChipLabel: {
+    fontSize: 9,
     fontWeight: '600',
-    color: '#374151',
+    color: '#6B7280',
+    marginBottom: 1,
   },
-  statRowValue: {
-    fontSize: 16,
+  statChipValue: {
+    fontSize: 13,
     fontWeight: '700',
-    color: '#374151',
+    color: '#1F2937',
+  },
+  abilityList: {
+    gap: 6,
+  },
+  abilityItem: {
+    padding: 8,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#F3F4F6',
+    backgroundColor: '#FFFFFF',
+  },
+  abilityName: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#1F2937',
+    marginBottom: 1,
+  },
+  abilityDesc: {
+    fontSize: 10,
+    color: '#6B7280',
   },
   expCard: {
-    borderRadius: 10,
+    borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
-    backgroundColor: '#F9FAFB',
-    padding: 12,
+    borderColor: '#F3F4F6',
+    backgroundColor: '#FFFFFF',
+    padding: 8,
   },
   expRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: 8,
+    marginBottom: 6,
   },
   expLabel: {
-    fontSize: 13,
+    fontSize: 10,
     fontWeight: '600',
     color: '#374151',
   },
   expValue: {
-    fontSize: 13,
+    fontSize: 10,
     color: '#6B7280',
   },
   expBarTrack: {
-    height: 8,
+    height: 6,
     backgroundColor: '#E5E7EB',
-    borderRadius: 8,
+    borderRadius: 999,
     overflow: 'hidden',
   },
   expBarFill: {
@@ -323,101 +363,102 @@ const styles = StyleSheet.create({
     backgroundColor: '#4B5563',
   },
   expHint: {
-    marginTop: 6,
-    fontSize: 12,
+    marginTop: 4,
+    fontSize: 10,
     color: '#6B7280',
     textAlign: 'right',
   },
+  compactList: {
+    gap: 6,
+  },
   factorItem: {
     flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 12,
-    padding: 12,
-    backgroundColor: '#F9FAFB',
-    borderRadius: 10,
+    alignItems: 'flex-start',
+    padding: 8,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#E5E7EB',
+    borderColor: '#F3F4F6',
   },
   factorIconContainer: {
-    width: 32,
-    height: 32,
+    width: 20,
+    height: 20,
     alignItems: 'center',
     justifyContent: 'center',
-    marginRight: 12,
+    marginRight: 8,
+    marginTop: 1,
   },
   factorInfo: {
     flex: 1,
   },
   factorName: {
-    fontSize: 14,
+    fontSize: 11,
     fontWeight: '600',
     color: '#1F2937',
-  },
-  factorDesc: {
-    fontSize: 12,
-    color: '#6B7280',
-    marginTop: 2,
   },
   factorEffectRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 6,
-    marginTop: 8,
+    gap: 4,
+    marginTop: 4,
   },
   factorEffectBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
-    backgroundColor: '#DCFCE7',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 999,
+    backgroundColor: '#ECFDF5',
   },
   factorEffectText: {
-    fontSize: 11,
+    fontSize: 9,
     color: '#166534',
     fontWeight: '600',
   },
-  modItem: {
+  modList: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 8,
-    padding: 12,
-    backgroundColor: '#F3F4F6',
-    borderRadius: 10,
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  modItem: {
+    width: '48%',
+    padding: 8,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 6,
     borderWidth: 1,
-    borderColor: '#DBEAFE',
+    borderColor: '#F3F4F6',
   },
   modName: {
-    fontSize: 14,
+    fontSize: 10,
     color: '#1F2937',
+    marginBottom: 2,
   },
   modEffect: {
-    fontSize: 14,
+    fontSize: 11,
     fontWeight: '600',
     color: '#1F2937',
   },
   equipmentButton: {
-    marginTop: 4,
-    marginBottom: 12,
+    marginTop: 2,
+    marginBottom: 8,
     backgroundColor: '#374151',
-    borderRadius: 10,
-    paddingVertical: 14,
+    borderRadius: 8,
+    paddingVertical: 11,
     alignItems: 'center',
   },
   equipmentButtonText: {
     color: '#FFFFFF',
     fontWeight: '700',
-    fontSize: 14,
+    fontSize: 12,
   },
   banishButton: {
-    marginBottom: 24,
-    backgroundColor: '#374151',
-    borderRadius: 10,
-    paddingVertical: 14,
+    marginBottom: 16,
+    backgroundColor: '#4B5563',
+    borderRadius: 8,
+    paddingVertical: 11,
     alignItems: 'center',
   },
   banishButtonText: {
     color: '#FFFFFF',
     fontWeight: '700',
-    fontSize: 14,
+    fontSize: 12,
   },
 })

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -1,5 +1,6 @@
 import type { AttackTargetDetail, BattleLogEntry, Enemy, Goblin, LearnedSpell } from '../../shared/types'
 import { SPELL_DEFS } from '../../shared/data/spells'
+import { getRaceAdditionalDamage, getRearProtectionMultiplier } from '../../shared/data/raceAbilities'
 import type { SpellDef } from '../../shared/types/Spell'
 import { CombatantManager } from './CombatantManager'
 import { DamageCalculator } from './DamageCalculator'
@@ -33,6 +34,7 @@ interface BattleUnit {
   rowSlot: number          // 列内のスロット番号（0-based）
   level: number            // 呪文のターゲット数計算用
   spellCharges: SpellCharge[]  // 戦闘中の呪文チャージ状態
+  race?: string
 }
 
 export interface BattleResult {
@@ -262,10 +264,15 @@ export class BattleSystem {
 
             // ダメージ補正: n<=2 → 1.0, n>=3 → 0.9^(n-2)
             const dmgMod = getDamageModifier(atkIdx + 1)
+            const additionalDamage = unit.race ? getRaceAdditionalDamage(unit.race) : 0
 
             // 被ダメージ軽減を適用
             const reductionFactor = 1 - target.damageReduction / 100
-            const damage = Math.max(1, Math.floor(baseDamage * dmgMod * reductionFactor))
+            const protectionFactor = this.getRearGuardReductionFactor(target, allyUnits)
+            const damage = Math.max(
+              1,
+              Math.floor((baseDamage * dmgMod + additionalDamage) * reductionFactor * protectionFactor),
+            )
 
             target.currentHP = Math.max(0, target.currentHP - damage)
 
@@ -506,6 +513,7 @@ export class BattleSystem {
       rowSlot: 0,
       level: goblin.level,
       spellCharges: this.initSpellCharges(goblin.spells),
+      race: goblin.race,
     }
   }
 
@@ -528,6 +536,17 @@ export class BattleSystem {
       level: enemy.level,
       spellCharges: this.initSpellCharges(enemy.spells),
     }
+  }
+
+  private getRearGuardReductionFactor(target: BattleUnit, allyUnits: BattleUnit[]): number {
+    if (!target.isAlly || target.currentHP <= 0) return 1
+
+    return allyUnits.reduce((factor, ally) => {
+      if (ally.currentHP <= 0 || ally.row >= target.row || !ally.race) {
+        return factor
+      }
+      return factor * getRearProtectionMultiplier(ally.race)
+    }, 1)
   }
 
   private createTurnStartLog(

--- a/goblin_native/src/core/services/EquipmentService.ts
+++ b/goblin_native/src/core/services/EquipmentService.ts
@@ -85,7 +85,10 @@ export class EquipmentService {
       if (!template) continue
 
       for (const bonus of template.statBonuses) {
-        bonuses.push(bonus)
+        bonuses.push({
+          ...bonus,
+          sourceCategory: template.category,
+        })
       }
     }
 
@@ -106,7 +109,10 @@ export class EquipmentService {
       if (!template?.effects) continue
 
       for (const effect of template.effects) {
-        effects.push(effect)
+        effects.push({
+          ...effect,
+          sourceCategory: template.category,
+        })
       }
     }
 

--- a/goblin_native/src/core/services/ModStatCalculator.ts
+++ b/goblin_native/src/core/services/ModStatCalculator.ts
@@ -2,6 +2,11 @@ import type { Goblin, GoblinStats } from '../../shared/types/Goblin'
 import type { ModInstance } from '../../shared/types/Mod'
 import type { EquipmentStatBonus, EquipmentEffect } from '../../shared/types/Equipment'
 import { getModTemplate, getDamageReductionCap } from '../../shared/data/modPoolLoader'
+import {
+  applyRaceBonusToEquipmentBonuses,
+  applyRaceBonusToEquipmentEffects,
+  getRaceStatBonuses,
+} from '../../shared/data/raceAbilities'
 import { FactorInheritanceService } from './FactorInheritanceService'
 import { factorDatabase } from '../../shared/data/factors'
 
@@ -34,13 +39,16 @@ export class ModStatCalculator {
     const percentBonuses = this.aggregatePercentBonuses(mods)
 
     // 4. 装備ボーナスを集計
-    const equipFlat = this.aggregateEquipmentFlat(equipmentBonuses ?? [])
-    const equipPercent = this.aggregateEquipmentPercent(equipmentBonuses ?? [])
+    const raceBonuses = getRaceStatBonuses(goblin.race)
+    const adjustedEquipmentBonuses = applyRaceBonusToEquipmentBonuses(goblin.race, equipmentBonuses ?? [])
+    const adjustedEquipmentEffects = applyRaceBonusToEquipmentEffects(goblin.race, equipmentEffects ?? [])
+    const equipFlat = this.aggregateEquipmentFlat(adjustedEquipmentBonuses)
+    const equipPercent = this.aggregateEquipmentPercent(adjustedEquipmentBonuses)
 
     // 5. 計算: (基礎 + 因子 + Modフラット + 装備フラット) * (1 + (Mod% + 装備%)/100)
     const calc = (key: keyof GoblinStats) =>
       Math.floor(
-        (base[key] + factorBonuses[key] + flatBonuses[key] + equipFlat[key]) *
+        (base[key] + factorBonuses[key] + flatBonuses[key] + equipFlat[key] + (raceBonuses[key] ?? 0)) *
         (1 + (percentBonuses[key] + equipPercent[key]) / 100)
       )
 
@@ -56,7 +64,7 @@ export class ModStatCalculator {
     }
 
     // 6. 装備特殊効果を適用（ステータス確定後）
-    this.applyEquipmentEffects(result, equipmentEffects ?? [])
+    this.applyEquipmentEffects(result, adjustedEquipmentEffects)
 
     return result
   }
@@ -68,6 +76,7 @@ export class ModStatCalculator {
   static getDamageReduction(goblin: Goblin, equipmentBonuses?: EquipmentStatBonus[]): number {
     const mods = goblin.mods ?? []
     let total = 0
+    const adjustedEquipmentBonuses = applyRaceBonusToEquipmentBonuses(goblin.race, equipmentBonuses ?? [])
 
     for (const mod of mods) {
       const template = getModTemplate(mod.templateId)
@@ -77,7 +86,7 @@ export class ModStatCalculator {
     }
 
     // 装備の被ダメージ軽減を加算
-    for (const bonus of equipmentBonuses ?? []) {
+    for (const bonus of adjustedEquipmentBonuses) {
       if (bonus.stat === 'damage_reduction') {
         total += bonus.value
       }

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -2,6 +2,7 @@ import { GoblinBirthService } from '../GoblinBirthService'
 import { ModStatCalculator } from '../ModStatCalculator'
 import { BattleSystem, getDamageModifier, getAccuracyModifier, getRowWeight, selectTarget } from '../BattleSystem'
 import { getBloodlineCombatStats } from '../../../shared/data/equipmentConfig'
+import { EquipmentService } from '../EquipmentService'
 import type { Goblin, Enemy } from '../../../shared/types'
 
 /**
@@ -247,6 +248,42 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
     expect(result.accuracy).toBe(150)  // 100 * 1.5
     expect(result.evasion).toBe(130)   // 100 * 1.3
   })
+
+  it('ウルフゴブリンは攻撃回数が+2される', () => {
+    const goblin = createTestGoblin({
+      race: 'ウルフゴブリン',
+      stats: { hp: 60, atk: 12, sp: 10, spd: 10, def: 10, attackCount: 3, accuracy: 20, evasion: 15 },
+    })
+    const result = ModStatCalculator.calculate(goblin)
+
+    expect(result.attackCount).toBe(5)
+  })
+
+  it('スライムゴブリンは鎧の能力値が1.3倍になる', () => {
+    const goblin = createTestGoblin({ race: 'スライムゴブリン' })
+    const result = ModStatCalculator.calculate(goblin, [
+      { stat: 'def_flat', value: 10, sourceCategory: 'armor' },
+    ])
+
+    expect(result.def).toBe(23)
+  })
+
+  it('ウルフゴブリンは装備の命中精度補正が2倍になる', () => {
+    const goblin = createTestGoblin({ race: 'ウルフゴブリン' })
+    const result = ModStatCalculator.calculate(goblin, [
+      { stat: 'accuracy_flat', value: 10, sourceCategory: 'weapon' },
+    ])
+
+    expect(result.accuracy).toBe(40)
+  })
+
+  it('EquipmentServiceは装備カテゴリをボーナスへ保持する', () => {
+    const bonuses = EquipmentService.calculateEquipmentBonuses([
+      { id: 'eq1', templateId: 'sword_cypress_stick', slotIndex: 0, goblinId: 1 },
+    ])
+
+    expect(bonuses[0].sourceCategory).toBe('weapon')
+  })
 })
 
 // =========================================================================
@@ -429,6 +466,88 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     for (const target of allyLog.targets) {
       expect(target.targetRow).toBeGreaterThanOrEqual(1)
     }
+  })
+
+  it('ウルフゴブリンの追加ダメージは通常攻撃へ固定値で加算される', () => {
+    const enemies = [[createTestEnemy({ hp: 9999, spd: 1, evasion: 0, def: 0 })]]
+    const rngA = createSeededRng(42)
+    const rngB = createSeededRng(42)
+
+    const normalResult = new BattleSystem().executeBattle([
+      createTestGoblin({
+        race: 'ゴブリン',
+        stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 3, accuracy: 999, evasion: 10 },
+      }),
+    ], [100], enemies, rngA, 1)
+    const wolfResult = new BattleSystem().executeBattle([
+      createTestGoblin({
+        race: 'ウルフゴブリン',
+        stats: { hp: 100, atk: 50, sp: 10, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 10 },
+      }),
+    ], [100], [[createTestEnemy({ hp: 9999, spd: 1, evasion: 0, def: 0 })]], rngB, 1)
+
+    const normalLog = normalResult.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    const wolfLog = wolfResult.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    const normalDamage = normalLog.targets[0].totalDamage
+    const wolfDamage = wolfLog.targets[0].totalDamage
+
+    expect(wolfLog.hitCount).toBe(normalLog.hitCount)
+    expect(wolfDamage - normalDamage).toBe(13 * wolfLog.hitCount)
+  })
+
+  it('スライムゴブリンより後列の仲間は通常攻撃ダメージが軽減される', () => {
+    const protectedAllies = [
+      createTestGoblin({
+        id: 1,
+        race: 'スライムゴブリン',
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 10, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+      createTestGoblin({
+        id: 2,
+        race: 'ゴブリン',
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 1, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+    ]
+    const plainAllies = [
+      createTestGoblin({
+        id: 1,
+        race: 'ゴブリン',
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 10, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+      createTestGoblin({
+        id: 2,
+        race: 'ゴブリン',
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 1, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+    ]
+    const enemies = [[createTestEnemy({
+      hp: 9999,
+      atk: 90,
+      def: 0,
+      spd: 100,
+      attackCount: 20,
+      accuracy: 999,
+      evasion: 0,
+    })]]
+
+    const protectedResult = new BattleSystem().executeBattle(protectedAllies, [9999, 9999], enemies, createSeededRng(7), 1)
+    const plainResult = new BattleSystem().executeBattle(plainAllies, [9999, 9999], [[createTestEnemy({
+      hp: 9999,
+      atk: 90,
+      def: 0,
+      spd: 100,
+      attackCount: 20,
+      accuracy: 999,
+      evasion: 0,
+    })]], createSeededRng(7), 1)
+
+    const protectedRear = protectedResult.detailedLog.find(log => log.action === '通常攻撃' && !log.isAlly)!.targets.find(target => target.targetId === '2')
+    const plainRear = plainResult.detailedLog.find(log => log.action === '通常攻撃' && !log.isAlly)!.targets.find(target => target.targetId === '2')
+
+    expect(protectedRear).toBeDefined()
+    expect(plainRear).toBeDefined()
+    expect(protectedRear!.hitCount).toBe(plainRear!.hitCount)
+    expect(protectedRear!.totalDamage).toBeLessThan(plainRear!.totalDamage)
   })
 })
 

--- a/goblin_native/src/shared/data/raceAbilities.ts
+++ b/goblin_native/src/shared/data/raceAbilities.ts
@@ -1,0 +1,138 @@
+import type {
+  EquipmentCategory,
+  EquipmentEffect,
+  EquipmentStat,
+  EquipmentStatBonus,
+  GoblinStats,
+  RaceAbility,
+} from '../types'
+
+const RACE_ABILITIES: Record<string, RaceAbility[]> = {
+  'スライムゴブリン': [
+    {
+      name: '[1.3倍]鎧装備',
+      equipmentCategoryMultiplier: {
+        armor: 1.3,
+      },
+    },
+    {
+      name: '後列防護',
+      protectRearAllyNormalAttackMultiplier: 2 / 3,
+    },
+  ],
+  'ウルフゴブリン': [
+    {
+      name: '[+2]攻撃回数アップ',
+      statBonuses: {
+        attackCount: 2,
+      },
+    },
+    {
+      name: '[2.0倍]命中精度',
+      equipmentStatMultipliers: {
+        accuracy_flat: 2,
+        accuracy_percent: 2,
+      },
+    },
+    {
+      name: '[+13]追加ダメージ',
+      additionalDamage: 13,
+    },
+  ],
+}
+
+export function getRaceAbilities(race: string): RaceAbility[] {
+  return RACE_ABILITIES[race] ?? []
+}
+
+export function describeRaceAbility(ability: RaceAbility): string {
+  if (ability.additionalDamage !== undefined) {
+    return `通常攻撃の各ヒットに固定で+${ability.additionalDamage}`
+  }
+
+  if (ability.protectRearAllyNormalAttackMultiplier !== undefined) {
+    const reducedRate = Math.round((1 - ability.protectRearAllyNormalAttackMultiplier) * 100)
+    return `自分より後列の仲間が受ける通常攻撃ダメージを${reducedRate}%軽減`
+  }
+
+  if (ability.equipmentCategoryMultiplier?.armor !== undefined) {
+    return `鎧カテゴリ装備の能力値が×${ability.equipmentCategoryMultiplier.armor.toFixed(1)}`
+  }
+
+  if (ability.equipmentStatMultipliers?.accuracy_flat !== undefined) {
+    return `装備由来の命中精度補正が×${ability.equipmentStatMultipliers.accuracy_flat.toFixed(1)}`
+  }
+
+  if (ability.statBonuses?.attackCount !== undefined) {
+    return `攻撃回数 +${ability.statBonuses.attackCount}`
+  }
+
+  return ability.name
+}
+
+export function getRaceStatBonuses(race: string): Partial<Record<keyof GoblinStats, number>> {
+  const bonuses: Partial<Record<keyof GoblinStats, number>> = {}
+
+  for (const ability of getRaceAbilities(race)) {
+    for (const [key, value] of Object.entries(ability.statBonuses ?? {})) {
+      const statKey = key as keyof GoblinStats
+      bonuses[statKey] = (bonuses[statKey] ?? 0) + (value ?? 0)
+    }
+  }
+
+  return bonuses
+}
+
+export function getRaceAdditionalDamage(race: string): number {
+  return getRaceAbilities(race).reduce((sum, ability) => sum + (ability.additionalDamage ?? 0), 0)
+}
+
+export function getRearProtectionMultiplier(race: string): number {
+  return getRaceAbilities(race).reduce(
+    (product, ability) => product * (ability.protectRearAllyNormalAttackMultiplier ?? 1),
+    1,
+  )
+}
+
+function getEquipmentValueMultiplier(
+  race: string,
+  category: EquipmentCategory | undefined,
+  stat: EquipmentStat | undefined,
+): number {
+  return getRaceAbilities(race).reduce((product, ability) => {
+    let next = product
+
+    if (category) {
+      next *= ability.equipmentCategoryMultiplier?.[category] ?? 1
+    }
+
+    if (stat) {
+      next *= ability.equipmentStatMultipliers?.[stat] ?? 1
+    }
+
+    return next
+  }, 1)
+}
+
+export function applyRaceBonusToEquipmentBonuses(
+  race: string,
+  bonuses: EquipmentStatBonus[],
+): EquipmentStatBonus[] {
+  return bonuses.map((bonus) => ({
+    ...bonus,
+    value: bonus.value * getEquipmentValueMultiplier(race, bonus.sourceCategory, bonus.stat),
+  }))
+}
+
+export function applyRaceBonusToEquipmentEffects(
+  race: string,
+  effects: EquipmentEffect[],
+): EquipmentEffect[] {
+  return effects.map((effect) => {
+    const statKey = effect.type === 'accuracy_boost' ? 'accuracy_flat' : undefined
+    return {
+      ...effect,
+      value: effect.value * getEquipmentValueMultiplier(race, effect.sourceCategory, statKey),
+    }
+  })
+}

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -43,6 +43,7 @@ export type EquipmentStat =
 export interface EquipmentStatBonus {
   stat: EquipmentStat
   value: number
+  sourceCategory?: EquipmentCategory
 }
 
 /**
@@ -56,6 +57,7 @@ export type EquipmentEffectType = 'def_to_hp' | 'critical_damage_bonus' | 'accur
 export interface EquipmentEffect {
   type: EquipmentEffectType
   value: number // def_to_hp: %, critical_damage_bonus: %, accuracy_boost: フラット値
+  sourceCategory?: EquipmentCategory
 }
 
 /**

--- a/goblin_native/src/shared/types/RaceAbility.ts
+++ b/goblin_native/src/shared/types/RaceAbility.ts
@@ -1,0 +1,11 @@
+import type { EquipmentCategory, EquipmentStat } from './Equipment'
+import type { GoblinStats } from './Goblin'
+
+export interface RaceAbility {
+  name: string
+  statBonuses?: Partial<Record<keyof GoblinStats, number>>
+  equipmentCategoryMultiplier?: Partial<Record<EquipmentCategory, number>>
+  equipmentStatMultipliers?: Partial<Record<EquipmentStat, number>>
+  additionalDamage?: number
+  protectRearAllyNormalAttackMultiplier?: number
+}

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -52,6 +52,9 @@ export type { SpellDef, SpellTargeting, LearnedSpell } from "./Spell"
 // Battle related types
 export type { AttackTargetDetail, BattleLogEntry, BattleLogMeta, CombatReplay } from "./Battle"
 
+// Race ability related types
+export type { RaceAbility } from "./RaceAbility"
+
 // Expedition related types
 export type {
   ExpeditionRequest,


### PR DESCRIPTION
## Summary
- ウルフゴブリン・スライムゴブリンの種族固有能力を新規実装（RaceAbility型 + raceAbilities.tsマスタデータ）
- BattleSystem・ModStatCalculator・EquipmentServiceに種族能力の計算ロジックを統合
- ゴブリン詳細画面のUI刷新（コンパクトレイアウト + 種族能力セクション追加）

## 種族能力の内容
**ウルフゴブリン**: 攻撃回数+2 / 追加ダメージ+13 / 装備命中精度補正×2.0
**スライムゴブリン**: 鎧装備能力値×1.3 / 後列防護（後方仲間のダメージ33%軽減）

## Test plan
- [x] CombatStats.test.ts に種族能力のテストケースを追加済み
- [ ] ウルフゴブリン・スライムゴブリンで遠征を実行し、種族能力が戦闘に反映されることを確認
- [ ] ゴブリン詳細画面で種族能力セクションが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)