### PR TITLE
feat: 遠征準備画面から装備一覧・装備変更画面へのナビゲーションを追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/_layout.tsx
+++ b/goblin_native/app/(tabs)/formation/_layout.tsx
@@ -24,6 +24,20 @@ export default function FormationLayout() {
         }}
       />
       <Stack.Screen
+        name="equipment-list"
+        options={{
+          title: '装備アイテムの一覧',
+          presentation: 'card',
+        }}
+      />
+      <Stack.Screen
+        name="equipment"
+        options={{
+          title: '装備変更',
+          presentation: 'formSheet',
+        }}
+      />
+      <Stack.Screen
         name="playback"
         options={{
           title: 'Expedition',

--- a/goblin_native/app/(tabs)/formation/equipment-list.tsx
+++ b/goblin_native/app/(tabs)/formation/equipment-list.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Stack, router, useLocalSearchParams } from 'expo-router'
+import { useFocusEffect } from '@react-navigation/native'
+import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
+import { EquipmentService } from '@/core/services/EquipmentService'
+import { EquipmentTitleService } from '@/core/services/EquipmentTitleService'
+import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
+import { getGoblinImage } from '@/shared/utils/goblinImages'
+import type { EquipmentInstance, EquipmentTemplate, Goblin, Party } from '@/shared/types'
+
+function getDisplayName(eq: EquipmentInstance, template: EquipmentTemplate): string {
+  if (eq.titleName) {
+    return EquipmentTitleService.formatTitledName(eq.titleName, template.name)
+  }
+  return template.name
+}
+
+export default function PartyEquipmentListScreen() {
+  const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { parties, isLoading: partiesLoading, getPartyById } = usePartyStore()
+  const { goblins, isLoading: goblinsLoading } = useGoblinStore()
+  const [party, setParty] = useState<Party | null>(null)
+  const [equipmentMap, setEquipmentMap] = useState<Record<number, EquipmentInstance[]>>({})
+  const [isLoadingEquipment, setIsLoadingEquipment] = useState(true)
+
+  useEffect(() => {
+    if (!partyId) {
+      setParty(null)
+      return
+    }
+    void getPartyById(parseInt(partyId, 10)).then(setParty).catch(() => setParty(null))
+  }, [partyId, parties, getPartyById])
+
+  const partyMembers = useMemo(() => {
+    if (!party) return []
+    return party.memberIds
+      .map(id => goblins.find(goblin => goblin.id === id))
+      .filter((goblin): goblin is Goblin => goblin !== undefined)
+  }, [party, goblins])
+
+  const loadEquipment = useCallback(async () => {
+    if (partyMembers.length === 0) {
+      setEquipmentMap({})
+      setIsLoadingEquipment(false)
+      return
+    }
+
+    setIsLoadingEquipment(true)
+    const repository = SQLiteEquipmentRepository.getInstance()
+    const entries = await Promise.all(
+      partyMembers.map(async member => {
+        const items = await repository.getByGoblinId(member.id)
+        return [member.id, items] as const
+      }),
+    )
+
+    setEquipmentMap(Object.fromEntries(entries))
+    setIsLoadingEquipment(false)
+  }, [partyMembers])
+
+  useEffect(() => {
+    void loadEquipment()
+  }, [loadEquipment])
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadEquipment()
+    }, [loadEquipment]),
+  )
+
+  const handleOpenGoblinEquipment = useCallback((goblinId: number) => {
+    router.push({
+      pathname: '/formation/equipment',
+      params: { goblinId: String(goblinId) },
+    })
+  }, [])
+
+  if (partiesLoading || goblinsLoading || isLoadingEquipment) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#10B981" />
+        <Text style={styles.loadingText}>装備情報を読み込み中...</Text>
+      </View>
+    )
+  }
+
+  if (!party) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorText}>パーティが見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: '装備アイテムの一覧',
+        }}
+      />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <View style={styles.headerCard}>
+          <Text style={styles.partyName}>{party.name}</Text>
+          <Text style={styles.description}>メンバーを選ぶと、そのまま装備変更画面を開きます。</Text>
+        </View>
+
+        {partyMembers.length === 0 ? (
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyText}>パーティメンバーがいません</Text>
+          </View>
+        ) : (
+          partyMembers.map(member => {
+            const equippedItems = equipmentMap[member.id] ?? []
+            const maxSlots = EquipmentService.getAvailableSlots(member)
+
+            return (
+              <TouchableOpacity
+                key={member.id}
+                style={styles.memberCard}
+                onPress={() => handleOpenGoblinEquipment(member.id)}
+                activeOpacity={0.85}
+              >
+                <View style={styles.memberHeader}>
+                  <Image source={getGoblinImage(member.avatar)} style={styles.avatar} />
+                  <View style={styles.memberMeta}>
+                    <Text style={styles.memberName}>{member.name}</Text>
+                    <Text style={styles.memberSubText}>
+                      装備 {equippedItems.length}/{maxSlots}
+                    </Text>
+                  </View>
+                  <Text style={styles.changeLink}>変更する</Text>
+                </View>
+
+                {equippedItems.length === 0 ? (
+                  <Text style={styles.emptyEquipmentText}>装備中のアイテムはありません</Text>
+                ) : (
+                  <View style={styles.equipmentList}>
+                    {equippedItems.map(item => {
+                      const template = getEquipmentTemplate(item.templateId)
+                      if (!template) return null
+
+                      return (
+                        <View key={item.id} style={styles.equipmentChip}>
+                          <Text style={styles.equipmentChipText} numberOfLines={1}>
+                            {getDisplayName(item, template)}
+                          </Text>
+                        </View>
+                      )
+                    })}
+                  </View>
+                )}
+              </TouchableOpacity>
+            )
+          })
+        )}
+      </ScrollView>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+  },
+  content: {
+    padding: 16,
+    gap: 12,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+    padding: 24,
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#DC2626',
+  },
+  headerCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+  },
+  partyName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  description: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#6B7280',
+  },
+  emptyCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 20,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  memberCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  memberHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  avatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 6,
+    marginRight: 12,
+  },
+  memberMeta: {
+    flex: 1,
+  },
+  memberName: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#1F2937',
+    marginBottom: 2,
+  },
+  memberSubText: {
+    fontSize: 12,
+    color: '#6B7280',
+  },
+  changeLink: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#2563EB',
+  },
+  emptyEquipmentText: {
+    fontSize: 13,
+    color: '#9CA3AF',
+  },
+  equipmentList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  equipmentChip: {
+    backgroundColor: '#EFF6FF',
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    maxWidth: '100%',
+  },
+  equipmentChipText: {
+    fontSize: 12,
+    color: '#1D4ED8',
+  },
+})

--- a/goblin_native/app/(tabs)/formation/equipment.tsx
+++ b/goblin_native/app/(tabs)/formation/equipment.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../goblin/equipment'

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -373,7 +373,7 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   partyName: {
-    fontSize: 18,
+    fontSize: 16,
     fontWeight: 'bold',
     color: '#1F2937',
   },

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -138,6 +138,13 @@ export default function ExpeditionPreparationScreen() {
     })
   }, [partyId])
 
+  const handleOpenEquipmentList = useCallback(() => {
+    router.push({
+      pathname: '/formation/equipment-list',
+      params: { partyId },
+    })
+  }, [partyId])
+
   const handleSelectDungeon = useCallback((dungeon: Dungeon) => {
     setSelectedDungeonId(dungeon.id)
     if (partyId) {
@@ -266,6 +273,10 @@ export default function ExpeditionPreparationScreen() {
 
             <TouchableOpacity style={styles.editButton} onPress={handleEditParty}>
               <Text style={styles.editButtonText}>メンバーを変更する</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.secondaryButton} onPress={handleOpenEquipmentList}>
+              <Text style={styles.secondaryButtonText}>装備アイテムの一覧</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -492,7 +503,7 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   partyName: {
-    fontSize: 20,
+    fontSize: 16,
     fontWeight: 'bold',
     color: '#1F2937',
     marginBottom: 16,
@@ -545,11 +556,25 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 14,
     alignItems: 'center',
+    marginBottom: 10,
   },
   editButtonText: {
     fontSize: 14,
     fontWeight: '600',
     color: '#4B5563',
+  },
+  secondaryButton: {
+    backgroundColor: '#EFF6FF',
+    borderRadius: 8,
+    padding: 14,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+  },
+  secondaryButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1D4ED8',
   },
   settingItem: {
     marginBottom: 12,

--- a/goblin_native/app/goblin/_layout.tsx
+++ b/goblin_native/app/goblin/_layout.tsx
@@ -13,7 +13,7 @@ export default function GoblinLayout() {
         options={{
           headerShown: true,
           title: '装備変更',
-          presentation: 'modal',
+          presentation: 'formSheet',
           headerStyle: { backgroundColor: '#FFFFFF' },
           headerTitleStyle: { color: '#1F2937', fontWeight: 'bold' },
           headerTintColor: '#6B7280',


### PR DESCRIPTION
## Summary
- 遠征準備画面に「装備アイテムの一覧」ボタンを追加
- パーティメンバーの装備状況を一覧表示する新規画面（equipment-list）を追加
- 一覧画面からメンバーをタップして装備変更画面へ遷移できるフローを実装
- 装備変更画面の表示スタイルをformSheetに統一

## Test plan
- [ ] 遠征準備画面で「装備アイテムの一覧」ボタンが表示されること
- [ ] ボタンタップでパーティメンバーの装備一覧画面に遷移すること
- [ ] 各メンバーの装備状況（装備数/スロット数、装備名）が正しく表示されること
- [ ] メンバーをタップして装備変更画面が開くこと
- [ ] 装備変更後に一覧画面に戻ると装備情報が更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)