### PR TITLE
feat: 待機中ゴブリンのタップで詳細画面を閲覧可能にする

### DIFF
--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -46,6 +46,13 @@ export default function GoblinListScreen() {
     router.push({ pathname: '/goblin/detail', params: { goblinId: String(goblin.id) } })
   }, [])
 
+  const handlePendingGoblinPress = useCallback((goblin: Goblin) => {
+    router.push({
+      pathname: '/goblin/detail',
+      params: { goblinId: String(goblin.id), source: 'pending' },
+    })
+  }, [])
+
   const handleAddPending = useCallback(async (goblin: Goblin) => {
     await saveGoblin(goblin)
     await removePendingGoblin(goblin.id)
@@ -134,31 +141,37 @@ export default function GoblinListScreen() {
               return (
                 <View key={goblin.id} style={styles.pendingCard}>
                   <View style={styles.pendingRow}>
-                    <Image source={getGoblinImage(goblin.avatar)} style={styles.pendingAvatar} />
-                    <View style={styles.pendingInfo}>
-                      <Text style={styles.pendingName} numberOfLines={1}>{goblin.name}</Text>
-                      <Text style={styles.pendingStats}>
-                        HP{effectiveStats.hp} / A{effectiveStats.atk} / D{effectiveStats.def} / S{effectiveStats.spd} / SP{effectiveStats.sp}
-                      </Text>
-                      {goblin.mods && goblin.mods.length > 0 && (
-                        <View style={styles.modRow}>
-                          {goblin.mods.map((mod, index) => {
-                            const template = getModTemplate(mod.templateId)
-                            if (!template) return null
-                            const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
-                            const label = `${getStatLabel(template.stat)}+${mod.value}${isPercent ? '%' : ''}`
-                            const isPrefix = template.type === 'prefix'
-                            return (
-                              <View key={index} style={[styles.modBadge, isPrefix ? styles.modBadgeBlue : styles.modBadgePurple]}>
-                                <Text style={[styles.modBadgeText, isPrefix ? styles.modBadgeTextBlue : styles.modBadgeTextPurple]}>
-                                  {label}
-                                </Text>
-                              </View>
-                            )
-                          })}
-                        </View>
-                      )}
-                    </View>
+                    <TouchableOpacity
+                      style={styles.pendingPressable}
+                      activeOpacity={0.8}
+                      onPress={() => handlePendingGoblinPress(goblin)}
+                    >
+                      <Image source={getGoblinImage(goblin.avatar)} style={styles.pendingAvatar} />
+                      <View style={styles.pendingInfo}>
+                        <Text style={styles.pendingName} numberOfLines={1}>{goblin.name}</Text>
+                        <Text style={styles.pendingStats}>
+                          HP{effectiveStats.hp} / A{effectiveStats.atk} / D{effectiveStats.def} / S{effectiveStats.spd} / SP{effectiveStats.sp}
+                        </Text>
+                        {goblin.mods && goblin.mods.length > 0 && (
+                          <View style={styles.modRow}>
+                            {goblin.mods.map((mod, index) => {
+                              const template = getModTemplate(mod.templateId)
+                              if (!template) return null
+                              const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
+                              const label = `${getStatLabel(template.stat)}+${mod.value}${isPercent ? '%' : ''}`
+                              const isPrefix = template.type === 'prefix'
+                              return (
+                                <View key={index} style={[styles.modBadge, isPrefix ? styles.modBadgeBlue : styles.modBadgePurple]}>
+                                  <Text style={[styles.modBadgeText, isPrefix ? styles.modBadgeTextBlue : styles.modBadgeTextPurple]}>
+                                    {label}
+                                  </Text>
+                                </View>
+                              )
+                            })}
+                          </View>
+                        )}
+                      </View>
+                    </TouchableOpacity>
                     {hasCapacity && (
                       <TouchableOpacity
                         style={styles.addButton}
@@ -315,6 +328,12 @@ const styles = StyleSheet.create({
     borderBottomColor: '#E5E7EB',
   },
   pendingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  pendingPressable: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,

--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Image, Alert } fr
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, router, useNavigation } from 'expo-router'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { useBaseStore } from '@/presentation/stores/useBaseStore'
 import type { Goblin } from '@/shared/types'
 import { getFactor } from '@/shared/data/factors'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
@@ -29,17 +30,26 @@ function getStatLabel(stat: string): string {
 }
 
 export default function GoblinDetailScreen() {
-  const { goblinId } = useLocalSearchParams<{ goblinId: string }>()
+  const { goblinId, source } = useLocalSearchParams<{ goblinId: string, source?: string }>()
   const { getGoblinById, deleteGoblin } = useGoblinStore()
+  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
   const [goblin, setGoblin] = useState<Goblin | null>(null)
   const parentNav = useNavigation()
+  const isPendingGoblin = source === 'pending'
 
   useEffect(() => {
     if (!goblinId) return
-    void getGoblinById(parseInt(goblinId, 10))
+    const parsedGoblinId = parseInt(goblinId, 10)
+
+    if (isPendingGoblin) {
+      setGoblin(pendingGoblins.find((item) => item.id === parsedGoblinId) ?? null)
+      return
+    }
+
+    void getGoblinById(parsedGoblinId)
       .then(setGoblin)
       .catch(() => setGoblin(null))
-  }, [goblinId, getGoblinById])
+  }, [goblinId, getGoblinById, isPendingGoblin, pendingGoblins])
 
   useEffect(() => {
     if (goblin) {
@@ -203,13 +213,17 @@ export default function GoblinDetailScreen() {
           </View>
         )}
 
-        <TouchableOpacity style={styles.equipmentButton} onPress={handleOpenEquipment}>
-          <Text style={styles.equipmentButtonText}>装備変更</Text>
-        </TouchableOpacity>
+        {!isPendingGoblin && (
+          <>
+            <TouchableOpacity style={styles.equipmentButton} onPress={handleOpenEquipment}>
+              <Text style={styles.equipmentButtonText}>装備変更</Text>
+            </TouchableOpacity>
 
-        <TouchableOpacity style={styles.banishButton} onPress={handleBanish}>
-          <Text style={styles.banishButtonText}>このゴブリンを追放する</Text>
-        </TouchableOpacity>
+            <TouchableOpacity style={styles.banishButton} onPress={handleBanish}>
+              <Text style={styles.banishButtonText}>このゴブリンを追放する</Text>
+            </TouchableOpacity>
+          </>
+        )}
       </ScrollView>
     </SafeAreaView>
   )


### PR DESCRIPTION
## Summary
- 待機中（pending）ゴブリンカードをタップすると詳細画面に遷移できるようにした
- 詳細画面では `source=pending` パラメータを判定し、装備変更・追放ボタンを非表示にして閲覧専用で表示
- 待機中ゴブリンのデータは `useBaseStore` の `pendingGoblins` から取得

## Test plan
- [ ] 待機中ゴブリンカードをタップして詳細画面に遷移できること
- [ ] 詳細画面でステータス・因子・スキル情報が正しく表示されること
- [ ] 装備変更・追放ボタンが非表示であること
- [ ] 通常ゴブリンの詳細画面は従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)