### PR TITLE
refactor: 各画面のパフォーマンス最適化（セレクタ個別化・memo・FlatList化）

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -1,39 +1,27 @@
-import { useCallback } from 'react'
+import { memo } from 'react'
 import { Tabs } from 'expo-router'
 import { View, Text, StyleSheet } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import ListIcon from '../../assets/list.svg'
 import HenseiIcon from '../../assets/hensei.svg'
 import BaseIcon from '../../assets/base.svg'
-import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
+import { CurrentTimeBadge } from '@/presentation/components/CurrentTimeBadge'
 
 interface TabIconProps {
   Icon: React.FC<{ width: number; height: number; fill?: string }>
   color: string
 }
 
-function TabIcon({ Icon, color }: TabIconProps) {
+const TabIcon = memo(function TabIcon({ Icon, color }: TabIconProps) {
   return (
     <View style={styles.iconContainer}>
       <Icon width={24} height={24} fill={color} />
     </View>
   )
-}
-
-function formatFullDateTimeWithSeconds(date: Date) {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
-  const seconds = String(date.getSeconds()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
-}
+})
 
 export default function TabLayout() {
   const insets = useSafeAreaInsets()
-  const currentTime = useCurrentTime({ enabled: true })
-  const currentTimeLabel = formatFullDateTimeWithSeconds(currentTime)
   const basePadding = 8
   const baseHeight = 60
   const safeAreaPadding = Math.max(basePadding, insets.bottom)
@@ -104,9 +92,7 @@ export default function TabLayout() {
         }}
       />
     </Tabs>
-    <View style={[styles.currentTimeBadge, { bottom: baseHeight + safeAreaPadding + 8 }]} pointerEvents="none">
-      <Text style={styles.currentTimeText}>{currentTimeLabel}</Text>
-    </View>
+    <CurrentTimeBadge bottom={baseHeight + safeAreaPadding + 8} />
     </View>
   )
 }
@@ -120,17 +106,5 @@ const styles = StyleSheet.create({
     height: 24,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  currentTimeBadge: {
-    position: 'absolute',
-    left: 12,
-    backgroundColor: 'rgba(17, 24, 39, 0.8)',
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-  },
-  currentTimeText: {
-    fontSize: 11,
-    color: '#F9FAFB',
   },
 })

--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -7,14 +7,16 @@ import { checkRankUpAvailable, BASE_RANK_CONFIGS } from '@/core/services/BaseRan
 import { areasData } from '@/shared/data'
 
 export default function BaseManagementScreen() {
-  const { isLoading: baseLoading, baseState, performRankUp } = useBaseStore()
+  const baseLoading = useBaseStore((state) => state.isLoading)
+  const baseState = useBaseStore((state) => state.baseState)
+  const performRankUp = useBaseStore((state) => state.performRankUp)
   const rank = useBaseStore(selectRank)
   const capacity = useBaseStore(selectCapacity)
   const maxParties = useBaseStore(selectMaxParties)
   const maxGoblins = useBaseStore(selectMaxGoblins)
   const ivBonus = useBaseStore(selectIvBonus)
   const gold = useBaseStore(selectGold)
-  const { goblins } = useGoblinStore()
+  const goblins = useGoblinStore((state) => state.goblins)
 
   const [isRankingUp, setIsRankingUp] = useState(false)
 

--- a/goblin_native/app/(tabs)/formation/edit.tsx
+++ b/goblin_native/app/(tabs)/formation/edit.tsx
@@ -60,8 +60,13 @@ function PartySlot({ goblin, isEmpty, isSelected, onPress, onRemove }: SlotProps
 
 export default function PartyEditScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
-  const { parties, isLoading: partiesLoading, updateMembers, getPartyById, refresh: refreshParties } = usePartyStore()
-  const { goblins, isLoading: goblinsLoading } = useGoblinStore()
+  const parties = usePartyStore((state) => state.parties)
+  const partiesLoading = usePartyStore((state) => state.isLoading)
+  const updateMembers = usePartyStore((state) => state.updateMembers)
+  const getPartyById = usePartyStore((state) => state.getPartyById)
+  const refreshParties = usePartyStore((state) => state.refresh)
+  const goblins = useGoblinStore((state) => state.goblins)
+  const goblinsLoading = useGoblinStore((state) => state.isLoading)
   const [retryCount, setRetryCount] = useState(0)
   const [party, setParty] = useState<Party | null>(null)
 

--- a/goblin_native/app/(tabs)/formation/equipment-list.tsx
+++ b/goblin_native/app/(tabs)/formation/equipment-list.tsx
@@ -20,8 +20,11 @@ function getDisplayName(eq: EquipmentInstance, template: EquipmentTemplate): str
 
 export default function PartyEquipmentListScreen() {
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
-  const { parties, isLoading: partiesLoading, getPartyById } = usePartyStore()
-  const { goblins, isLoading: goblinsLoading } = useGoblinStore()
+  const parties = usePartyStore((state) => state.parties)
+  const partiesLoading = usePartyStore((state) => state.isLoading)
+  const getPartyById = usePartyStore((state) => state.getPartyById)
+  const goblins = useGoblinStore((state) => state.goblins)
+  const goblinsLoading = useGoblinStore((state) => state.isLoading)
   const [party, setParty] = useState<Party | null>(null)
   const [equipmentMap, setEquipmentMap] = useState<Record<number, EquipmentInstance[]>>({})
   const [isLoadingEquipment, setIsLoadingEquipment] = useState(true)

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -1,11 +1,12 @@
-import { useMemo, useCallback } from 'react'
-import { View, Text, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator, Image, useWindowDimensions } from 'react-native'
+import { memo, useMemo, useCallback } from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator, Image, useWindowDimensions } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useExpeditionFlow, type ExpeditionHistoryDisplay } from '@/presentation/hooks/useExpeditionFlow'
+import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import type { Party, Goblin, ExpeditionRecord } from '@/shared/types'
@@ -19,7 +20,7 @@ interface MemberSlotProps {
   avatarSize: number
 }
 
-function MemberSlot({ goblin, isEmpty, slotSize, avatarSize }: MemberSlotProps) {
+const MemberSlot = memo(function MemberSlot({ goblin, isEmpty, slotSize, avatarSize }: MemberSlotProps) {
   if (isEmpty || !goblin) {
     return (
       <View style={[styles.memberSlot, { width: slotSize }]}>
@@ -39,7 +40,7 @@ function MemberSlot({ goblin, isEmpty, slotSize, avatarSize }: MemberSlotProps) 
       <Text style={styles.memberHp}>HP{stats.hp}</Text>
     </View>
   )
-}
+})
 
 interface PartyCardProps {
   party: Party
@@ -52,7 +53,7 @@ interface PartyCardProps {
   avatarSize: number
 }
 
-function PartyCard({
+const PartyCard = memo(function PartyCard({
   party,
   goblins,
   onPress,
@@ -123,19 +124,22 @@ function PartyCard({
       )}
     </View>
   )
-}
+})
 
 export default function FormationScreen() {
   const { width } = useWindowDimensions()
-  const { parties, isLoading: partiesLoading, createParty } = usePartyStore()
-  const { goblins, isLoading: goblinsLoading } = useGoblinStore()
-  const { isLoading: baseLoading } = useBaseStore()
+  const parties = usePartyStore((state) => state.parties)
+  const partiesLoading = usePartyStore((state) => state.isLoading)
+  const createParty = usePartyStore((state) => state.createParty)
+  const goblins = useGoblinStore((state) => state.goblins)
+  const goblinsLoading = useGoblinStore((state) => state.isLoading)
+  const baseLoading = useBaseStore((state) => state.isLoading)
   const rank = useBaseStore(selectRank)
+  const currentTime = useCurrentTime({ enabled: true })
   const {
-    completeDueExpeditions,
     partyHistories,
     partyHistoryDisplays,
-  } = useExpeditionFlow({ parties, enableAutoCompletion: true })
+  } = useExpeditionFlow({ parties, enableAutoCompletion: true, currentTime })
   const { slotSize, avatarSize } = useMemo(() => {
     const slotGap = 8
     const maxSlotWidth = 50
@@ -229,48 +233,49 @@ export default function FormationScreen() {
     )
   }
 
+  const renderPartyItem = useCallback(({ item, index }: { item: Party | null; index: number }) => {
+    if (item) {
+      return (
+        <PartyCard
+          party={item}
+          goblins={goblins}
+          onPress={() => handlePartyPress(item, index)}
+          historyDisplays={partyHistoryDisplays[item.id] ?? []}
+          onHistoryPress={handleHistoryPress}
+          onLogPress={handleLogPress}
+          slotSize={slotSize}
+          avatarSize={avatarSize}
+        />
+      )
+    }
+
+    return (
+      <TouchableOpacity
+        style={styles.partyCard}
+        onPress={() => handlePartyPress(null, index)}
+        activeOpacity={0.7}
+      >
+        <View style={styles.partyHeader}>
+          <Text style={styles.partyName}>PT{index + 1}</Text>
+        </View>
+        <View style={styles.membersRow}>
+          {Array.from({ length: MAX_PARTY_SLOTS }).map((_, slotIndex) => (
+            <MemberSlot key={slotIndex} isEmpty slotSize={slotSize} avatarSize={avatarSize} />
+          ))}
+        </View>
+      </TouchableOpacity>
+    )
+  }, [avatarSize, goblins, handleHistoryPress, handleLogPress, handlePartyPress, partyHistoryDisplays, slotSize])
+
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
-        <Text style={styles.prepTitle}>冒険の準備</Text>
-
-        {displayParties.map((party, index) => {
-          if (party) {
-            return (
-              <PartyCard
-                key={party.id}
-                party={party}
-                goblins={goblins}
-                onPress={() => handlePartyPress(party, index)}
-                historyDisplays={partyHistoryDisplays[party.id] ?? []}
-                onHistoryPress={handleHistoryPress}
-                onLogPress={handleLogPress}
-                slotSize={slotSize}
-                avatarSize={avatarSize}
-              />
-            )
-          } else {
-            // 空のパーティ枠
-            return (
-              <TouchableOpacity
-                key={`empty-${index}`}
-                style={styles.partyCard}
-                onPress={() => handlePartyPress(null, index)}
-                activeOpacity={0.7}
-              >
-                <View style={styles.partyHeader}>
-                  <Text style={styles.partyName}>PT{index + 1}</Text>
-                </View>
-                <View style={styles.membersRow}>
-                  {Array.from({ length: MAX_PARTY_SLOTS }).map((_, slotIndex) => (
-                    <MemberSlot key={slotIndex} isEmpty slotSize={slotSize} avatarSize={avatarSize} />
-                  ))}
-                </View>
-              </TouchableOpacity>
-            )
-          }
-        })}
-      </ScrollView>
+      <FlatList
+        data={displayParties}
+        keyExtractor={(item, index) => item?.id.toString() ?? `empty-${index}`}
+        renderItem={renderPartyItem}
+        contentContainerStyle={styles.contentContainer}
+        ListHeaderComponent={<Text style={styles.prepTitle}>冒険の準備</Text>}
+      />
     </SafeAreaView>
   )
 }
@@ -279,9 +284,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#F3F4F6',
-  },
-  scrollView: {
-    flex: 1,
   },
   contentContainer: {
     paddingHorizontal: 16,
@@ -304,12 +306,6 @@ const styles = StyleSheet.create({
     marginTop: 12,
     fontSize: 16,
     color: '#6B7280',
-  },
-  screenTitle: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#1F2937',
-    marginBottom: 16,
   },
   partyCard: {
     backgroundColor: '#FFFFFF',

--- a/goblin_native/app/(tabs)/formation/log.tsx
+++ b/goblin_native/app/(tabs)/formation/log.tsx
@@ -33,8 +33,8 @@ const getEventColor = (type: LogEntry['type']): string => {
 export default function ExpeditionLogScreen() {
   const { partyId, dungeonId } = useLocalSearchParams<{ partyId: string; dungeonId?: string }>()
 
-  const { getPartyById } = usePartyStore()
-  const { dungeons } = useDungeonStore()
+  const getPartyById = usePartyStore((state) => state.getPartyById)
+  const dungeons = useDungeonStore((state) => state.dungeons)
 
   const [party, setParty] = useState<Awaited<ReturnType<typeof getPartyById>> | null>(null)
 

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -25,9 +25,10 @@ export default function ExpeditionPlaybackScreen() {
     expeditionId?: string
   }>()
 
-  const { getPartyById, isLoading: isPartyLoading } = usePartyStore()
-  const { isLoading: isGoblinLoading } = useGoblinStore()
-  const { dungeons } = useDungeonStore()
+  const getPartyById = usePartyStore((state) => state.getPartyById)
+  const isPartyLoading = usePartyStore((state) => state.isLoading)
+  const isGoblinLoading = useGoblinStore((state) => state.isLoading)
+  const dungeons = useDungeonStore((state) => state.dungeons)
   const {
     expeditionRecords,
     getExpeditionById,

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -62,8 +62,10 @@ export default function ExpeditionPreparationScreen() {
     setTargetFloor,
     refresh: refreshParties,
   } = usePartyStore()
-  const { goblins, isLoading: goblinsLoading } = useGoblinStore()
-  const { dungeons, isLoading: dungeonsLoading } = useDungeonStore()
+  const goblins = useGoblinStore((state) => state.goblins)
+  const goblinsLoading = useGoblinStore((state) => state.isLoading)
+  const dungeons = useDungeonStore((state) => state.dungeons)
+  const dungeonsLoading = useDungeonStore((state) => state.isLoading)
   const { startExpedition, estimateExplorationTime } = useExpeditionFlow()
   const [retryCount, setRetryCount] = useState(0)
   const [party, setParty] = useState<Party | null>(null)

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -12,8 +12,10 @@ import type { ExpeditionRecord, Goblin, TimelineEvent } from '@/shared/types'
 export default function ExpeditionResultScreen() {
   const { expeditionId } = useLocalSearchParams<{ expeditionId?: string }>()
 
-  const { dungeons } = useDungeonStore()
-  const { progress, markDungeonCleared, markUnlockNotified } = useDungeonStore()
+  const dungeons = useDungeonStore((state) => state.dungeons)
+  const progress = useDungeonStore((state) => state.progress)
+  const markDungeonCleared = useDungeonStore((state) => state.markDungeonCleared)
+  const markUnlockNotified = useDungeonStore((state) => state.markUnlockNotified)
   const {
     expeditionRecords,
     getExpeditionById,

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef, useState } from 'react'
-import { View, Text, TouchableOpacity, Pressable, StyleSheet, ScrollView, ActivityIndicator, Image, Alert } from 'react-native'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { View, Text, TouchableOpacity, Pressable, StyleSheet, FlatList, ActivityIndicator, Image, Alert } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
@@ -29,8 +29,12 @@ function getStatLabel(stat: string): string {
 }
 
 export default function GoblinListScreen() {
-  const { goblins, isLoading, saveGoblin, deleteGoblin } = useGoblinStore()
-  const { pendingGoblins, removePendingGoblin } = useBaseStore()
+  const goblins = useGoblinStore((state) => state.goblins)
+  const isLoading = useGoblinStore((state) => state.isLoading)
+  const saveGoblin = useGoblinStore((state) => state.saveGoblin)
+  const deleteGoblin = useGoblinStore((state) => state.deleteGoblin)
+  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
+  const removePendingGoblin = useBaseStore((state) => state.removePendingGoblin)
   const maxGoblins = useBaseStore(selectMaxGoblins)
   const swipeableRefs = useRef<Record<number, Swipeable | null>>({})
   const [openSwipeableId, setOpenSwipeableId] = useState<number | null>(null)
@@ -38,12 +42,14 @@ export default function GoblinListScreen() {
   const hasCapacity = goblins.length < maxGoblins
   const [sortKey, setSortKey] = useState<'level' | 'atk' | 'hp'>('level')
 
-  const sortedGoblins = [...goblins].sort((a, b) => {
-    if (sortKey === 'level') return b.level - a.level
-    const statsA = getEffectiveStats(a)
-    const statsB = getEffectiveStats(b)
-    return sortKey === 'atk' ? statsB.atk - statsA.atk : statsB.hp - statsA.hp
-  })
+  const sortedGoblins = useMemo(() => (
+    [...goblins].sort((a, b) => {
+      if (sortKey === 'level') return b.level - a.level
+      const statsA = getEffectiveStats(a)
+      const statsB = getEffectiveStats(b)
+      return sortKey === 'atk' ? statsB.atk - statsA.atk : statsB.hp - statsA.hp
+    })
+  ), [goblins, sortKey])
 
   const closeOpenSwipeable = useCallback(() => {
     if (openSwipeableId === null) return
@@ -139,6 +145,101 @@ export default function GoblinListScreen() {
     )
   }, [closeOpenSwipeable, removePendingGoblin])
 
+  const renderGoblinItem = useCallback(({ item: goblin }: { item: Goblin }) => (
+    <View style={styles.cardWrapper}>
+      <Swipeable
+        ref={(ref) => {
+          swipeableRefs.current[goblin.id] = ref
+        }}
+        friction={2}
+        overshootRight={false}
+        rightThreshold={40}
+        renderRightActions={() => renderRightActions(goblin)}
+        onSwipeableWillOpen={() => handleSwipeableWillOpen(goblin.id)}
+        onSwipeableClose={() => handleSwipeableClose(goblin.id)}
+      >
+        <Pressable onPress={() => handleGoblinPress(goblin)}>
+          <GoblinCard goblin={goblin} />
+        </Pressable>
+      </Swipeable>
+    </View>
+  ), [handleGoblinPress, handleSwipeableClose, handleSwipeableWillOpen, renderRightActions])
+
+  const renderPendingFooter = useCallback(() => {
+    if (pendingGoblins.length === 0) {
+      return <View style={styles.footerSpacer} />
+    }
+
+    return (
+      <View style={styles.pendingSection}>
+        <View style={styles.pendingSectionHeader}>
+          <Text style={styles.pendingSectionTitle}>産まれたゴブリン</Text>
+          <View style={styles.pendingBadge}>
+            <Text style={styles.pendingBadgeText}>{pendingGoblins.length}体</Text>
+          </View>
+        </View>
+        <Text style={styles.pendingSectionDesc}>
+          拠点がいっぱいのため待機中です。
+        </Text>
+        {pendingGoblins.map((goblin) => {
+          const effectiveStats = ModStatCalculator.calculate(goblin)
+          return (
+            <View key={goblin.id} style={styles.pendingCard}>
+              <View style={styles.pendingRow}>
+                <TouchableOpacity
+                  style={styles.pendingPressable}
+                  activeOpacity={0.8}
+                  onPress={() => handlePendingGoblinPress(goblin)}
+                >
+                  <Image source={getGoblinImage(goblin.avatar)} style={styles.pendingAvatar} />
+                  <View style={styles.pendingInfo}>
+                    <Text style={styles.pendingName} numberOfLines={1}>{goblin.name}</Text>
+                    <Text style={styles.pendingStats}>
+                      HP{effectiveStats.hp} / A{effectiveStats.atk} / D{effectiveStats.def} / S{effectiveStats.spd} / SP{effectiveStats.sp}
+                    </Text>
+                    {goblin.mods && goblin.mods.length > 0 && (
+                      <View style={styles.modRow}>
+                        {goblin.mods.map((mod, index) => {
+                          const template = getModTemplate(mod.templateId)
+                          if (!template) return null
+                          const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
+                          const label = `${getStatLabel(template.stat)}+${mod.value}${isPercent ? '%' : ''}`
+                          const isPrefix = template.type === 'prefix'
+                          return (
+                            <View key={index} style={[styles.modBadge, isPrefix ? styles.modBadgeBlue : styles.modBadgePurple]}>
+                              <Text style={[styles.modBadgeText, isPrefix ? styles.modBadgeTextBlue : styles.modBadgeTextPurple]}>
+                                {label}
+                              </Text>
+                            </View>
+                          )
+                        })}
+                      </View>
+                    )}
+                  </View>
+                </TouchableOpacity>
+                {hasCapacity && (
+                  <TouchableOpacity
+                    style={styles.addButton}
+                    onPress={() => handleAddPending(goblin)}
+                  >
+                    <Text style={styles.addButtonText}>追加</Text>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity
+                  style={styles.dismissButton}
+                  onPress={() => handleDismissPending(goblin)}
+                >
+                  <Text style={styles.dismissButtonText}>解雇</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          )
+        })}
+        <View style={styles.footerSpacer} />
+      </View>
+    )
+  }, [handleAddPending, handleDismissPending, handlePendingGoblinPress, hasCapacity, pendingGoblins])
+
 
   if (isLoading) {
     return (
@@ -185,101 +286,15 @@ export default function GoblinListScreen() {
           ))}
         </View>
       </View>
-      <ScrollView
+      <FlatList
+        data={sortedGoblins}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={renderGoblinItem}
         contentContainerStyle={styles.scrollContent}
         onScrollBeginDrag={closeOpenSwipeable}
         keyboardShouldPersistTaps="handled"
-      >
-        <View style={styles.listContent}>
-          {sortedGoblins.map((goblin) => (
-            <View key={goblin.id} style={styles.cardWrapper}>
-              <Swipeable
-                ref={(ref) => {
-                  swipeableRefs.current[goblin.id] = ref
-                }}
-                friction={2}
-                overshootRight={false}
-                rightThreshold={40}
-                renderRightActions={() => renderRightActions(goblin)}
-                onSwipeableWillOpen={() => handleSwipeableWillOpen(goblin.id)}
-                onSwipeableClose={() => handleSwipeableClose(goblin.id)}
-              >
-                <Pressable onPress={() => handleGoblinPress(goblin)}>
-                  <GoblinCard goblin={goblin} />
-                </Pressable>
-              </Swipeable>
-            </View>
-          ))}
-        </View>
-
-        {pendingGoblins.length > 0 && (
-          <View style={styles.pendingSection}>
-            <View style={styles.pendingSectionHeader}>
-              <Text style={styles.pendingSectionTitle}>産まれたゴブリン</Text>
-              <View style={styles.pendingBadge}>
-                <Text style={styles.pendingBadgeText}>{pendingGoblins.length}体</Text>
-              </View>
-            </View>
-            <Text style={styles.pendingSectionDesc}>
-              拠点がいっぱいのため待機中です。
-            </Text>
-            {pendingGoblins.map((goblin) => {
-              const effectiveStats = ModStatCalculator.calculate(goblin)
-              return (
-                <View key={goblin.id} style={styles.pendingCard}>
-                  <View style={styles.pendingRow}>
-                    <TouchableOpacity
-                      style={styles.pendingPressable}
-                      activeOpacity={0.8}
-                      onPress={() => handlePendingGoblinPress(goblin)}
-                    >
-                      <Image source={getGoblinImage(goblin.avatar)} style={styles.pendingAvatar} />
-                      <View style={styles.pendingInfo}>
-                        <Text style={styles.pendingName} numberOfLines={1}>{goblin.name}</Text>
-                        <Text style={styles.pendingStats}>
-                          HP{effectiveStats.hp} / A{effectiveStats.atk} / D{effectiveStats.def} / S{effectiveStats.spd} / SP{effectiveStats.sp}
-                        </Text>
-                        {goblin.mods && goblin.mods.length > 0 && (
-                          <View style={styles.modRow}>
-                            {goblin.mods.map((mod, index) => {
-                              const template = getModTemplate(mod.templateId)
-                              if (!template) return null
-                              const isPercent = template.stat.includes('percent') || template.stat === 'damage_reduction'
-                              const label = `${getStatLabel(template.stat)}+${mod.value}${isPercent ? '%' : ''}`
-                              const isPrefix = template.type === 'prefix'
-                              return (
-                                <View key={index} style={[styles.modBadge, isPrefix ? styles.modBadgeBlue : styles.modBadgePurple]}>
-                                  <Text style={[styles.modBadgeText, isPrefix ? styles.modBadgeTextBlue : styles.modBadgeTextPurple]}>
-                                    {label}
-                                  </Text>
-                                </View>
-                              )
-                            })}
-                          </View>
-                        )}
-                      </View>
-                    </TouchableOpacity>
-                    {hasCapacity && (
-                      <TouchableOpacity
-                        style={styles.addButton}
-                        onPress={() => handleAddPending(goblin)}
-                      >
-                        <Text style={styles.addButtonText}>追加</Text>
-                      </TouchableOpacity>
-                    )}
-                    <TouchableOpacity
-                      style={styles.dismissButton}
-                      onPress={() => handleDismissPending(goblin)}
-                    >
-                      <Text style={styles.dismissButtonText}>解雇</Text>
-                    </TouchableOpacity>
-                  </View>
-                </View>
-              )
-            })}
-          </View>
-        )}
-      </ScrollView>
+        ListFooterComponent={renderPendingFooter}
+      />
     </SafeAreaView>
   )
 }
@@ -371,8 +386,6 @@ const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: 32,
   },
-  listContent: {
-  },
   cardWrapper: {
     backgroundColor: '#F9FAFB',
   },
@@ -390,6 +403,9 @@ const styles = StyleSheet.create({
   },
   pendingSection: {
     paddingTop: 8,
+  },
+  footerSpacer: {
+    height: 32,
   },
   pendingSectionHeader: {
     flexDirection: 'row',

--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -31,7 +31,8 @@ function getStatLabel(stat: string): string {
 
 export default function GoblinDetailScreen() {
   const { goblinId, source } = useLocalSearchParams<{ goblinId: string, source?: string }>()
-  const { getGoblinById, deleteGoblin } = useGoblinStore()
+  const getGoblinById = useGoblinStore((state) => state.getGoblinById)
+  const deleteGoblin = useGoblinStore((state) => state.deleteGoblin)
   const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
   const [goblin, setGoblin] = useState<Goblin | null>(null)
   const parentNav = useNavigation()

--- a/goblin_native/app/goblin/equipment.tsx
+++ b/goblin_native/app/goblin/equipment.tsx
@@ -181,7 +181,7 @@ function EquipmentRow({
 
 export default function EquipmentScreenPage() {
   const { goblinId } = useLocalSearchParams<{ goblinId: string }>()
-  const { getGoblinById } = useGoblinStore()
+  const getGoblinById = useGoblinStore((state) => state.getGoblinById)
   const { equippedItems, inventoryItems, refreshEquipment, equipItem, unequipItem } =
     useEquipmentService()
   const [goblin, setGoblin] = useState<Goblin | null>(null)

--- a/goblin_native/src/presentation/components/CurrentTimeBadge.tsx
+++ b/goblin_native/src/presentation/components/CurrentTimeBadge.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
+
+function formatFullDateTimeWithSeconds(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+  return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
+}
+
+interface CurrentTimeBadgeProps {
+  bottom: number
+}
+
+export const CurrentTimeBadge = memo(function CurrentTimeBadge({
+  bottom,
+}: CurrentTimeBadgeProps) {
+  const currentTime = useCurrentTime({ enabled: true })
+  const currentTimeLabel = formatFullDateTimeWithSeconds(currentTime)
+
+  return (
+    <View style={[styles.currentTimeBadge, { bottom }]} pointerEvents="none">
+      <Text style={styles.currentTimeText}>{currentTimeLabel}</Text>
+    </View>
+  )
+})
+
+const styles = StyleSheet.create({
+  currentTimeBadge: {
+    position: 'absolute',
+    left: 12,
+    backgroundColor: 'rgba(17, 24, 39, 0.8)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  currentTimeText: {
+    fontSize: 11,
+    color: '#F9FAFB',
+  },
+})

--- a/goblin_native/src/presentation/components/GoblinCard.tsx
+++ b/goblin_native/src/presentation/components/GoblinCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
@@ -29,7 +30,7 @@ interface GoblinCardProps {
   disabled?: boolean
 }
 
-export function GoblinCard({
+export const GoblinCard = memo(function GoblinCard({
   goblin,
   onPress,
   isAssigned = false,
@@ -113,7 +114,7 @@ export function GoblinCard({
   }
 
   return content
-}
+})
 
 const styles = StyleSheet.create({
   container: {

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -20,6 +20,7 @@ import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQL
 interface UseExpeditionFlowParams {
   parties?: Party[]
   enableAutoCompletion?: boolean
+  currentTime?: Date
 }
 
 interface StartExpeditionInput {
@@ -44,27 +45,28 @@ export interface ExpeditionHistoryDisplay {
 export const useExpeditionFlow = ({
   parties,
   enableAutoCompletion = false,
+  currentTime: externalCurrentTime,
 }: UseExpeditionFlowParams = {}) => {
   const [isProcessing, setIsProcessing] = useState(false)
-  const [currentTime, setCurrentTime] = useState(new Date())
   const processedExpeditionsRef = useRef<Set<string>>(new Set())
+  const currentTime = externalCurrentTime ?? new Date()
 
   const partyRepository = getPartyRepository()
   const goblinRepository = getGoblinRepository()
-  const { goblins } = useGoblinStore()
-  const { pendingGoblins, addPendingGoblin, isLoading: isPendingLoading, getNextGoblinId } = useBaseStore()
+  const goblins = useGoblinStore((state) => state.goblins)
+  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
+  const addPendingGoblin = useBaseStore((state) => state.addPendingGoblin)
+  const isPendingLoading = useBaseStore((state) => state.isLoading)
+  const getNextGoblinId = useBaseStore((state) => state.getNextGoblinId)
   const rank = useBaseStore(s => s.baseState?.rank ?? 1)
   const maxGoblins = useBaseStore(s => s.baseState?.currentMaxGoblins ?? 10)
   const isBaseLoading = useBaseStore(s => s.isLoading)
   const baseStateRepository = getBaseStateRepository()
-  const { markDungeonCleared } = useDungeonStore()
-  const {
-    expeditionRecords,
-    getPartyExpeditionHistory,
-    saveExpeditionRecord,
-    completeExpeditionRecord,
-    refresh: refreshExpeditions,
-  } = useExpeditionStore()
+  const markDungeonCleared = useDungeonStore((state) => state.markDungeonCleared)
+  const expeditionRecords = useExpeditionStore((state) => state.expeditionRecords)
+  const getPartyExpeditionHistory = useExpeditionStore((state) => state.getPartyExpeditionHistory)
+  const saveExpeditionRecord = useExpeditionStore((state) => state.saveExpeditionRecord)
+  const completeExpeditionRecord = useExpeditionStore((state) => state.completeExpeditionRecord)
 
   const startExpeditionUseCase = useMemo(() => {
     return new StartExpeditionUseCase(
@@ -263,7 +265,6 @@ export const useExpeditionFlow = ({
       }
     }
   }, [
-    currentTime,
     expeditionRecords,
     completeExpeditionUseCase,
     completeExpeditionRecord,
@@ -336,15 +337,11 @@ export const useExpeditionFlow = ({
 
   useEffect(() => {
     if (!enableAutoCompletion) return
+    void completeDueExpeditions()
     const interval = setInterval(() => {
-      setCurrentTime(new Date())
+      void completeDueExpeditions()
     }, 1000)
     return () => clearInterval(interval)
-  }, [enableAutoCompletion])
-
-  useEffect(() => {
-    if (!enableAutoCompletion) return
-    void completeDueExpeditions()
   }, [enableAutoCompletion, completeDueExpeditions])
 
   return {


### PR DESCRIPTION
## Summary
- Zustandストアのセレクタをオブジェクト分割代入から個別セレクタに変更し、不要な再レンダリングを防止
- 主要コンポーネント（TabIcon, MemberSlot, PartyCard, GoblinCard）に`memo`を適用
- ゴブリン一覧・パーティ一覧画面で`ScrollView`を`FlatList`に移行しリスト描画を最適化
- `CurrentTimeBadge`を独立コンポーネントとして抽出
- `useExpeditionFlow`のタイマー管理を外部から注入可能に変更
- ソート処理を`useMemo`でメモ化

## Test plan
- [ ] ゴブリン一覧画面の表示・スクロール・スワイプ操作が正常に動作すること
- [ ] パーティ一覧画面の表示・遠征履歴表示が正常に動作すること
- [ ] 拠点管理画面が正常に表示されること
- [ ] 遠征フロー（準備→再生→結果）が正常に動作すること
- [ ] 現在時刻バッジが正しく表示・更新されること
- [ ] ゴブリン詳細・装備変更画面が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)