### PR TITLE
docs(claude): add rn implementation notes

### DIFF
--- a/goblin_native/CLAUDE.md
+++ b/goblin_native/CLAUDE.md
@@ -112,3 +112,44 @@ app/
 - SVGファイルは `react-native-svg-transformer` 経由でコンポーネントとしてインポート可能 (metro.config.js)
 - Firebase設定は `.env.local` から環境変数 `EXPO_PUBLIC_FIREBASE_*` で読み込み
 - 遠征システムはシード値ベースのため、同じシードで同じ結果を再現可能
+
+## React Native 実装ガイド（react-native-best-practices）
+
+### 基本方針
+
+- パフォーマンス問題は必ず **計測 → 改善 → 再計測** の順で進める。体感だけで最適化しない
+- `presentation/` の改善でも、まず「再レンダー過多」「長いJS処理」「リスト描画」「入力遅延」のどれかを切り分ける
+- 新しい抽象化や共通化は、可読性だけでなく起動時間・再レンダー範囲・依存サイズへの影響も見る
+
+### UI / 再レンダー
+
+- `ScrollView` に大量の要素を直接 `map()` する実装は避け、件数が増える一覧は `FlatList` か `FlashList` を優先する
+- 固定高の行は `getItemLayout`、`FlashList` では `estimatedItemSize` を設定してレイアウト計算コストを下げる
+- 画面全体の state をむやみに持ち上げず、変更頻度の高い state はできるだけ局所化する
+- 重い計算やフィルタは render 中に毎回実行せず、`useMemo` や事前計算で render コストを抑える
+- 入力値や選択状態の変更で一覧全体が再描画されないよう、`renderItem`・`keyExtractor`・props の安定性を保つ
+
+### TextInput / フォーム
+
+- `TextInput` は必要以上に完全制御しない。単純入力は `value` より `defaultValue` ベースの非制御運用を検討する
+- 1文字ごとのバリデーションや整形が必要な場合だけ制御コンポーネントにする
+- 検索入力などで重い処理を即時実行しない。絞り込み・検索・集計は debounce や遅延実行を挟む
+
+### バンドル / 起動時間
+
+- バレル export (`index.ts` でまとめて export) の乱用は避け、内部実装では直接 import を優先する
+- 依存追加時は「便利か」だけでなく「bundle size / 起動時間 / ネイティブ依存の重さ」を確認する
+- Android の起動速度改善のための Hermes / `noCompress` などの設定は、Expo / React Native のバージョン差異を確認してから適用する
+
+### Native / Expo 境界
+
+- ネイティブモジュールや重いネイティブSDK導入は最後の手段にし、まず既存の Expo / React Native 標準機能で解決できるか確認する
+- ネイティブ側の重い同期処理は UI スレッドを詰まらせるため避ける。同期APIより非同期APIを優先する
+- Expo managed workflow で永続化したいネイティブ設定変更は、手作業の `prebuild` 差分放置ではなく、必要なら config plugin 化も検討する
+
+### このリポジトリで特に意識する点
+
+- `core/` のシミュレーションや計算処理は UI スレッド体感に直結するため、画面描画中に大きな同期処理を走らせない
+- 遠征ログ、戦闘ログ、ゴブリン一覧など件数が伸びる画面は、まず仮想化リスト前提で設計する
+- Context は便利だが更新範囲が広がりやすい。高頻度更新データを `presentation/contexts/` に集約しすぎない
+- 画像・SVG・マスターデータは「読み込みやすさ」だけでなく、初回描画コストとメモリ使用量も考慮して扱う


### PR DESCRIPTION
## 概要
- CLAUDE.md に React Native 実装ガイドを追記
- react-native-best-practices の観点で実装ポイントと注意点を整理
- 再レンダー、リスト、TextInput、bundle、Native/Expo 境界の指針を明文化

## テスト
- 未実施（ドキュメント更新のみ）