### PR TITLE
feat: 爪武器カテゴリの追加とエリアレベル表示・調整

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -21,6 +21,11 @@ const RETURN_POLICIES: { value: ReturnPolicy; label: string }[] = [
   { value: 'last_one', label: '最後の1人まで' },
 ]
 
+function formatDungeonLabel(dungeon: Dungeon): string {
+  if (dungeon.areaLevel === undefined) return dungeon.name
+  return `${dungeon.name} / エリアLv.${dungeon.areaLevel}`
+}
+
 interface MemberSlotProps {
   goblin?: Goblin
   isEmpty: boolean
@@ -297,7 +302,7 @@ export default function ExpeditionPreparationScreen() {
               >
                 {selectedDungeon ? (
                   <>
-                    <Text style={styles.settingValueText}>{selectedDungeon.name}</Text>
+                    <Text style={styles.settingValueText}>{formatDungeonLabel(selectedDungeon)}</Text>
                     <Text style={styles.settingValueDescription}>{selectedDungeon.description}</Text>
                   </>
                 ) : (
@@ -372,7 +377,7 @@ export default function ExpeditionPreparationScreen() {
                       styles.modalOptionTitle,
                       selectedDungeonId === dungeon.id && styles.modalOptionTitleSelected,
                     ]}>
-                      {dungeon.name}
+                      {formatDungeonLabel(dungeon)}
                     </Text>
                     <Text style={styles.modalOptionDescription}>{dungeon.description}</Text>
                   </TouchableOpacity>

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -302,6 +302,20 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
 
     expect(goblin.skills.some((skill) => skill.physicalDamageReductionPercent === 6)).toBe(false)
   })
+
+  it('EquipmentServiceは爪装備に応じた攻撃回数スキルを付与・解除する', () => {
+    const goblin = createTestGoblin({ skills: [] })
+    const equipment = { id: 'eq1', templateId: 'claw_kaiser', slotIndex: -1, goblinId: null }
+
+    const equipResult = EquipmentService.equip(goblin, equipment, 0, [])
+
+    expect(equipResult.success).toBe(true)
+    expect(goblin.skills.some((skill) => skill.statBonuses?.attackCount === 8)).toBe(true)
+
+    EquipmentService.unequip(equipment, goblin)
+
+    expect(goblin.skills.some((skill) => skill.statBonuses?.attackCount === 8)).toBe(false)
+  })
 })
 
 // =========================================================================

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -43,6 +43,11 @@ export interface ExpeditionHistoryDisplay {
   record: ExpeditionRecord
 }
 
+function formatDungeonLabel(dungeonName: string, areaLevel?: number): string {
+  if (areaLevel === undefined) return dungeonName
+  return `${dungeonName} / エリアLv.${areaLevel}`
+}
+
 export const useExpeditionFlow = ({
   parties,
   enableAutoCompletion = false,
@@ -301,6 +306,7 @@ export const useExpeditionFlow = ({
     const displays: Record<number, ExpeditionHistoryDisplay[]> = {}
     Object.entries(partyHistories).forEach(([partyId, history]) => {
       const items = history.map(record => {
+        const dungeon = areasData.find(area => area.id === record.dungeonId)
         const ongoing = isExpeditionOngoing(record, currentTime)
         const floorReached = record.replay?.summary.maxFloorReached ?? 0
         const remainingMinutes = ongoing && record.returnTime
@@ -312,7 +318,7 @@ export const useExpeditionFlow = ({
         return {
           id: record.id,
           title,
-          subtitle: record.dungeonName,
+          subtitle: formatDungeonLabel(record.dungeonName, dungeon?.areaLevel),
           ongoing,
           record,
         }

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -41,4 +41,14 @@ describe('characterSkills - 物理ダメージ軽減', () => {
 
     expect(describeCharacterSkill(skill)).toBe('[-10%] 物理ダメージ軽減(%)')
   })
+
+  it('攻撃回数スキルの説明文を表記ルールどおり返す', () => {
+    const skill: CharacterSkill = {
+      id: 'attack_count_11',
+      name: '[+11]攻撃回数',
+      statBonuses: { attackCount: 11 },
+    }
+
+    expect(describeCharacterSkill(skill)).toBe('攻撃回数 +11')
+  })
 })

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "templates": [
     {
       "_comment": "===== 武器:剣 (melee) ====="
@@ -335,6 +335,346 @@
       "dropLevelMin": 120,
       "dropLevelMax": 150,
       "description": "最硬の鉱石アダマンタイトで造られた剣。振るえる者は限られる"
+    },
+    {
+      "_comment": "===== 武器:爪 (melee) ====="
+    },
+    {
+      "id": "claw_sharp",
+      "name": "トゲ",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 1
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_sharp_attack_count_1",
+          "name": "[+1]攻撃回数",
+          "statBonuses": {
+            "attackCount": 1
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 16,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 5,
+      "unlockRank": 1,
+      "dropLevelMin": 4,
+      "dropLevelMax": 10,
+      "description": "トゲリスのトゲをそのまま握って使うだけの原始的な武器。まだ爪ですらない"
+    },
+    {
+      "id": "claw_beast",
+      "name": "ウルフの爪",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 3
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_beast_attack_count_2",
+          "name": "[+2]攻撃回数",
+          "statBonuses": {
+            "attackCount": 2
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 24,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 15,
+      "unlockRank": 1,
+      "dropLevelMin": 4,
+      "dropLevelMax": 10,
+      "description": "ウルフから剥ぎ取った爪をそのまま使う。荒削りだが獣らしい手数が出る"
+    },
+    {
+      "id": "claw_copper",
+      "name": "どうのツメ",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 5
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_copper_attack_count_3",
+          "name": "[+3]攻撃回数",
+          "statBonuses": {
+            "attackCount": 3
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 32,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 30,
+      "unlockRank": 1,
+      "dropLevelMin": 8,
+      "dropLevelMax": 15,
+      "description": "銅板を曲げて爪状にした簡易武器。素早い連撃向き"
+    },
+    {
+      "id": "claw_iron",
+      "name": "てつのツメ",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 7
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_iron_attack_count_4",
+          "name": "[+4]攻撃回数",
+          "statBonuses": {
+            "attackCount": 4
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 40,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 60,
+      "unlockRank": 1,
+      "dropLevelMin": 8,
+      "dropLevelMax": 15,
+      "description": "鉄で補強した爪。斬り刻むような攻撃に向く"
+    },
+    {
+      "id": "claw_steel",
+      "name": "はがねのツメ",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 10
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_steel_attack_count_5",
+          "name": "[+5]攻撃回数",
+          "statBonuses": {
+            "attackCount": 5
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 56,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 100,
+      "unlockRank": 1,
+      "dropLevelMin": 12,
+      "dropLevelMax": 25,
+      "description": "鋼の刃先を備えた爪。軽快さを保ったまま切れ味を増す"
+    },
+    {
+      "id": "claw_mithril",
+      "name": "ミスリルクロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 14
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_mithril_attack_count_6",
+          "name": "[+6]攻撃回数",
+          "statBonuses": {
+            "attackCount": 6
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 80,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 500,
+      "dropLevelMin": 20,
+      "dropLevelMax": 40,
+      "description": "ミスリルで鍛えた軽量の爪。鋭さと扱いやすさを両立する"
+    },
+    {
+      "id": "claw_royal",
+      "name": "ロイヤルクロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 18
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_royal_attack_count_7",
+          "name": "[+7]攻撃回数",
+          "statBonuses": {
+            "attackCount": 7
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 104,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 2500,
+      "dropLevelMin": 35,
+      "dropLevelMax": 60,
+      "description": "王侯の近衛が使う高級爪。狙った急所を外さない"
+    },
+    {
+      "id": "claw_kaiser",
+      "name": "カイザークロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 26
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_kaiser_attack_count_8",
+          "name": "[+8]攻撃回数",
+          "statBonuses": {
+            "attackCount": 8
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 152,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 12500,
+      "unlockRank": 3,
+      "dropLevelMin": 50,
+      "dropLevelMax": 80,
+      "description": "皇帝の闘技兵が使う爪。苛烈な連撃を叩き込む"
+    },
+    {
+      "id": "claw_ancient",
+      "name": "エンシェントクロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 34
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_ancient_attack_count_9",
+          "name": "[+9]攻撃回数",
+          "statBonuses": {
+            "attackCount": 9
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 208,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 60000,
+      "unlockRank": 5,
+      "dropLevelMin": 70,
+      "dropLevelMax": 105,
+      "description": "古代の加工技術で生まれた爪。吸い付くような精度を持つ"
+    },
+    {
+      "id": "claw_dragon",
+      "name": "ドラゴンクロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 48
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_dragon_attack_count_10",
+          "name": "[+10]攻撃回数",
+          "statBonuses": {
+            "attackCount": 10
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 304,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 240000,
+      "dropLevelMin": 95,
+      "dropLevelMax": 135,
+      "description": "竜の鉤爪を加工した凶器。嵐のような手数で切り裂く"
+    },
+    {
+      "id": "claw_adamant",
+      "name": "アダマントクロー",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 64
+        }
+      ],
+      "grantedSkills": [
+        {
+          "id": "claw_adamant_attack_count_11",
+          "name": "[+11]攻撃回数",
+          "statBonuses": {
+            "attackCount": 11
+          }
+        }
+      ],
+      "weaponStats": {
+        "accuracy": 400,
+        "attackCountModifier": 0
+      },
+      "range": "melee",
+      "price": 720000,
+      "dropLevelMin": 120,
+      "dropLevelMax": 150,
+      "description": "アダマンタイトで造られた究極の爪。連撃のすべてが致命傷になる"
     },
     {
       "_comment": "===== 武器:弓 (ranged) ====="

--- a/goblin_native/src/shared/data/expeditionArea/allArea.json
+++ b/goblin_native/src/shared/data/expeditionArea/allArea.json
@@ -14,7 +14,7 @@
     {
       "id": "forest_outskirts",
       "name": "周辺の森",
-      "areaLevel": 1,
+      "areaLevel": 4,
       "floors": 3,
       "exploration_time_sec_first": 60,
       "exploration_time_sec": 30,
@@ -25,7 +25,7 @@
     {
       "id": "goblin_village_1",
       "name": "ゴブリン集落・外縁",
-      "areaLevel": 2,
+      "areaLevel": 6,
       "floors": 2,
       "exploration_time_sec_first": 60,
       "exploration_time_sec": 30,
@@ -36,7 +36,7 @@
     {
       "id": "goblin_village_2",
       "name": "ゴブリン集落・内部",
-      "areaLevel": 2,
+      "areaLevel": 7,
       "floors": 2,
       "exploration_time_sec_first": 60,
       "exploration_time_sec": 35,
@@ -47,7 +47,7 @@
     {
       "id": "goblin_village_3",
       "name": "ゴブリン集落・中枢",
-      "areaLevel": 2,
+      "areaLevel": 8,
       "floors": 2,
       "exploration_time_sec_first": 1,
       "exploration_time_sec": 40,

--- a/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
+++ b/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
@@ -1,7 +1,7 @@
 {
   "id": "forest_outskirts",
   "name": "周辺の森",
-  "areaLevel": 2,
+  "areaLevel": 4,
   "floors": 3,
   "baseDurationSec": 60,
   "description": "明るい森、弱い獣や小鬼が出現",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
@@ -1,7 +1,7 @@
 {
   "id": "goblin_village_1",
   "name": "ゴブリン集落・外縁",
-  "areaLevel": 2,
+  "areaLevel": 6,
   "floors": 2,
   "baseDurationSec": 30,
   "description": "ゴブリン集落の外縁部。雑兵ゴブリンやシーフが群れをなして徘徊している。",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
@@ -1,7 +1,7 @@
 {
   "id": "goblin_village_2",
   "name": "ゴブリン集落・内部",
-  "areaLevel": 2,
+  "areaLevel": 7,
   "floors": 2,
   "baseDurationSec": 35,
   "description": "集落の内部へ侵入。ウォリアーやメイジが組織的に守りを固めている。",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
@@ -1,7 +1,7 @@
 {
   "id": "goblin_village_3",
   "name": "ゴブリン集落・中枢",
-  "areaLevel": 2,
+  "areaLevel": 8,
   "floors": 2,
   "baseDurationSec": 40,
   "description": "集落の中枢。ガードに守られた奥にホブゴブリンが君臨する。独立を勝ち取るため、反逆の狼煙を上げる。",

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -9,7 +9,7 @@ export type EquipmentCategory = 'weapon' | 'armor' | 'accessory'
 /**
  * 武器のサブカテゴリ
  */
-export type WeaponSubCategory = 'sword' | 'axe' | 'spear' | 'bow' | 'staff'
+export type WeaponSubCategory = 'sword' | 'axe' | 'spear' | 'bow' | 'staff' | 'claw'
 
 /**
  * 武器の射程


### PR DESCRIPTION
## Summary
- 爪(claw)武器11種（トゲ〜アダマントクロー）を追加。装備ごとに攻撃回数スキルを付与
- WeaponSubCategoryに`claw`を追加
- 各エリアのareaLevelを適切な値に調整（森:1→4, 外縁:2→6, 内部:2→7, 中枢:2→8）
- ダンジョン選択画面と遠征履歴にエリアLv表示を追加
- 爪装備の装着/解除と攻撃回数スキルのテストを追加

## Test plan
- [ ] 爪装備がショップ・ドロップで正しく出現すること
- [ ] 爪装備の装着で攻撃回数スキルが付与され、解除で消えること
- [ ] ダンジョン選択画面でエリアLvが表示されること
- [ ] 遠征履歴でエリアLvが表示されること
- [ ] 既存テスト・新規テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)