### PR TITLE
refactor: 装備枠計算をレベル閾値テーブルに統一

### DIFF
--- a/goblin_native/src/core/services/EquipmentService.ts
+++ b/goblin_native/src/core/services/EquipmentService.ts
@@ -13,7 +13,7 @@ export class EquipmentService {
    * ゴブリンが利用可能なスロット数を取得
    */
   static getAvailableSlots(goblin: Goblin): number {
-    return calculateSlotCount(goblin.race, goblin.level)
+    return calculateSlotCount(goblin.level)
   }
 
   /**

--- a/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
+++ b/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
@@ -1,0 +1,22 @@
+import { EQUIPMENT_SLOT_LEVELS, calculateSlotCount } from '../equipmentConfig'
+
+describe('equipmentConfig', () => {
+  it('装備枠の解放レベル表を正しく持つ', () => {
+    expect(EQUIPMENT_SLOT_LEVELS).toEqual([
+      1, 3, 6, 9, 12, 16, 20, 25, 30, 36, 42, 49,
+      58, 67, 77, 89, 102, 118, 134, 150, 166, 183, 200,
+    ])
+  })
+
+  it('レベル閾値どおりに装備枠数を返す', () => {
+    expect(calculateSlotCount(1)).toBe(1)
+    expect(calculateSlotCount(2)).toBe(1)
+    expect(calculateSlotCount(3)).toBe(2)
+    expect(calculateSlotCount(5)).toBe(2)
+    expect(calculateSlotCount(6)).toBe(3)
+    expect(calculateSlotCount(9)).toBe(4)
+    expect(calculateSlotCount(16)).toBe(6)
+    expect(calculateSlotCount(200)).toBe(23)
+    expect(calculateSlotCount(250)).toBe(23)
+  })
+})

--- a/goblin_native/src/shared/data/equipmentConfig.ts
+++ b/goblin_native/src/shared/data/equipmentConfig.ts
@@ -1,13 +1,11 @@
-import type { RaceSlotConfig } from '../types/Equipment'
-
 /**
- * 種族ごとの装備スロット設定
- * スロット数 = baseSlots + floor((level - 1) / slotsPerLevel)、maxSlots上限
+ * 装備枠の解放レベル表
+ * index 0 が1枠目、index 1 が2枠目を表す
  */
-export const RACE_SLOT_CONFIGS: Record<string, RaceSlotConfig> = {
-  'ゴブリン': { baseSlots: 2, slotsPerLevel: 5, maxSlots: 6 },
-  '魔獣': { baseSlots: 1, slotsPerLevel: 7, maxSlots: 4 },
-}
+export const EQUIPMENT_SLOT_LEVELS = [
+  1, 3, 6, 9, 12, 16, 20, 25, 30, 36, 42, 49,
+  58, 67, 77, 89, 102, 118, 134, 150, 166, 183, 200,
+] as const
 
 /**
  * 血統別の戦闘ステータス初期値
@@ -38,17 +36,16 @@ export function getBloodlineCombatStats(bloodline: string): BloodlineCombatStats
   return BLOODLINE_COMBAT_STATS[bloodline] ?? DEFAULT_COMBAT_STATS
 }
 
-const DEFAULT_SLOT_CONFIG: RaceSlotConfig = {
-  baseSlots: 2,
-  slotsPerLevel: 5,
-  maxSlots: 6,
-}
-
 /**
- * ゴブリンのレベルと種族からスロット数を計算
+ * ゴブリンのレベルからスロット数を計算
  */
-export function calculateSlotCount(race: string, level: number): number {
-  const config = RACE_SLOT_CONFIGS[race] ?? DEFAULT_SLOT_CONFIG
-  const bonusSlots = Math.floor((level - 1) / config.slotsPerLevel)
-  return Math.min(config.baseSlots + bonusSlots, config.maxSlots)
+export function calculateSlotCount(level: number): number {
+  let unlockedSlots = 0
+
+  for (const unlockLevel of EQUIPMENT_SLOT_LEVELS) {
+    if (level < unlockLevel) break
+    unlockedSlots++
+  }
+
+  return Math.max(1, unlockedSlots)
 }

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -102,12 +102,3 @@ export interface EquipmentInstance {
   titleId?: EquipmentTitleId   // 称号ID（未設定 = 称号なし）
   titleName?: string           // 称号の表示名（例: "伝説の"）
 }
-
-/**
- * 種族ごとのスロット設定
- */
-export interface RaceSlotConfig {
-  baseSlots: number      // Lv1時のスロット数
-  slotsPerLevel: number  // 何レベルごとに+1スロット
-  maxSlots: number       // 上限
-}

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -43,7 +43,6 @@ export type {
   WeaponStats,
   EquipmentTemplate,
   EquipmentInstance,
-  RaceSlotConfig,
 } from "./Equipment"
 
 // Spell related types


### PR DESCRIPTION
## 概要
- 装備枠計算を種族別設定からレベル閾値テーブルベースに変更
- `魔獣` と `RaceSlotConfig` の依存を削除
- 装備枠テーブルのユニットテストを追加

## テスト
- `npx tsc --noEmit`
- `npm test -- --runInBand src/shared/data/__tests__/equipmentConfig.test.ts`

## 補足
- 装備可能数は 1〜23 枠、解放レベルは `1, 3, 6, 9, 12, 16, 20, 25, 30, 36, 42, 49, 58, 67, 77, 89, 102, 118, 134, 150, 166, 183, 200` を使用しています。