### PR TITLE
[codex] 装備枠数のNaN表示を修正

### DIFF
--- a/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
+++ b/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
@@ -19,4 +19,8 @@ describe('equipmentConfig', () => {
     expect(calculateSlotCount(200)).toBe(23)
     expect(calculateSlotCount(250)).toBe(23)
   })
+
+  it('不正なレベル値でもNaNを返さない', () => {
+    expect(calculateSlotCount(Number.NaN)).toBe(1)
+  })
 })

--- a/goblin_native/src/shared/data/equipmentConfig.ts
+++ b/goblin_native/src/shared/data/equipmentConfig.ts
@@ -36,14 +36,24 @@ export function getBloodlineCombatStats(bloodline: string): BloodlineCombatStats
   return BLOODLINE_COMBAT_STATS[bloodline] ?? DEFAULT_COMBAT_STATS
 }
 
+function normalizeEquipmentLevel(level: unknown): number {
+  if (typeof level !== 'number' || !Number.isFinite(level)) {
+    return 1
+  }
+
+  return Math.max(1, Math.floor(level))
+}
+
 /**
  * ゴブリンのレベルからスロット数を計算
  */
+export function calculateSlotCount(level: number): number
 export function calculateSlotCount(level: number): number {
+  const normalizedLevel = normalizeEquipmentLevel(level)
   let unlockedSlots = 0
 
   for (const unlockLevel of EQUIPMENT_SLOT_LEVELS) {
-    if (level < unlockLevel) break
+    if (normalizedLevel < unlockLevel) break
     unlockedSlots++
   }
 


### PR DESCRIPTION
## 概要
- 装備枠数の計算で不正なレベル値が入っても `NaN` を返さないよう修正
- 装備枠計算のテストを追加し、`NaN` が表示に伝播しないことを確認

## 原因
- 装備枠数計算が `goblin.level` をそのまま数値比較に使っており、不正値が入ると計算結果が壊れていました

## 影響
- 装備アイテム一覧画面
- 装備変更画面

## 確認
- `npm test -- --runInBand src/shared/data/__tests__/equipmentConfig.test.ts`
