### PR TITLE
fix: improve equipment screen behavior

### DIFF
--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -11,7 +11,7 @@ import { getFactorImage } from '@/shared/utils/factorImages'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 import { getExpForNextLevel, getExpProgress } from '@/core/services/ExperienceSystem'
 import { getModTemplate } from '@/shared/data/modPoolLoader'
-import { describeCharacterSkill } from '@/shared/data/characterSkills'
+import { describeCharacterSkill, getUniqueSkillsById } from '@/shared/data/characterSkills'
 
 const STAT_LABELS: Record<string, string> = {
   hp_percent: 'HP', hp_flat: 'HP',
@@ -64,7 +64,7 @@ export default function GoblinDetailScreen() {
   )
   const expForNext = goblin ? getExpForNextLevel(goblin.level) : 0
   const expProgress = goblin ? getExpProgress(goblin.level, goblin.experience) : 0
-  const characterSkills = useMemo(() => goblin?.skills ?? [], [goblin])
+  const characterSkills = useMemo(() => getUniqueSkillsById(goblin?.skills ?? []), [goblin])
 
   const handleBanish = useCallback(() => {
     if (!goblin) return

--- a/goblin_native/app/goblin/equipment.tsx
+++ b/goblin_native/app/goblin/equipment.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Modal, Alert } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal, Alert } from 'react-native'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams } from 'expo-router'
 import type { EquipmentInstance, EquipmentTemplate, EquipmentCategory } from '@/shared/types'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
@@ -42,6 +42,13 @@ function getDisplayName(eq: EquipmentInstance, template: EquipmentTemplate): str
   return template.name
 }
 
+type InventoryGroup = {
+  key: string
+  equipment: EquipmentInstance
+  template: EquipmentTemplate
+  count: number
+}
+
 function formatBonus(stat: string, value: number): string {
   const isPercent = stat.includes('percent') || stat === 'damage_reduction'
   return `${value > 0 ? '+' : ''}${value}${isPercent ? '%' : ''}`
@@ -65,6 +72,31 @@ function sortEquipment(items: EquipmentInstance[]): EquipmentInstance[] {
     const titleB = titleOrder.get(b.titleId ?? 'none') ?? 0
     return titleA - titleB
   })
+}
+
+function groupInventory(items: EquipmentInstance[]): InventoryGroup[] {
+  const grouped = new Map<string, InventoryGroup>()
+
+  for (const eq of sortEquipment(items)) {
+    const template = getEquipmentTemplate(eq.templateId)
+    if (!template) continue
+
+    const key = `${eq.templateId}::${eq.titleId ?? 'none'}`
+    const existing = grouped.get(key)
+    if (existing) {
+      existing.count += 1
+      continue
+    }
+
+    grouped.set(key, {
+      key,
+      equipment: eq,
+      template,
+      count: 1,
+    })
+  }
+
+  return Array.from(grouped.values())
 }
 
 /** 装備済みアイテムの詳細モーダル */
@@ -143,11 +175,13 @@ function EquipmentRow({
   template,
   onPress,
   highlighted,
+  count,
 }: {
   eq: EquipmentInstance
   template: EquipmentTemplate
   onPress: () => void
   highlighted?: boolean
+  count?: number
 }) {
   return (
     <TouchableOpacity
@@ -156,7 +190,7 @@ function EquipmentRow({
     >
       <View style={styles.itemInfo}>
         <Text style={styles.itemName} numberOfLines={1}>
-          {getDisplayName(eq, template)}
+          {count && count > 1 ? `x${count} ${getDisplayName(eq, template)}` : getDisplayName(eq, template)}
         </Text>
         <View style={styles.itemBonusRow}>
           {template.statBonuses.map((bonus, i) => (
@@ -181,6 +215,7 @@ function EquipmentRow({
 
 export default function EquipmentScreenPage() {
   const { goblinId } = useLocalSearchParams<{ goblinId: string }>()
+  const insets = useSafeAreaInsets()
   const getGoblinById = useGoblinStore((state) => state.getGoblinById)
   const { equippedItems, inventoryItems, refreshEquipment, equipItem, unequipItem } =
     useEquipmentService()
@@ -206,7 +241,7 @@ export default function EquipmentScreenPage() {
   }, [goblin, refreshEquipment])
 
   const sortedEquipped = useMemo(() => sortEquipment(equippedItems), [equippedItems])
-  const sortedInventory = useMemo(() => sortEquipment(inventoryItems), [inventoryItems])
+  const groupedInventory = useMemo(() => groupInventory(inventoryItems), [inventoryItems])
   const emptySlots = maxSlots - equippedItems.length
 
   const handleEquip = useCallback(
@@ -227,6 +262,7 @@ export default function EquipmentScreenPage() {
       const result = await equipItem(goblin, equipment, targetSlot)
       if (!result.success) {
         Alert.alert('装備エラー', result.error ?? '装備できませんでした')
+        return
       }
     },
     [equippedItems, maxSlots, goblin, equipItem],
@@ -246,57 +282,60 @@ export default function EquipmentScreenPage() {
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
-      <ScrollView
+      <FlatList
         style={styles.content}
-        contentContainerStyle={styles.contentContainer}
+        contentContainerStyle={[styles.contentContainer, { paddingBottom: 32 + insets.bottom + 16 }]}
         showsVerticalScrollIndicator={true}
-      >
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>装備枠 ({equippedItems.length}/{maxSlots})</Text>
-          <View style={styles.slotList}>
-            {sortedEquipped.map(eq => {
-              const template = getEquipmentTemplate(eq.templateId)
-              if (!template) return null
-              return (
-                <EquipmentRow
-                  key={eq.id}
-                  eq={eq}
-                  template={template}
-                  onPress={() => setSelectedEquipped(eq)}
-                />
-              )
-            })}
-            {Array.from({ length: emptySlots }).map((_, i) => (
-              <View key={`empty-${i}`} style={styles.emptySlot}>
-                <Text style={styles.emptySlotText}>空きスロット</Text>
+        data={groupedInventory}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item }) => (
+          <EquipmentRow
+            eq={item.equipment}
+            template={item.template}
+            onPress={() => handleEquip(item.equipment)}
+            highlighted={emptySlots > 0}
+            count={item.count}
+          />
+        )}
+        ListHeaderComponent={(
+          <>
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>装備枠 ({equippedItems.length}/{maxSlots})</Text>
+              <View style={styles.slotList}>
+                {sortedEquipped.map(eq => {
+                  const template = getEquipmentTemplate(eq.templateId)
+                  if (!template) return null
+                  return (
+                    <EquipmentRow
+                      key={eq.id}
+                      eq={eq}
+                      template={template}
+                      onPress={() => setSelectedEquipped(eq)}
+                    />
+                  )
+                })}
+                {Array.from({ length: emptySlots }).map((_, i) => (
+                  <View key={`empty-${i}`} style={styles.emptySlot}>
+                    <Text style={styles.emptySlotText}>空きスロット</Text>
+                  </View>
+                ))}
               </View>
-            ))}
-          </View>
-        </View>
+            </View>
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>所持アイテム</Text>
-          {sortedInventory.length === 0 ? (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>所持アイテム</Text>
+            </View>
+          </>
+        )}
+        ListEmptyComponent={(
+          <View style={[styles.section, styles.inventoryEmptySection]}>
             <View style={styles.emptyInventory}>
               <Text style={styles.emptyInventoryText}>所持アイテムがありません</Text>
             </View>
-          ) : (
-            sortedInventory.map(eq => {
-              const template = getEquipmentTemplate(eq.templateId)
-              if (!template) return null
-              return (
-                <EquipmentRow
-                  key={eq.id}
-                  eq={eq}
-                  template={template}
-                  onPress={() => handleEquip(eq)}
-                  highlighted={emptySlots > 0}
-                />
-              )
-            })
-          )}
-        </View>
-      </ScrollView>
+          </View>
+        )}
+        ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+      />
 
       {selectedEquipped && selectedEquippedTemplate && (
         <EquippedItemDetail
@@ -349,7 +388,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#E5E7EB',
     backgroundColor: '#F9FAFB',
-    marginBottom: 8,
+  },
+  itemSeparator: {
+    height: 8,
+  },
+  inventoryEmptySection: {
+    marginTop: -16,
   },
   itemRowHighlighted: {
     borderColor: '#93C5FD',

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -1,7 +1,11 @@
 import type { CharacterSkill } from '../../types'
 import {
   describeCharacterSkill,
+  getAdditionalDamageFromSkills,
   getPhysicalDamageReductionFromSkills,
+  getRearProtectionMultiplierFromSkills,
+  getSkillStatBonuses,
+  getUniqueSkillsById,
 } from '../characterSkills'
 
 describe('characterSkills - 物理ダメージ軽減', () => {
@@ -32,6 +36,43 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     expect(getPhysicalDamageReductionFromSkills(skills)).toBe(1)
   })
 
+  it('同じidの攻撃回数スキルは重複計算しない', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'claw_shared', name: '[+1]攻撃回数', statBonuses: { attackCount: 1 } },
+      { id: 'claw_shared', name: '[+1]攻撃回数', statBonuses: { attackCount: 1 } },
+    ]
+
+    expect(getSkillStatBonuses(skills).attackCount).toBe(1)
+  })
+
+  it('同じidの追加ダメージスキルは重複計算しない', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'damage_shared', name: '[+13]追加ダメージ', additionalDamage: 13 },
+      { id: 'damage_shared', name: '[+13]追加ダメージ', additionalDamage: 13 },
+    ]
+
+    expect(getAdditionalDamageFromSkills(skills)).toBe(13)
+  })
+
+  it('同じidの後列保護スキルは重複計算しない', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'rear_shared', name: '後列保護', protectRearAllyNormalAttackMultiplier: 0.8 },
+      { id: 'rear_shared', name: '後列保護', protectRearAllyNormalAttackMultiplier: 0.8 },
+    ]
+
+    expect(getRearProtectionMultiplierFromSkills(skills)).toBe(0.8)
+  })
+
+  it('スキル一覧取得時も同じidは1件にまとまる', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'shared', name: 'A' },
+      { id: 'shared', name: 'A' },
+      { id: 'other', name: 'B' },
+    ]
+
+    expect(getUniqueSkillsById(skills)).toHaveLength(2)
+  })
+
   it('物理ダメージ軽減スキルの説明文を表記ルールどおり返す', () => {
     const skill: CharacterSkill = {
       id: 'physical_10',
@@ -49,6 +90,6 @@ describe('characterSkills - 物理ダメージ軽減', () => {
       statBonuses: { attackCount: 11 },
     }
 
-    expect(describeCharacterSkill(skill)).toBe('攻撃回数 +11')
+    expect(describeCharacterSkill(skill)).toBe('[+11]攻撃回数')
   })
 })

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -24,6 +24,18 @@ export function cloneCharacterSkills(skills: CharacterSkill[]): CharacterSkill[]
   return skills.map(cloneCharacterSkill)
 }
 
+export function getUniqueSkillsById(skills: CharacterSkill[]): CharacterSkill[] {
+  const seen = new Set<string>()
+
+  return skills.filter((skill) => {
+    if (seen.has(skill.id)) {
+      return false
+    }
+    seen.add(skill.id)
+    return true
+  })
+}
+
 export function describeCharacterSkill(skill: CharacterSkill): string {
   if (skill.physicalDamageReductionPercent !== undefined) {
     return `[-${skill.physicalDamageReductionPercent}%] 物理ダメージ軽減(%)`
@@ -47,7 +59,7 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
   }
 
   if (skill.statBonuses?.attackCount !== undefined) {
-    return `攻撃回数 +${skill.statBonuses.attackCount}`
+    return `[+${skill.statBonuses.attackCount}]攻撃回数`
   }
 
   return skill.name
@@ -56,7 +68,7 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
 export function getSkillStatBonuses(skills: CharacterSkill[]): Partial<Record<keyof GoblinStats, number>> {
   const bonuses: Partial<Record<keyof GoblinStats, number>> = {}
 
-  for (const skill of skills) {
+  for (const skill of getUniqueSkillsById(skills)) {
     for (const [key, value] of Object.entries(skill.statBonuses ?? {})) {
       const statKey = key as keyof GoblinStats
       bonuses[statKey] = (bonuses[statKey] ?? 0) + (value ?? 0)
@@ -67,27 +79,21 @@ export function getSkillStatBonuses(skills: CharacterSkill[]): Partial<Record<ke
 }
 
 export function getAdditionalDamageFromSkills(skills: CharacterSkill[]): number {
-  return skills.reduce((sum, skill) => sum + (skill.additionalDamage ?? 0), 0)
+  return getUniqueSkillsById(skills).reduce((sum, skill) => sum + (skill.additionalDamage ?? 0), 0)
 }
 
 export function getRearProtectionMultiplierFromSkills(skills: CharacterSkill[]): number {
-  return skills.reduce(
+  return getUniqueSkillsById(skills).reduce(
     (product, skill) => product * (skill.protectRearAllyNormalAttackMultiplier ?? 1),
     1,
   )
 }
 
 export function getPhysicalDamageReductionFromSkills(skills: CharacterSkill[]): number {
-  const appliedSkillIds = new Set<string>()
-
-  return skills.reduce((sum, skill) => {
-    if (appliedSkillIds.has(skill.id)) {
-      return sum
-    }
-
-    appliedSkillIds.add(skill.id)
-    return sum + (skill.physicalDamageReductionPercent ?? 0)
-  }, 0)
+  return getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.physicalDamageReductionPercent ?? 0),
+    0,
+  )
 }
 
 function getEquipmentValueMultiplier(
@@ -95,7 +101,7 @@ function getEquipmentValueMultiplier(
   category: EquipmentCategory | undefined,
   stat: EquipmentStat | undefined,
 ): number {
-  return skills.reduce((product, skill) => {
+  return getUniqueSkillsById(skills).reduce((product, skill) => {
     let next = product
 
     if (category) {


### PR DESCRIPTION
## 概要
- 装備変更画面の所持アイテム一覧を、称号込みの同一装備ごとに集計表示へ変更
- 装備変更画面の一覧描画を `FlatList` 化し、下端の safe area 余白を調整
- スキル効果とスキル一覧表示を、同一 `skill.id` は重複しない仕様に統一

## テスト
- `npx tsc --noEmit`
- `npx jest src/shared/data/__tests__/characterSkills.test.ts --runInBand`

## 補足
- PR のマージ先は `develop` です
- 攻撃回数スキルの表示は `[+x]攻撃回数` に統一しています