### PR TITLE
[codex] 敵ごとのドロップ抽選に変更

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -20,8 +20,8 @@ import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
 
-/** 全エリア共通の宝箱ドロップ確率（戦闘勝利ごと） */
-const DROP_CHANCE = 0.4
+/** 全エリア共通の宝箱ドロップ確率（敵1体ごと） */
+const DROP_CHANCE = 0.15
 
 export class ExpeditionEngine {
   private rng: () => number
@@ -519,9 +519,11 @@ export class ExpeditionEngine {
 
   /**
    * 宝箱ドロップを判定（同一遠征中に同じアイテムは1個まで）
-   * 1. ダンジョンレベルに対応する装備プールから均等抽選
-   * 2. 敵個別の equipmentDrops でレアアイテムを抽選
-   * 3. ドロップ時に称号を抽選して付与
+   * 1. 敵1体ごとにダンジョンレベル対応の装備プールを15%で抽選
+   * 2. 同一戦闘内では同じアイテムの重複を許可する
+   * 3. 敵個別の equipmentDrops も同じ戦闘内では重複を許可する
+   * 4. 戦闘終了後、ドロップしたtemplateIdを遠征全体の重複防止に登録する
+   * 5. ドロップ時に称号を抽選して付与
    */
   private rollTreasureDrops(
     dungeonLevel: number,
@@ -530,13 +532,14 @@ export class ExpeditionEngine {
     titleMultiplier: number = 1
   ): TreasureDrop[] {
     const drops: TreasureDrop[] = []
+    const expeditionDroppedIds = new Set(droppedIds)
+    const pendingDroppedIds = new Set<string>()
+    const pool = getEquipmentByDungeonLevel(dungeonLevel)
+    const candidates = pool.filter(t => !expeditionDroppedIds.has(t.id))
 
-    // ダンジョンレベルに応じた装備プールから抽選
-    if (this.rng() < DROP_CHANCE) {
-      const pool = getEquipmentByDungeonLevel(dungeonLevel)
-      const candidates = pool.filter(t => !droppedIds.has(t.id))
-
-      if (candidates.length > 0) {
+    // ダンジョンレベルに応じた装備プールから敵1体ごとに抽選
+    for (const _enemy of enemies) {
+      if (this.rng() < DROP_CHANCE && candidates.length > 0) {
         const index = Math.floor(this.rng() * candidates.length)
         const selected = candidates[index]
 
@@ -550,7 +553,7 @@ export class ExpeditionEngine {
           titleId: title.titleId !== 'none' ? title.titleId : undefined,
           titleName: title.titleName || undefined,
         })
-        droppedIds.add(selected.id)
+        pendingDroppedIds.add(selected.id)
       }
     }
 
@@ -558,7 +561,7 @@ export class ExpeditionEngine {
     for (const enemy of enemies) {
       if (!enemy.equipmentDrops) continue
       for (const drop of enemy.equipmentDrops) {
-        if (droppedIds.has(drop.templateId)) continue
+        if (expeditionDroppedIds.has(drop.templateId)) continue
         if (this.rng() < drop.probability) {
           const template = getEquipmentTemplate(drop.templateId)
           if (template) {
@@ -572,10 +575,14 @@ export class ExpeditionEngine {
               titleId: title.titleId !== 'none' ? title.titleId : undefined,
               titleName: title.titleName || undefined,
             })
-            droppedIds.add(drop.templateId)
+            pendingDroppedIds.add(drop.templateId)
           }
         }
       }
+    }
+
+    for (const templateId of pendingDroppedIds) {
+      droppedIds.add(templateId)
     }
 
     return drops

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -69,7 +69,7 @@ describe('rollTreasureDrops', () => {
   })
 
   describe('ドロップ確率の基本動作', () => {
-    it('一律40%のドロップ確率で装備がドロップする', () => {
+    it('敵1体あたり15%のドロップ確率で装備がドロップする', () => {
       // areaLevel=1 にはひのきの棒(dropLevelMin=1,dropLevelMax=2)がある
       const pool = getEquipmentByDungeonLevel(1)
       if (pool.length === 0) return // プールが空なら skip
@@ -83,10 +83,27 @@ describe('rollTreasureDrops', () => {
         )
         if (result.length > 0) dropCount++
       }
-      // 40%前後であることを確認（30%〜50%の範囲）
+      // 15%前後であることを確認（10%〜20%の範囲）
       const rate = dropCount / iterations
-      expect(rate).toBeGreaterThan(0.3)
-      expect(rate).toBeLessThan(0.5)
+      expect(rate).toBeGreaterThan(0.1)
+      expect(rate).toBeLessThan(0.2)
+    })
+
+    it('敵数が増えると1戦闘で複数ドロップしうる', () => {
+      const enemies = Array.from({ length: 5 }, (_, i) => createDummyEnemy({ id: `enemy_${i}` }))
+
+      for (let seed = 0; seed < 2000; seed++) {
+        const engine = createEngine(seed)
+        const result = callRollTreasureDrops(
+          engine, 1, enemies, new Set()
+        )
+        if (result.length >= 2) {
+          expect(result.length).toBeGreaterThanOrEqual(2)
+          return
+        }
+      }
+
+      throw new Error('5体戦闘で複数ドロップになるシードが見つかりませんでした')
     })
   })
 
@@ -97,8 +114,8 @@ describe('rollTreasureDrops', () => {
 
       // 確実にドロップするシードを探す
       let result: any[] = []
-      for (let seed = 0; seed < 100; seed++) {
-        const engine = createEngine(seed)
+      for (let seed = 0; seed < 1000; seed++) {
+        const engine = createEngine(seed * 1000)
         result = callRollTreasureDrops(
           engine, 1, [createDummyEnemy()], new Set()
         )
@@ -115,8 +132,8 @@ describe('rollTreasureDrops', () => {
     it('称号なしの場合、titleId/titleNameはundefined', () => {
       // 倍率1ではほぼ称号なし。多数試行してnoneを見つける
       let foundNone = false
-      for (let seed = 0; seed < 500; seed++) {
-        const engine = createEngine(seed)
+      for (let seed = 0; seed < 5000; seed++) {
+        const engine = createEngine(seed * 1000)
         const result = callRollTreasureDrops(
           engine, 1, [createDummyEnemy()], new Set()
         )
@@ -132,8 +149,8 @@ describe('rollTreasureDrops', () => {
     it('称号ありの場合、titleIdとtitleNameが設定される', () => {
       // 倍率99で多数試行して称号付きを見つける
       let foundTitle = false
-      for (let seed = 0; seed < 500; seed++) {
-        const engine = createEngine(seed)
+      for (let seed = 0; seed < 5000; seed++) {
+        const engine = createEngine(seed * 1000)
         const result = callRollTreasureDrops(
           engine, 1, [createDummyEnemy()], new Set(), 99
         )
@@ -305,6 +322,58 @@ describe('rollTreasureDrops', () => {
         }
       }
       expect(foundTitle).toBe(true)
+    })
+
+    it('同一戦闘内なら同じ敵ドロップが複数回発生しうる', () => {
+      const duplicatedEnemies = [
+        createDummyEnemy({
+          id: 'enemy_a',
+          equipmentDrops: [
+            { templateId: 'sword_cypress_stick', probability: 1.0 },
+          ],
+        }),
+        createDummyEnemy({
+          id: 'enemy_b',
+          equipmentDrops: [
+            { templateId: 'sword_cypress_stick', probability: 1.0 },
+          ],
+        }),
+      ]
+
+      const result = callRollTreasureDrops(
+        createEngine(1), 1, duplicatedEnemies, new Set()
+      )
+
+      const duplicatedDrops = result.filter((d: any) => d.templateId === 'sword_cypress_stick')
+      expect(duplicatedDrops).toHaveLength(2)
+    })
+
+    it('同じアイテムは戦闘をまたぐと再ドロップしない', () => {
+      const duplicatedEnemies = [
+        createDummyEnemy({
+          id: 'enemy_a',
+          equipmentDrops: [
+            { templateId: 'sword_cypress_stick', probability: 1.0 },
+          ],
+        }),
+        createDummyEnemy({
+          id: 'enemy_b',
+          equipmentDrops: [
+            { templateId: 'sword_cypress_stick', probability: 1.0 },
+          ],
+        }),
+      ]
+      const droppedIds = new Set<string>()
+
+      const firstBattle = callRollTreasureDrops(
+        createEngine(1), 1, duplicatedEnemies, droppedIds
+      )
+      const secondBattle = callRollTreasureDrops(
+        createEngine(2), 1, duplicatedEnemies, droppedIds
+      )
+
+      expect(firstBattle.filter((d: any) => d.templateId === 'sword_cypress_stick')).toHaveLength(2)
+      expect(secondBattle.filter((d: any) => d.templateId === 'sword_cypress_stick')).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
## 概要
- 通常ドロップを 1 戦闘 1 回から敵 1 体ごと 15% 抽選へ変更
- 1 戦闘内で複数ドロップ、および同一アイテム重複を許可
- 遠征全体では同一アイテムが再ドロップしないことを維持
- ドロップ関連テストを新仕様に合わせて更新

## 検証
- `npm test -- --runInBand src/core/services/__tests__/TreasureDrop.test.ts`
