### PR TITLE
fix: 待機ゴブリン追加と出撃警告を調整

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -137,6 +137,7 @@ export default function FormationScreen() {
   const dungeons = useDungeonStore((state) => state.dungeons)
   const dungeonsLoading = useDungeonStore((state) => state.isLoading)
   const baseLoading = useBaseStore((state) => state.isLoading)
+  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
   const rank = useBaseStore(selectRank)
   const currentTime = useCurrentTime({ enabled: true })
   const {
@@ -287,8 +288,30 @@ export default function FormationScreen() {
       Alert.alert('一括出撃', message)
     }
 
+    const launchableParties = parties.filter((party) => {
+      if ((party.status ?? 'idle') === 'expedition') return false
+      if (party.memberIds.length === 0) return false
+      if (!party.dungeonId) return false
+      const dungeon = dungeons.find((item) => item.id === party.dungeonId)
+      return Boolean(dungeon?.unlocked)
+    })
+
+    const maxPendingGoblins = rank * 5
+    const remainingPendingSlots = Math.max(0, maxPendingGoblins - pendingGoblins.length)
+    if (launchableParties.length > remainingPendingSlots) {
+      Alert.alert(
+        '確認',
+        `待機枠が不足しています。${launchableParties.length}PT出撃すると、遠征成功時に追加されるゴブリンを受け取れず破棄する可能性があります。出撃しますか？`,
+        [
+          { text: 'キャンセル', style: 'cancel' },
+          { text: '出撃する', onPress: () => void doBulkLaunch() },
+        ],
+      )
+      return
+    }
+
     void doBulkLaunch()
-  }, [dungeons, parties, startExpedition])
+  }, [dungeons, parties, pendingGoblins.length, rank, startExpedition])
 
   const canBulkLaunch = useMemo(() => {
     return parties.some((party) => {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator
 import { router, useLocalSearchParams, Stack } from 'expo-router'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinImage } from '@/shared/utils/goblinImages'
@@ -69,6 +70,8 @@ export default function ExpeditionPreparationScreen() {
   } = usePartyStore()
   const goblins = useGoblinStore((state) => state.goblins)
   const goblinsLoading = useGoblinStore((state) => state.isLoading)
+  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
+  const rank = useBaseStore(selectRank)
   const dungeons = useDungeonStore((state) => state.dungeons)
   const dungeonsLoading = useDungeonStore((state) => state.isLoading)
   const { startExpedition, estimateExplorationTime } = useExpeditionFlow()
@@ -197,9 +200,24 @@ export default function ExpeditionPreparationScreen() {
       }
     }
 
+    const maxPendingGoblins = rank * 5
+    if (pendingGoblins.length >= maxPendingGoblins) {
+      Alert.alert(
+        '確認',
+        '待機枠がいっぱいです。遠征に成功してゴブリンが追加された場合、受け取れず破棄される可能性があります。出撃しますか？',
+        [
+          { text: 'キャンセル', style: 'cancel' },
+          { text: '出撃する', onPress: () => void doStartExpedition() },
+        ],
+      )
+      return
+    }
+
     void doStartExpedition()
   }, [
+    pendingGoblins.length,
     party,
+    rank,
     selectedDungeon,
     selectedDungeonId,
     selectedReturnPolicy,

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
-import { useBaseStore, selectMaxGoblins } from '@/presentation/stores/useBaseStore'
+import { useBaseStore, selectMaxGoblins, selectRank } from '@/presentation/stores/useBaseStore'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { GoblinCard } from '@/presentation/components/GoblinCard'
 import type { Goblin } from '@/shared/types'
@@ -38,12 +38,14 @@ export default function GoblinListScreen() {
   const removePendingGoblin = useBaseStore((state) => state.removePendingGoblin)
   const clearPendingGoblins = useBaseStore((state) => state.clearPendingGoblins)
   const maxGoblins = useBaseStore(selectMaxGoblins)
+  const rank = useBaseStore(selectRank)
   const parties = usePartyStore((state) => state.parties)
   const swipeableRefs = useRef<Record<number, Swipeable | null>>({})
   const [openSwipeableId, setOpenSwipeableId] = useState<number | null>(null)
   const [isBulkDismissingPending, setIsBulkDismissingPending] = useState(false)
 
   const hasCapacity = goblins.length < maxGoblins
+  const maxPendingGoblins = rank * 5
   const [sortKey, setSortKey] = useState<'level' | 'atk' | 'hp'>('level')
 
   const sortedGoblins = useMemo(() => (
@@ -231,7 +233,7 @@ export default function GoblinListScreen() {
           <View style={styles.pendingSectionHeaderLeft}>
             <Text style={styles.pendingSectionTitle}>産まれたゴブリン</Text>
             <View style={styles.pendingBadge}>
-              <Text style={styles.pendingBadgeText}>{pendingGoblins.length}体</Text>
+              <Text style={styles.pendingBadgeText}>{pendingGoblins.length} / {maxPendingGoblins}</Text>
             </View>
           </View>
           <TouchableOpacity
@@ -244,9 +246,6 @@ export default function GoblinListScreen() {
             </Text>
           </TouchableOpacity>
         </View>
-        <Text style={styles.pendingSectionDesc}>
-          拠点がいっぱいのため待機中です。
-        </Text>
         {pendingGoblins.map((goblin) => {
           const effectiveStats = ModStatCalculator.calculate(goblin)
           return (
@@ -304,7 +303,7 @@ export default function GoblinListScreen() {
         <View style={styles.footerSpacer} />
       </View>
     )
-  }, [handleAddPending, handleDismissAllPending, handleDismissPending, handlePendingGoblinPress, hasCapacity, isBulkDismissingPending, pendingGoblins])
+  }, [handleAddPending, handleDismissAllPending, handleDismissPending, handlePendingGoblinPress, hasCapacity, isBulkDismissingPending, maxPendingGoblins, pendingGoblins])
 
 
   if (isLoading) {
@@ -500,12 +499,6 @@ const styles = StyleSheet.create({
     fontSize: 11,
     color: '#4B5563',
     fontWeight: '600',
-  },
-  pendingSectionDesc: {
-    fontSize: 12,
-    color: '#9CA3AF',
-    marginBottom: 8,
-    paddingHorizontal: 12,
   },
   bulkDismissButton: {
     backgroundColor: '#991B1B',

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -60,12 +60,10 @@ export const useExpeditionFlow = ({
   const partyRepository = getPartyRepository()
   const goblinRepository = getGoblinRepository()
   const goblins = useGoblinStore((state) => state.goblins)
-  const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
   const addPendingGoblin = useBaseStore((state) => state.addPendingGoblin)
   const isPendingLoading = useBaseStore((state) => state.isLoading)
   const getNextGoblinId = useBaseStore((state) => state.getNextGoblinId)
   const rank = useBaseStore(s => s.baseState?.rank ?? 1)
-  const maxGoblins = useBaseStore(s => s.baseState?.currentMaxGoblins ?? 10)
   const isBaseLoading = useBaseStore(s => s.isLoading)
   const baseStateRepository = getBaseStateRepository()
   const markDungeonCleared = useDungeonStore((state) => state.markDungeonCleared)
@@ -110,22 +108,18 @@ export const useExpeditionFlow = ({
       rank
     )
 
-    if (goblins.length < maxGoblins) {
-      await useGoblinStore.getState().saveGoblin(newGoblin)
-    } else {
-      const maxPending = rank * 5
-      if (pendingGoblins.length >= maxPending) return
-      await addPendingGoblin(newGoblin)
-    }
+    await useBaseStore.getState().refreshPendingGoblins()
+    const latestPendingGoblins = useBaseStore.getState().pendingGoblins
+    const maxPending = rank * 5
+    if (latestPendingGoblins.length >= maxPending) return
+    await addPendingGoblin(newGoblin)
   }, [
     addPendingGoblin,
     getNextGoblinId,
     goblins,
-    maxGoblins,
     isBaseLoading,
     isPendingLoading,
     markDungeonCleared,
-    pendingGoblins.length,
     rank,
   ])
 


### PR DESCRIPTION
## 概要
- 遠征クリア時の新規ゴブリン追加先を待機リストへ統一
- 待機リストのヘッダーに待機数と待機枠を表示
- 待機枠超過の可能性がある単独出撃・一括出撃で確認アラートを追加
- 待機ゴブリン追加時に最新件数を見て上限超過を防止

## テスト
- npm test -- --runInBand