### PR TITLE
[codex] fix battle log duplicate enemy labels

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -26,7 +26,9 @@ interface SpellCharge {
 }
 
 interface BattleUnit {
+  instanceId?: string
   combatant: Combatant
+  logName?: string
   currentHP: number
   maxHP: number
   initialHP: number
@@ -209,6 +211,7 @@ export class BattleSystem {
         enemyIdx++
       }
     }
+    this.assignEnemyLogNames(enemyUnits)
 
     const detailedLog: BattleLogEntry[] = []
     let currentTurn = 0
@@ -256,7 +259,7 @@ export class BattleSystem {
           detailedLog.push({
             turn: currentTurn,
             actorId: unit.combatant.id,
-            actorName: unit.combatant.name,
+            actorName: this.getLogName(unit),
             actorRow: unit.row + 1,
             action: spellAction.name,
             attackCount: totalHitCount,
@@ -321,29 +324,13 @@ export class BattleSystem {
             target.currentHP = Math.max(0, target.currentHP - damage)
 
             // ターゲットごとの結果を集約
-            const existing = targetDetails.get(target.combatant.id)
-            if (existing) {
-              existing.totalDamage += damage
-              existing.hitCount++
-              existing.defeated = target.currentHP <= 0
-              existing.targetHP = target.currentHP
-            } else {
-              targetDetails.set(target.combatant.id, {
-                targetId: target.combatant.id,
-                targetName: target.combatant.name,
-                targetRow: target.row + 1,
-                totalDamage: damage,
-                hitCount: 1,
-                defeated: target.currentHP <= 0,
-                targetHP: target.currentHP,
-              })
-            }
+            this.accumulateTargetDetail(targetDetails, target, damage)
           }
 
           detailedLog.push({
             turn: currentTurn,
             actorId: unit.combatant.id,
-            actorName: unit.combatant.name,
+            actorName: this.getLogName(unit),
             actorRow: unit.row + 1,
             action: BASIC_ATTACK_SKILL.name,
             attackCount: unit.attackCount,
@@ -517,16 +504,17 @@ export class BattleSystem {
     target: BattleUnit,
     damage: number,
   ): void {
-    const existing = details.get(target.combatant.id)
+    const targetKey = this.getUnitKey(target)
+    const existing = details.get(targetKey)
     if (existing) {
       existing.totalDamage += damage
       existing.hitCount++
       existing.defeated = target.currentHP <= 0
       existing.targetHP = target.currentHP
     } else {
-      details.set(target.combatant.id, {
+      details.set(targetKey, {
         targetId: target.combatant.id,
-        targetName: target.combatant.name,
+        targetName: this.getLogName(target),
         targetRow: target.row + 1,
         totalDamage: damage,
         hitCount: 1,
@@ -545,6 +533,7 @@ export class BattleSystem {
     const physicalDamageReduction = getPhysicalDamageReductionFromSkills(goblin.skills)
     const learnedSpells = this.mergeLearnedSpells(goblin.spells, goblin.skills)
     return {
+      instanceId: `ally:${combatant.id}`,
       combatant,
       currentHP: hp,
       maxHP: effectiveStats.hp,
@@ -570,6 +559,7 @@ export class BattleSystem {
     const skills = enemy.skills ?? []
     const learnedSpells = this.mergeLearnedSpells(enemy.spells, skills)
     return {
+      instanceId: `enemy:${combatant.id}:${originalIndex}`,
       combatant,
       currentHP: enemy.hp,
       maxHP: enemy.hp,
@@ -618,7 +608,7 @@ export class BattleSystem {
     const candidates = defendingGroup
       .filter((unit) => (
         unit.currentHP > 0 &&
-        unit.combatant.id !== target.combatant.id &&
+        this.getUnitKey(unit) !== this.getUnitKey(target) &&
         unit.row < target.row &&
         hasCoverLowHpAllySkill(unit.skills)
       ))
@@ -647,13 +637,13 @@ export class BattleSystem {
       turnState: {
         allies: allyUnits.map(unit => ({
           id: unit.combatant.id,
-          name: unit.combatant.name,
+          name: this.getLogName(unit),
           currentHP: unit.currentHP,
           maxHP: unit.maxHP,
         })),
         enemies: enemyUnits.map(unit => ({
           id: unit.combatant.id,
-          name: unit.combatant.name,
+          name: this.getLogName(unit),
           currentHP: unit.currentHP,
           maxHP: unit.maxHP,
         })),
@@ -678,5 +668,46 @@ export class BattleSystem {
       enemyDefeated,
       detailedLog,
     }
+  }
+
+  private getUnitKey(unit: BattleUnit): string {
+    return unit.instanceId ?? unit.combatant.id
+  }
+
+  private getLogName(unit: BattleUnit): string {
+    return unit.logName ?? unit.combatant.name
+  }
+
+  private assignEnemyLogNames(enemyUnits: BattleUnit[]): void {
+    const groups = new Map<string, BattleUnit[]>()
+
+    for (const unit of enemyUnits) {
+      const group = groups.get(unit.combatant.id) ?? []
+      group.push(unit)
+      groups.set(unit.combatant.id, group)
+    }
+
+    for (const group of groups.values()) {
+      if (group.length === 1) {
+        group[0].logName = group[0].combatant.name
+        continue
+      }
+
+      group.forEach((unit, index) => {
+        unit.logName = `${unit.combatant.name}${this.toAlphabetLabel(index)}`
+      })
+    }
+  }
+
+  private toAlphabetLabel(index: number): string {
+    let n = index
+    let label = ''
+
+    do {
+      label = String.fromCharCode(65 + (n % 26)) + label
+      n = Math.floor(n / 26) - 1
+    } while (n >= 0)
+
+    return label
   }
 }

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1012,6 +1012,71 @@ describe('selectTarget — 隊列ターゲット選択', () => {
 // 呪文チャージ
 // =========================================================================
 describe('spell charges', () => {
+  it('ファイヤーボールは同じ敵IDの別個体を別ターゲットとして記録する', () => {
+    const battleSystem = new BattleSystem()
+    const caster = createTestEnemy({
+      id: 'FIRE_CASTER',
+      name: '火術師',
+      level: 1,
+      hp: 999,
+      atk: 1,
+      def: 1,
+      spd: 100,
+      attackCount: 0,
+      skills: [
+        { id: 'fireball', name: 'ファイヤーボール', grantsSpellId: 'fireball' },
+      ],
+    })
+    const allyA = createTestGoblin({
+      id: 1,
+      name: '前衛A',
+      stats: { hp: 120, atk: 10, sp: 0, spd: 1, def: 10, attackCount: 1, accuracy: 20, evasion: 0 },
+    })
+    const allyB = createTestGoblin({
+      id: 2,
+      name: '前衛B',
+      stats: { hp: 120, atk: 10, sp: 0, spd: 1, def: 10, attackCount: 1, accuracy: 20, evasion: 0 },
+    })
+
+    const result = battleSystem.executeBattle([allyA, allyB], [allyA.stats.hp, allyB.stats.hp], [[caster]], createSeededRng(1), 1)
+    const spellLog = result.detailedLog.find(log => log.actorId === 'FIRE_CASTER' && log.action === 'ファイヤーボール')
+
+    expect(spellLog?.targets).toHaveLength(2)
+    expect(spellLog?.targets.map(target => target.targetId).sort()).toEqual(['1', '2'])
+    expect(spellLog?.targets.every(target => target.hitCount === 1)).toBe(true)
+  })
+
+  it('同じ敵IDが複数いる場合はログ表示名にA/Bサフィックスを付ける', () => {
+    const battleSystem = new BattleSystem()
+    const attacker = createTestGoblin({
+      id: 1,
+      stats: { hp: 120, atk: 40, sp: 0, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const enemyA = createTestEnemy({
+      id: 'ORC002',
+      name: 'オーク兵',
+      hp: 60,
+      def: 1,
+      spd: 1,
+      evasion: 0,
+    })
+    const enemyB = createTestEnemy({
+      id: 'ORC002',
+      name: 'オーク兵',
+      hp: 60,
+      def: 1,
+      spd: 1,
+      evasion: 0,
+    })
+
+    const result = battleSystem.executeBattle([attacker], [attacker.stats.hp], [[enemyA, enemyB]], createSeededRng(1), 1)
+    const turnStartLog = result.detailedLog.find(log => log.action === 'turn_start')
+    const attackLog = result.detailedLog.find(log => log.actorId === '1' && log.action === '通常攻撃')
+
+    expect(turnStartLog?.turnState?.enemies.map(enemy => enemy.name)).toEqual(['オーク兵A', 'オーク兵B'])
+    expect(attackLog?.targets[0]?.targetName).toBe('オーク兵A')
+  })
+
   it('ファイヤーボール2回は1戦闘で2回使える', () => {
     const battleSystem = new BattleSystem()
     const ally = createTestGoblin({


### PR DESCRIPTION
## 概要
- 戦闘ログで同じ敵IDの別個体が1行に集約される問題を修正
- 重複する敵IDがいる場合に `A/B/C...` のサフィックス付き表示名を付与
- 重複敵表示とファイヤーボールのログ記録に対する回帰テストを追加

## 原因
- 戦闘ログの集約キーが敵のマスタID単位だったため、同種の別個体へのヒットが同一対象として表示されていました。

## 確認
- `npm test -- --runInBand src/core/services/__tests__/CombatStats.test.ts`
- 69 tests passed
