### PR TITLE
feat: add hobgoblin inspire and guts skills

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -7,6 +7,7 @@ import {
   getPhysicalDamageReductionFromSkills,
   getRearProtectionMultiplierFromSkills,
   hasCoverLowHpAllySkill,
+  hasSurviveLethalDamageAtHp1Skill,
 } from '../../shared/data/characterSkills'
 import type { SpellDef } from '../../shared/types/Spell'
 import { CombatantManager } from './CombatantManager'
@@ -321,7 +322,7 @@ export class BattleSystem {
               Math.floor((baseDamage * dmgMod * rearDamageMultiplier + additionalDamage) * reductionFactor * physicalReductionFactor * protectionFactor),
             )
 
-            target.currentHP = Math.max(0, target.currentHP - damage)
+            this.applyDamage(target, damage)
 
             // ターゲットごとの結果を集約
             this.accumulateTargetDetail(targetDetails, target, damage)
@@ -463,7 +464,7 @@ export class BattleSystem {
         const rearDamageMultiplier = this.getRearDamageMultiplier(unit, sourceGroup)
         const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier))
 
-        target.currentHP = Math.max(0, target.currentHP - damage)
+        this.applyDamage(target, damage)
         totalHitCount++
 
         this.accumulateTargetDetail(targetDetails, target, damage)
@@ -489,7 +490,7 @@ export class BattleSystem {
         const rearDamageMultiplier = this.getRearDamageMultiplier(unit, sourceGroup)
         const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier))
 
-        target.currentHP = Math.max(0, target.currentHP - damage)
+        this.applyDamage(target, damage)
         totalHitCount++
 
         this.accumulateTargetDetail(targetDetails, target, damage)
@@ -522,6 +523,17 @@ export class BattleSystem {
         targetHP: target.currentHP,
       })
     }
+  }
+
+  private applyDamage(target: BattleUnit, damage: number): void {
+    const nextHP = target.currentHP - damage
+
+    if (nextHP <= 0 && target.currentHP > 0 && hasSurviveLethalDamageAtHp1Skill(target.skills)) {
+      target.currentHP = 1
+      return
+    }
+
+    target.currentHP = Math.max(0, nextHP)
   }
 
   private createAllyUnit(goblin: Goblin, initialHP: number | undefined, originalIndex: number): BattleUnit {
@@ -583,21 +595,41 @@ export class BattleSystem {
   private getRearGuardReductionFactor(target: BattleUnit, allyUnits: BattleUnit[]): number {
     if (!target.isAlly || target.currentHP <= 0) return 1
 
-    return allyUnits.reduce((factor, ally) => {
-      if (ally.currentHP <= 0 || ally.row >= target.row) {
-        return factor
-      }
-      return factor * getRearProtectionMultiplierFromSkills(ally.skills)
-    }, 1)
+    const frontmostRearGuardUnit = allyUnits
+      .filter((ally) => (
+        ally.currentHP > 0 &&
+        ally.row < target.row &&
+        getRearProtectionMultiplierFromSkills(ally.skills) !== 1
+      ))
+      .sort((a, b) => {
+        if (a.row !== b.row) return a.row - b.row
+        return a.rowSlot - b.rowSlot
+      })[0]
+
+    if (!frontmostRearGuardUnit) {
+      return 1
+    }
+
+    return getRearProtectionMultiplierFromSkills(frontmostRearGuardUnit.skills)
   }
 
   private getRearDamageMultiplier(unit: BattleUnit, groupUnits: BattleUnit[]): number {
-    return groupUnits.reduce((factor, ally) => {
-      if (ally.currentHP <= 0 || ally.row >= unit.row) {
-        return factor
-      }
-      return factor * getRearAllyDamageMultiplierFromSkills(ally.skills)
-    }, 1)
+    const frontmostInspireUnit = groupUnits
+      .filter((ally) => (
+        ally.currentHP > 0 &&
+        ally.row < unit.row &&
+        getRearAllyDamageMultiplierFromSkills(ally.skills) !== 1
+      ))
+      .sort((a, b) => {
+        if (a.row !== b.row) return a.row - b.row
+        return a.rowSlot - b.rowSlot
+      })[0]
+
+    if (!frontmostInspireUnit) {
+      return 1
+    }
+
+    return getRearAllyDamageMultiplierFromSkills(frontmostInspireUnit.skills)
   }
 
   private resolveCoverTarget(target: BattleUnit, defendingGroup: BattleUnit[]): BattleUnit {

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -582,6 +582,41 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     expect(protectedRear!.totalDamage).toBeLessThan(plainRear!.totalDamage)
   })
 
+  it('後列防護持ちが複数いても最前列の1体分だけ適用する', () => {
+    const allies = [
+      createTestGoblin({
+        id: 1,
+        skills: [{ id: 'rear_guard_front', name: '後列防護', protectRearAllyNormalAttackMultiplier: 2 / 3 }],
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 10, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+      createTestGoblin({
+        id: 2,
+        skills: [{ id: 'rear_guard_middle', name: '後列防護', protectRearAllyNormalAttackMultiplier: 2 / 3 }],
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 5, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+      createTestGoblin({
+        id: 3,
+        skills: [],
+        stats: { hp: 9999, atk: 1, sp: 10, spd: 1, def: 0, attackCount: 1, accuracy: 1, evasion: 0 },
+      }),
+    ]
+    const enemy = createTestEnemy({
+      hp: 9999,
+      atk: 90,
+      def: 0,
+      spd: 100,
+      attackCount: 20,
+      accuracy: 999,
+      evasion: 0,
+    })
+
+    const result = new BattleSystem().executeBattle(allies, [9999, 9999, 9999], [[enemy]], createSeededRng(7), 1)
+    const rear = result.detailedLog.find(log => log.action === '通常攻撃' && !log.isAlly)!.targets.find(target => target.targetId === '3')
+
+    expect(rear).toBeDefined()
+    expect(rear!.totalDamage).toBe(201)
+  })
+
   it('遠征戦闘でもスライムゴブリンの後列防護が適用される', () => {
     const protectedPartyState = [
       {
@@ -1175,6 +1210,58 @@ describe('BattleSystem — ジョブ系スキル', () => {
     const attackerLog = result.detailedLog.find(log => log.actorId === String(attacker.id) && log.action === '通常攻撃')
 
     expect((attackerLog?.targets[0]?.totalDamage ?? 0)).toBeGreaterThan(50)
+  })
+
+  it('鼓舞持ちが複数いても最前列の1体分だけ適用する', () => {
+    const battleSystem = new BattleSystem()
+    const frontInspire = createTestGoblin({
+      id: 1,
+      skills: [{ id: 'inspire_front', name: '鼓舞', rearAllyDamageMultiplier: 1.5 }],
+      stats: { hp: 120, atk: 5, sp: 0, spd: 20, def: 20, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const middleInspire = createTestGoblin({
+      id: 2,
+      skills: [{ id: 'inspire_middle', name: '鼓舞', rearAllyDamageMultiplier: 1.5 }],
+      stats: { hp: 120, atk: 5, sp: 0, spd: 15, def: 20, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const attacker = createTestGoblin({
+      id: 3,
+      name: '後衛',
+      skills: [],
+      stats: { hp: 100, atk: 40, sp: 0, spd: 100, def: 5, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const enemy = createTestEnemy({ hp: 200, def: 1, evasion: 0, spd: 1 })
+
+    const result = battleSystem.executeBattle(
+      [frontInspire, middleInspire, attacker],
+      [frontInspire.stats.hp, middleInspire.stats.hp, attacker.stats.hp],
+      [[enemy]],
+      createSeededRng(1),
+      1,
+    )
+    const attackerLog = result.detailedLog.find(log => log.actorId === String(attacker.id) && log.action === '通常攻撃')
+
+    expect(attackerLog?.targets[0]?.totalDamage).toBe(58)
+  })
+
+  it('気合い持ちは致死ダメージを受けてもHP1で耐える', () => {
+    const battleSystem = new BattleSystem()
+    const hobgoblin = createTestGoblin({
+      id: 1,
+      race: 'ホブゴブリン',
+      stats: { hp: 100, atk: 10, sp: 0, spd: 50, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const enemy = createTestEnemy({
+      atk: 999,
+      accuracy: 999,
+      evasion: 0,
+      spd: 100,
+    })
+
+    const result = battleSystem.executeBattle([hobgoblin], [hobgoblin.stats.hp], [[enemy]], createSeededRng(2), 1)
+
+    expect(result.allyHPDelta[0]).toBe(1 - hobgoblin.stats.hp)
+    expect(result.outcome).not.toBe('lose')
   })
 })
 

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -9,6 +9,7 @@ import {
   getSkillStatBonuses,
   getSkillStatMultipliers,
   hasCoverLowHpAllySkill,
+  hasSurviveLethalDamageAtHp1Skill,
   getUniqueSkillsById,
 } from '../characterSkills'
 
@@ -94,6 +95,14 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     expect(hasCoverLowHpAllySkill(skills)).toBe(true)
   })
 
+  it('気合いスキルを判定できる', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'guts', name: '気合い', surviveLethalDamageAtHp1: true },
+    ]
+
+    expect(hasSurviveLethalDamageAtHp1Skill(skills)).toBe(true)
+  })
+
   it('スキル一覧取得時も同じidは1件にまとまる', () => {
     const skills: CharacterSkill[] = [
       { id: 'shared', name: 'A' },
@@ -132,6 +141,16 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     }
 
     expect(describeCharacterSkill(skill)).toBe('SPDが×1.2')
+  })
+
+  it('気合いスキルの説明文を返す', () => {
+    const skill: CharacterSkill = {
+      id: 'guts',
+      name: '気合い',
+      surviveLethalDamageAtHp1: true,
+    }
+
+    expect(describeCharacterSkill(skill)).toBe('HPが0になる攻撃を受けてもHP1で耐える')
   })
 
   it('呪文付与スキルからLearnedSpellへ変換できる', () => {

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -43,6 +43,10 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
     return 'HPが半分以下の味方への通常攻撃を代わりに受ける'
   }
 
+  if (skill.surviveLethalDamageAtHp1) {
+    return 'HPが0になる攻撃を受けてもHP1で耐える'
+  }
+
   if (skill.physicalDamageReductionPercent !== undefined) {
     return `[-${skill.physicalDamageReductionPercent}%] 物理ダメージ軽減(%)`
   }
@@ -130,6 +134,10 @@ export function getRearAllyDamageMultiplierFromSkills(skills: CharacterSkill[]):
 
 export function hasCoverLowHpAllySkill(skills: CharacterSkill[]): boolean {
   return getUniqueSkillsById(skills).some((skill) => skill.coverLowHpAlly)
+}
+
+export function hasSurviveLethalDamageAtHp1Skill(skills: CharacterSkill[]): boolean {
+  return getUniqueSkillsById(skills).some((skill) => skill.surviveLethalDamageAtHp1)
 }
 
 export function getPhysicalDamageReductionFromSkills(skills: CharacterSkill[]): number {

--- a/goblin_native/src/shared/data/enemy/goblin_village_3.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_3.json
@@ -96,6 +96,10 @@
       "evasion": 18,
       "exp": 80,
       "gold": 70,
+      "skills": [
+        { "id": "hobgoblin_inspire", "name": "鼓舞", "rearAllyDamageMultiplier": 1.5 },
+        { "id": "hobgoblin_guts", "name": "気合い", "surviveLethalDamageAtHp1": true }
+      ],
       "factorDrops": [
         { "factorId": "hobgoblin", "probability": 1 }
       ]

--- a/goblin_native/src/shared/data/raceSkills.ts
+++ b/goblin_native/src/shared/data/raceSkills.ts
@@ -14,6 +14,16 @@ const CHARACTER_SKILL_LIBRARY: Record<string, CharacterSkill> = {
     name: '後列防護',
     protectRearAllyNormalAttackMultiplier: 2 / 3,
   },
+  hobgoblinInspire: {
+    id: 'hobgoblin_inspire',
+    name: '鼓舞',
+    rearAllyDamageMultiplier: 1.5,
+  },
+  hobgoblinGuts: {
+    id: 'hobgoblin_guts',
+    name: '気合い',
+    surviveLethalDamageAtHp1: true,
+  },
   wolfAttackCountUp: {
     id: 'wolf_attack_count_up',
     name: '[+2]攻撃回数アップ',
@@ -45,6 +55,10 @@ const RACE_DEFAULT_SKILLS: Record<string, CharacterSkill[]> = {
     CHARACTER_SKILL_LIBRARY.wolfAttackCountUp,
     CHARACTER_SKILL_LIBRARY.wolfAccuracyBoost,
     CHARACTER_SKILL_LIBRARY.wolfAdditionalDamage,
+  ],
+  'ホブゴブリン': [
+    CHARACTER_SKILL_LIBRARY.hobgoblinInspire,
+    CHARACTER_SKILL_LIBRARY.hobgoblinGuts,
   ],
 }
 

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -13,6 +13,7 @@ export interface CharacterSkill {
   protectRearAllyNormalAttackMultiplier?: number
   rearAllyDamageMultiplier?: number
   coverLowHpAlly?: boolean
+  surviveLethalDamageAtHp1?: boolean
   grantsSpellId?: string
   spellChargeBonusForId?: string
   extraSpellCharges?: number


### PR DESCRIPTION
## 概要
- ホブゴブリンに種族スキル `鼓舞` と `気合い` を追加
- `鼓舞` と `後列防護` が複数いても最前列の1体分だけ適用されるように調整
- ボスのホブゴブリン敵データと関連テストを更新

## テスト
- `npm test -- --runInBand src/core/services/__tests__/CombatStats.test.ts src/shared/data/__tests__/characterSkills.test.ts`
