### PR TITLE
PT報酬倍率システムを追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -10,9 +10,14 @@ import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import { normalizePartyRewardMultipliers } from '@/shared/types'
 import type { Party, Goblin, ExpeditionRecord } from '@/shared/types'
 
 const MAX_PARTY_SLOTS = 6
+
+function formatMultiplier(value: number): string {
+  return value.toFixed(1)
+}
 
 interface MemberSlotProps {
   goblin?: Goblin
@@ -70,6 +75,11 @@ const PartyCard = memo(function PartyCard({
       .filter((g): g is Goblin => g !== undefined)
   }, [party.memberIds, goblins])
 
+  const partyRewardText = useMemo(() => {
+    const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
+    return `G ${formatMultiplier(multipliers.gold)}倍  レア ${formatMultiplier(multipliers.rare)}倍  称号 ${formatMultiplier(multipliers.title)}倍`
+  }, [party.rewardMultipliers])
+
   // 6スロット分の配列を作成
   const slots = useMemo(() => {
     const result: (Goblin | undefined)[] = []
@@ -91,6 +101,8 @@ const PartyCard = memo(function PartyCard({
             </View>
           )}
         </View>
+
+        <Text style={styles.partyRewardText}>{partyRewardText}</Text>
 
         <View style={styles.membersRow}>
           {slots.map((goblin, index) => (
@@ -494,6 +506,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     color: '#1F2937',
+  },
+  partyRewardText: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 12,
   },
   expeditionBadge: {
     backgroundColor: '#3B82F6',

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -8,6 +8,7 @@ import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import { normalizePartyRewardMultipliers } from '@/shared/types'
 import type { ExpeditionRequest, Goblin, Dungeon, Party } from '@/shared/types'
 
 type ReturnPolicy = ExpeditionRequest['returnPolicy']
@@ -25,6 +26,10 @@ const RETURN_POLICIES: { value: ReturnPolicy; label: string }[] = [
 function formatDungeonLabel(dungeon: Dungeon): string {
   if (dungeon.areaLevel === undefined) return dungeon.name
   return `${dungeon.name} / エリアLv.${dungeon.areaLevel}`
+}
+
+function formatMultiplier(value: number): string {
+  return value.toFixed(1)
 }
 
 interface MemberSlotProps {
@@ -118,6 +123,12 @@ export default function ExpeditionPreparationScreen() {
       .map(id => goblins.find(g => g.id === id))
       .filter((g): g is Goblin => g !== undefined)
   }, [party, goblins])
+
+  const partyRewardText = useMemo(() => {
+    if (!party) return ''
+    const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
+    return `G ${formatMultiplier(multipliers.gold)}倍  レア ${formatMultiplier(multipliers.rare)}倍  称号 ${formatMultiplier(multipliers.title)}倍`
+  }, [party])
 
   // 6スロット分の配列を作成
   const slots = useMemo(() => {
@@ -289,6 +300,7 @@ export default function ExpeditionPreparationScreen() {
           <Text style={styles.sectionTitle}>パーティ</Text>
           <View style={styles.card}>
             <Text style={styles.partyName}>{party.name}</Text>
+            <Text style={styles.partyRewardText}>{partyRewardText}</Text>
 
             <View style={styles.membersRow}>
               {slots.map((goblin, index) => (
@@ -531,6 +543,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     color: '#1F2937',
+    marginBottom: 6,
+  },
+  partyRewardText: {
+    fontSize: 13,
+    color: '#6B7280',
     marginBottom: 16,
   },
   membersRow: {

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -12,6 +12,7 @@ import type {
   PartyState,
   ExpeditionEndReason,
   AreaConfig,
+  PartyRewardMultipliers,
 } from '../../shared/types'
 import { getAreaConfig } from '../../shared/data/expeditionArea'
 import { getEnemyDatabase } from '../../shared/data/enemy'
@@ -19,6 +20,7 @@ import { getEquipmentTemplate, getEquipmentByDungeonLevel } from '../../shared/d
 import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
+import { normalizePartyRewardMultipliers } from '../../shared/types'
 
 /** 全エリア共通の宝箱ドロップ確率（敵1体ごと） */
 const DROP_CHANCE = 0.15
@@ -47,8 +49,13 @@ export class ExpeditionEngine {
     }
   }
 
-  public async generateExpedition(request: ExpeditionRequest, party: Goblin[]): Promise<ExpeditionReplay> {
+  public async generateExpedition(
+    request: ExpeditionRequest,
+    party: Goblin[],
+    rewardMultipliers?: PartyRewardMultipliers
+  ): Promise<ExpeditionReplay> {
     console.log('ExpeditionEngine: Starting generateExpedition', { request, partySize: party.length })
+    const normalizedRewardMultipliers = normalizePartyRewardMultipliers(rewardMultipliers)
     // ダンジョンIDからエリアIDにマッピング
     const dungeonToAreaMap: Record<string, string> = {
       "1": "forest_outskirts",
@@ -140,7 +147,12 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const treasureDrops = this.rollTreasureDrops(area.areaLevel, enemies.flat(), droppedTemplateIds)
+            const treasureDrops = this.rollTreasureDrops(
+              area.areaLevel,
+              enemies.flat(),
+              droppedTemplateIds,
+              normalizedRewardMultipliers
+            )
             if (treasureDrops.length > 0) {
               events.push({
                 type: "treasure",
@@ -196,7 +208,12 @@ export class ExpeditionEngine {
             }
 
             // 宝箱ドロップ判定（勝利時のみ）
-            const defaultTreasure = this.rollTreasureDrops(area.areaLevel, enemies.flat(), droppedTemplateIds)
+            const defaultTreasure = this.rollTreasureDrops(
+              area.areaLevel,
+              enemies.flat(),
+              droppedTemplateIds,
+              normalizedRewardMultipliers
+            )
             if (defaultTreasure.length > 0) {
               events.push({
                 type: "treasure",
@@ -260,7 +277,12 @@ export class ExpeditionEngine {
 
         // ボス戦勝利時の宝箱ドロップ判定
         if (bossCombat.outcome === 'win') {
-          const bossTreasure = this.rollTreasureDrops(area.areaLevel, bossEnemies.flat(), droppedTemplateIds)
+          const bossTreasure = this.rollTreasureDrops(
+            area.areaLevel,
+            bossEnemies.flat(),
+            droppedTemplateIds,
+            normalizedRewardMultipliers
+          )
           if (bossTreasure.length > 0) {
             events.push({
               type: "treasure",
@@ -289,7 +311,7 @@ export class ExpeditionEngine {
     }
 
     console.log('ExpeditionEngine: Generated events:', events.length)
-    const summary = this.calculateRewardSummary(events, partyState)
+    const summary = this.calculateRewardSummary(events, partyState, normalizedRewardMultipliers)
     console.log('ExpeditionEngine: Expedition complete', summary)
 
     return {
@@ -301,6 +323,7 @@ export class ExpeditionEngine {
         baseDurationSec: adjustedDuration,
         party: party.map(g => g.id.toString()),
         partySnapshot: party.map(g => ({ ...g })),
+        partyRewardMultipliers: normalizedRewardMultipliers,
         returnPolicy: request.returnPolicy,
         seed: this.seed
       },
@@ -529,8 +552,9 @@ export class ExpeditionEngine {
     dungeonLevel: number,
     enemies: Enemy[],
     droppedIds: Set<string>,
-    titleMultiplier: number = 1
+    rewardMultipliers?: PartyRewardMultipliers
   ): TreasureDrop[] {
+    const { title: titleMultiplier, rare: rareMultiplier } = normalizePartyRewardMultipliers(rewardMultipliers)
     const drops: TreasureDrop[] = []
     const expeditionDroppedIds = new Set(droppedIds)
     const pendingDroppedIds = new Set<string>()
@@ -562,7 +586,8 @@ export class ExpeditionEngine {
       if (!enemy.equipmentDrops) continue
       for (const drop of enemy.equipmentDrops) {
         if (expeditionDroppedIds.has(drop.templateId)) continue
-        if (this.rng() < drop.probability) {
+        const dropProbability = Math.min(1, drop.probability * rareMultiplier)
+        if (this.rng() < dropProbability) {
           const template = getEquipmentTemplate(drop.templateId)
           if (template) {
             // 称号を抽選
@@ -588,16 +613,21 @@ export class ExpeditionEngine {
     return drops
   }
 
-  private calculateRewardSummary(events: TimelineEvent[], partyState: PartyState[]): RewardSummary {
+  private calculateRewardSummary(
+    events: TimelineEvent[],
+    partyState: PartyState[],
+    rewardMultipliers?: PartyRewardMultipliers
+  ): RewardSummary {
+    const { gold: goldMultiplier } = normalizePartyRewardMultipliers(rewardMultipliers)
     let xpGained = 0
-    let goldGained = 0
+    let baseGoldGained = 0
     let maxFloorReached = 1
     const treasureDrops: TreasureDrop[] = []
 
     for (const event of events) {
       if (event.type === "battle" || event.type === "boss") {
         xpGained += event.xp
-        goldGained += event.enemy.gold
+        baseGoldGained += event.enemy.gold
         maxFloorReached = Math.max(maxFloorReached, event.floor)
       } else if (event.type === "floor_up") {
         maxFloorReached = Math.max(maxFloorReached, event.to)
@@ -616,6 +646,8 @@ export class ExpeditionEngine {
       event.reason !== undefined &&
       successReasons.has(event.reason)
     )
+
+    const goldGained = Math.floor(baseGoldGained * goldMultiplier)
 
     return {
       success,

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -1,0 +1,60 @@
+import { ExpeditionEngine } from '../ExpeditionEngine'
+import { DEFAULT_PARTY_REWARD_MULTIPLIERS } from '../../../shared/types'
+import type { TimelineEvent, PartyState } from '../../../shared/types'
+
+describe('ExpeditionEngine reward multipliers', () => {
+  it('goldMultiplier を報酬 gold に適用する', () => {
+    const engine = new ExpeditionEngine(1)
+    const events: TimelineEvent[] = [
+      { type: 'move_start', at: 0, floor: 1 },
+      {
+        type: 'battle',
+        at: 10,
+        floor: 1,
+        enemy: { id: 'e1', name: '敵1', lvl: 1, count: 1, gold: 10 },
+        combat: { rounds: 1, outcome: 'win', allyHPDelta: [0], enemyDefeated: 1 },
+        xp: 5,
+      },
+      {
+        type: 'boss',
+        at: 20,
+        floor: 2,
+        enemy: { id: 'b1', name: 'ボス', lvl: 2, count: 1, gold: 25 },
+        combat: { rounds: 2, outcome: 'win', allyHPDelta: [0], enemyDefeated: 1 },
+        xp: 20,
+      },
+      { type: 'return', at: 30, reason: 'completed' },
+    ]
+    const partyState: PartyState[] = [
+      {
+        id: '1',
+        name: 'テスト',
+        race: 'ゴブリン',
+        currentHP: 10,
+        maxHP: 10,
+        baseHP: 10,
+        atk: 5,
+        def: 5,
+        spd: 5,
+        sp: 5,
+        attackCount: 1,
+        accuracy: 10,
+        evasion: 5,
+        isKO: false,
+        isDead: false,
+        mods: [],
+        skills: [],
+        factors: [],
+        level: 1,
+        avatar: 'test.png',
+      },
+    ]
+
+    const summary = (engine as any).calculateRewardSummary(events, partyState, {
+      ...DEFAULT_PARTY_REWARD_MULTIPLIERS,
+      gold: 1.5,
+    })
+
+    expect(summary.goldGained).toBe(52)
+  })
+})

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -1,6 +1,6 @@
 import { ExpeditionEngine } from '../ExpeditionEngine'
 import { getEquipmentByDungeonLevel, getEquipmentTemplate } from '../../../shared/data/equipmentPoolLoader'
-import type { Enemy } from '../../../shared/types'
+import type { Enemy, PartyRewardMultipliers } from '../../../shared/types'
 
 /**
  * ExpeditionEngine の private メソッド rollTreasureDrops をテストするため、
@@ -16,10 +16,10 @@ function callRollTreasureDrops(
   dungeonLevel: number,
   enemies: Enemy[],
   droppedIds: Set<string>,
-  titleMultiplier?: number
+  rewardMultipliers?: Partial<PartyRewardMultipliers>
 ) {
   return (engine as any).rollTreasureDrops(
-    dungeonLevel, enemies, droppedIds, titleMultiplier
+    dungeonLevel, enemies, droppedIds, rewardMultipliers
   )
 }
 
@@ -152,7 +152,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < 5000; seed++) {
         const engine = createEngine(seed * 1000)
         const result = callRollTreasureDrops(
-          engine, 1, [createDummyEnemy()], new Set(), 99
+          engine, 1, [createDummyEnemy()], new Set(), { title: 99 }
         )
         if (result.length > 0 && result[0].titleId !== undefined) {
           expect(typeof result[0].titleId).toBe('string')
@@ -239,7 +239,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < iterations; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1, [createDummyEnemy()], new Set(), 1
+          engine, 1, [createDummyEnemy()], new Set(), { title: 1 }
         )
         for (const drop of result) {
           totalDrops++
@@ -260,7 +260,7 @@ describe('rollTreasureDrops', () => {
       for (let seed = 0; seed < iterations; seed++) {
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1, [createDummyEnemy()], new Set(), 99
+          engine, 1, [createDummyEnemy()], new Set(), { title: 99 }
         )
         for (const drop of result) {
           totalDrops++
@@ -312,7 +312,7 @@ describe('rollTreasureDrops', () => {
 
         const engine = createEngine(seed)
         const result = callRollTreasureDrops(
-          engine, 1, [enemy], new Set(), 99
+          engine, 1, [enemy], new Set(), { title: 99 }
         )
 
         const enemyDrop = result.find((d: any) => d.templateId === 'sword_cypress_stick')
@@ -374,6 +374,44 @@ describe('rollTreasureDrops', () => {
 
       expect(firstBattle.filter((d: any) => d.templateId === 'sword_cypress_stick')).toHaveLength(2)
       expect(secondBattle.filter((d: any) => d.templateId === 'sword_cypress_stick')).toHaveLength(0)
+    })
+
+    it('rareMultiplier が敵個別ドロップ確率に乗る', () => {
+      const enemy = createDummyEnemy({
+        equipmentDrops: [
+          { templateId: 'sword_cypress_stick', probability: 0.2 },
+        ],
+      })
+
+      let baseDrops = 0
+      let boostedDrops = 0
+      const iterations = 1000
+
+      for (let seed = 0; seed < iterations; seed++) {
+        const baseResult = callRollTreasureDrops(
+          createEngine(seed),
+          1,
+          [enemy],
+          new Set(),
+          { rare: 1 }
+        )
+        const boostedResult = callRollTreasureDrops(
+          createEngine(seed),
+          1,
+          [enemy],
+          new Set(),
+          { rare: 2 }
+        )
+
+        if (baseResult.some((d: any) => d.templateId === 'sword_cypress_stick')) {
+          baseDrops++
+        }
+        if (boostedResult.some((d: any) => d.templateId === 'sword_cypress_stick')) {
+          boostedDrops++
+        }
+      }
+
+      expect(boostedDrops).toBeGreaterThan(baseDrops)
     })
   })
 })

--- a/goblin_native/src/core/usecases/CreatePartyUseCase.ts
+++ b/goblin_native/src/core/usecases/CreatePartyUseCase.ts
@@ -1,4 +1,7 @@
-import type { ExpeditionRequest, Party } from '../../shared/types'
+import {
+  normalizePartyRewardMultipliers,
+} from '../../shared/types'
+import type { ExpeditionRequest, Party, PartyRewardMultipliers } from '../../shared/types'
 import type { IPartyRepository } from '../repositories'
 
 export interface CreatePartyInput {
@@ -6,6 +9,7 @@ export interface CreatePartyInput {
   memberIds: number[]
   dungeonId?: string
   returnPolicy?: ExpeditionRequest['returnPolicy']
+  rewardMultipliers?: Partial<PartyRewardMultipliers>
 }
 
 export class CreatePartyUseCase {
@@ -29,6 +33,7 @@ export class CreatePartyUseCase {
       status: 'idle',
       dungeonId: input.dungeonId,
       returnPolicy: input.returnPolicy,
+      rewardMultipliers: normalizePartyRewardMultipliers(input.rewardMultipliers),
     }
 
     await this.partyRepository.saveParty(party)

--- a/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
@@ -4,6 +4,7 @@ import type {
   Goblin,
   Party,
 } from '../../shared/types'
+import { normalizePartyRewardMultipliers } from '../../shared/types'
 import { GoblinEntity, PartyEntity } from '../domain'
 import type { IGoblinRepository, IPartyRepository } from '../repositories'
 import { ExpeditionEngine } from '../services'
@@ -44,7 +45,11 @@ export class StartExpeditionUseCase {
       throw new Error('遠征可能なメンバーがいません')
     }
 
-    const replay = await this.expeditionEngine.generateExpedition(request, goblins)
+    const replay = await this.expeditionEngine.generateExpedition(
+      request,
+      goblins,
+      normalizePartyRewardMultipliers(party.rewardMultipliers)
+    )
     await this.partyRepository.updatePartyStatus(partyId, 'expedition')
     return replay
   }

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -1,6 +1,7 @@
 import { CompleteExpeditionUseCase } from '../CompleteExpeditionUseCase'
 import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../../repositories'
 import { getDefaultSkillsForRace } from '../../../shared/data/raceSkills'
+import { DEFAULT_PARTY_REWARD_MULTIPLIERS } from '../../../shared/types'
 import type { Goblin, GoblinStats, Party, BaseState, ExpeditionReplay, TimelineEvent } from '../../../shared/types'
 
 // --- テストヘルパー ---
@@ -72,6 +73,7 @@ function createTestReplay(overrides: Partial<ExpeditionReplay> = {}): Expedition
       floors: 3,
       baseDurationSec: 60,
       party: ['1'],
+      partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
       returnPolicy: 'never',
       seed: 12345,
     },
@@ -168,7 +170,17 @@ describe('CompleteExpeditionUseCase', () => {
         { type: 'return', at: 60, reason: 'completed' },
       ]
       const replay = createTestReplay({
-        meta: { expeditionId: 'exp-1', areaId: 'dungeon_1', areaName: 'テスト', floors: 3, baseDurationSec: 60, party: ['1', '2'], returnPolicy: 'never', seed: 12345 },
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'dungeon_1',
+          areaName: 'テスト',
+          floors: 3,
+          baseDurationSec: 60,
+          party: ['1', '2'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'never',
+          seed: 12345,
+        },
         events,
         summary: { success: true, maxFloorReached: 3, xpGained: 100, goldGained: 50, casualties: ['1'] },
       })
@@ -329,7 +341,17 @@ describe('CompleteExpeditionUseCase', () => {
         { type: 'return', at: 60, reason: 'completed' },
       ]
       const replay = createTestReplay({
-        meta: { expeditionId: 'exp-1', areaId: 'dungeon_1', areaName: 'テスト', floors: 3, baseDurationSec: 60, party: ['1', '2', '3'], returnPolicy: 'never', seed: 12345 },
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'dungeon_1',
+          areaName: 'テスト',
+          floors: 3,
+          baseDurationSec: 60,
+          party: ['1', '2', '3'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'never',
+          seed: 12345,
+        },
         events,
         summary: { success: true, maxFloorReached: 3, xpGained: 9, goldGained: 0, casualties: [] },
       })
@@ -364,7 +386,17 @@ describe('CompleteExpeditionUseCase', () => {
         { type: 'return', at: 60, reason: 'completed' },
       ]
       const replay = createTestReplay({
-        meta: { expeditionId: 'exp-1', areaId: 'dungeon_1', areaName: 'テスト', floors: 3, baseDurationSec: 60, party: ['1', '2', '3'], returnPolicy: 'never', seed: 12345 },
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'dungeon_1',
+          areaName: 'テスト',
+          floors: 3,
+          baseDurationSec: 60,
+          party: ['1', '2', '3'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'never',
+          seed: 12345,
+        },
         events,
         summary: { success: true, maxFloorReached: 3, xpGained: 17, goldGained: 0, casualties: ['1'] },
       })

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -6,9 +6,10 @@ import * as SQLite from 'expo-sqlite'
 import { migrateV1 } from './migrations/v1'
 import { migrateV2 } from './migrations/v2'
 import { migrateV3 } from './migrations/v3'
+import { migrateV4 } from './migrations/v4'
 
 const DB_NAME = 'goblin_kingdom.db'
-const CURRENT_SCHEMA_VERSION = 3
+const CURRENT_SCHEMA_VERSION = 4
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -90,6 +91,13 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
     await migrateV3(database)
     await setSchemaVersion(database, 3)
     console.log('[DB] Migration v3 completed')
+  }
+
+  if (currentVersion < 4) {
+    console.log('[DB] Running migration v4...')
+    await migrateV4(database)
+    await setSchemaVersion(database, 4)
+    console.log('[DB] Migration v4 completed')
   }
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v4.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v4.ts
@@ -1,0 +1,27 @@
+import type * as SQLite from 'expo-sqlite'
+
+async function addPartyMultiplierColumn(
+  database: SQLite.SQLiteDatabase,
+  columnName: string
+): Promise<void> {
+  try {
+    await database.execAsync(
+      `ALTER TABLE parties ADD COLUMN ${columnName} REAL NOT NULL DEFAULT 1.0`
+    )
+  } catch {
+    // 既に列がある場合は何もしない
+  }
+}
+
+export const migrateV4 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  await addPartyMultiplierColumn(database, 'gold_multiplier')
+  await addPartyMultiplierColumn(database, 'rare_multiplier')
+  await addPartyMultiplierColumn(database, 'title_multiplier')
+
+  await database.runAsync(
+    `UPDATE parties
+     SET gold_multiplier = COALESCE(gold_multiplier, 1.0),
+         rare_multiplier = COALESCE(rare_multiplier, 1.0),
+         title_multiplier = COALESCE(title_multiplier, 1.0)`
+  )
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -59,6 +59,9 @@ export const SCHEMA = {
       dungeon_id TEXT,
       target_floor INTEGER,
       return_policy TEXT,
+      gold_multiplier REAL NOT NULL DEFAULT 1.0,
+      rare_multiplier REAL NOT NULL DEFAULT 1.0,
+      title_multiplier REAL NOT NULL DEFAULT 1.0,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -2,6 +2,9 @@
  * SQLiteを使用したパーティリポジトリ実装
  * DBから直接読み書きする設計
  */
+import {
+  normalizePartyRewardMultipliers,
+} from '../../shared/types'
 import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
 import type { IPartyRepository } from '../../core/repositories/IPartyRepository'
 import { getDatabase } from '../database'
@@ -14,6 +17,9 @@ interface PartyRow {
   dungeon_id: string | null
   target_floor: number | null
   return_policy: string | null
+  gold_multiplier: number | null
+  rare_multiplier: number | null
+  title_multiplier: number | null
   created_at: string
   updated_at: string
 }
@@ -42,10 +48,12 @@ export class SQLitePartyRepository implements IPartyRepository {
 
   async saveParty(party: Party): Promise<void> {
     const db = await getDatabase()
+    const rewardMultipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
     await db.runAsync(
       `INSERT OR REPLACE INTO parties
-       (id, name, member_ids_json, status, dungeon_id, target_floor, return_policy, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+       (id, name, member_ids_json, status, dungeon_id, target_floor, return_policy,
+        gold_multiplier, rare_multiplier, title_multiplier, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
       [
         party.id,
         party.name,
@@ -54,6 +62,9 @@ export class SQLitePartyRepository implements IPartyRepository {
         party.dungeonId ?? null,
         party.targetFloor ?? null,
         party.returnPolicy ?? null,
+        rewardMultipliers.gold,
+        rewardMultipliers.rare,
+        rewardMultipliers.title,
       ]
     )
   }
@@ -110,6 +121,11 @@ export class SQLitePartyRepository implements IPartyRepository {
       dungeonId: row.dungeon_id ?? undefined,
       targetFloor: row.target_floor ?? undefined,
       returnPolicy: (row.return_policy as ExpeditionRequest['returnPolicy']) ?? undefined,
+      rewardMultipliers: normalizePartyRewardMultipliers({
+        gold: row.gold_multiplier ?? undefined,
+        rare: row.rare_multiplier ?? undefined,
+        title: row.title_multiplier ?? undefined,
+      }),
     }
   }
 }

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -2,6 +2,7 @@ import type { EnemySnap } from "./Enemy"
 import type { CombatReplay } from "./Battle"
 import type { EquipmentTitleId } from "./EquipmentTitle"
 import type { Goblin } from "./Goblin"
+import type { PartyRewardMultipliers } from "./Party"
 
 export interface ExpeditionRequest {
   partyId: string
@@ -30,6 +31,7 @@ export interface ExpeditionReplay {
     baseDurationSec: number
     party: string[]
     partySnapshot?: Goblin[]
+    partyRewardMultipliers: PartyRewardMultipliers
     returnPolicy: ExpeditionRequest["returnPolicy"]
     seed: number
     serverCommitHash?: string

--- a/goblin_native/src/shared/types/Party.ts
+++ b/goblin_native/src/shared/types/Party.ts
@@ -5,6 +5,35 @@ import type { LearnedSpell } from "./Spell"
 
 export type PartyStatus = "idle" | "expedition"
 
+export interface PartyRewardMultipliers {
+  gold: number
+  rare: number
+  title: number
+}
+
+export const DEFAULT_PARTY_REWARD_MULTIPLIERS: PartyRewardMultipliers = {
+  gold: 1.0,
+  rare: 1.0,
+  title: 1.0,
+}
+
+export function normalizePartyRewardMultipliers(
+  multipliers?: Partial<PartyRewardMultipliers> | null
+): PartyRewardMultipliers {
+  const normalize = (value: number | undefined, fallback: number): number => {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      return fallback
+    }
+    return value
+  }
+
+  return {
+    gold: normalize(multipliers?.gold, DEFAULT_PARTY_REWARD_MULTIPLIERS.gold),
+    rare: normalize(multipliers?.rare, DEFAULT_PARTY_REWARD_MULTIPLIERS.rare),
+    title: normalize(multipliers?.title, DEFAULT_PARTY_REWARD_MULTIPLIERS.title),
+  }
+}
+
 export type Party = {
   id: number
   name: string
@@ -13,6 +42,7 @@ export type Party = {
   dungeonId?: string
   targetFloor?: number | null  // null = どこまでも進む
   returnPolicy?: ExpeditionRequest["returnPolicy"]
+  rewardMultipliers?: PartyRewardMultipliers
 }
 
 export interface PartyState {

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -2,7 +2,8 @@
 export type { Goblin, GoblinStats, GoblinJob } from "./Goblin"
 
 // Party related types
-export type { Party, PartyStatus, PartyState } from "./Party"
+export type { Party, PartyStatus, PartyState, PartyRewardMultipliers } from "./Party"
+export { DEFAULT_PARTY_REWARD_MULTIPLIERS, normalizePartyRewardMultipliers } from "./Party"
 
 // Enemy related types
 export type { Enemy, EnemyPattern, EnemyDatabase, EnemySnap, EquipmentDropConfig } from "./Enemy"


### PR DESCRIPTION
## 概要
- パーティごとの GOLD / レア / 称号倍率を追加
- 倍率を SQLite に保存し、遠征開始時のスナップショットをリプレイに保持
- 編成画面と冒険準備画面の PT カードに倍率表示を追加

## 変更内容
- `Party.rewardMultipliers` を追加し、未設定時はすべて `1.0` 倍で正規化
- `parties` テーブルに倍率カラムを追加する migration v4 を追加
- 遠征生成時に倍率を反映
  - GOLD: 獲得 gold に適用
  - レア: 敵個別ドロップ確率に適用
  - 称号: 装備称号抽選に適用
- リプレイ `meta` に遠征開始時の倍率を保存
- PT カードに `G x.x倍 レア x.x倍 称号 x.x倍` を表示

## テスト
- `npm test -- --runInBand`
- `npx tsc --noEmit`

## 残タスク
- 倍率を上昇させる導線・UI は未実装