### PR TITLE
fix: 全タブで所持ゴールドを右下表示に統一

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ import ListIcon from '../../assets/list.svg'
 import HenseiIcon from '../../assets/hensei.svg'
 import BaseIcon from '../../assets/base.svg'
 import { CurrentTimeBadge } from '@/presentation/components/CurrentTimeBadge'
+import { GoldBadge } from '@/presentation/components/GoldBadge'
 
 interface TabIconProps {
   Icon: React.FC<{ width: number; height: number; fill?: string }>
@@ -93,6 +94,7 @@ export default function TabLayout() {
       />
     </Tabs>
     <CurrentTimeBadge bottom={baseHeight + safeAreaPadding + 8} />
+    <GoldBadge bottom={baseHeight + safeAreaPadding + 8} />
     </View>
   )
 }

--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -1,7 +1,7 @@
 import { View, Text, ScrollView, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
-import { useBaseStore, selectRank, selectMaxParties, selectMaxGoblins, selectIvBonus, selectGold } from '@/presentation/stores/useBaseStore'
+import { useBaseStore, selectRank, selectMaxParties, selectMaxGoblins, selectIvBonus } from '@/presentation/stores/useBaseStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 
 const BASE_LOCATION_NAMES: Record<number, string> = {
@@ -20,7 +20,6 @@ export default function BaseManagementScreen() {
   const maxParties = useBaseStore(selectMaxParties)
   const maxGoblins = useBaseStore(selectMaxGoblins)
   const ivBonus = useBaseStore(selectIvBonus)
-  const gold = useBaseStore(selectGold)
   const goblins = useGoblinStore((state) => state.goblins)
   const baseLocationName = BASE_LOCATION_NAMES[rank] ?? '未設定'
 
@@ -68,11 +67,7 @@ export default function BaseManagementScreen() {
             <Text style={styles.menuButtonArrow}>›</Text>
           </TouchableOpacity>
         </View>
-
       </ScrollView>
-      <View style={styles.goldBadge} pointerEvents="none">
-        <Text style={styles.goldBadgeText}>{gold}G</Text>
-      </View>
     </SafeAreaView>
   )
 }
@@ -192,18 +187,5 @@ const styles = StyleSheet.create({
     fontSize: 26,
     lineHeight: 26,
     color: '#9CA3AF',
-  },
-  goldBadge: {
-    position: 'absolute',
-    left: 12,
-    bottom: 12,
-    backgroundColor: 'rgba(17, 24, 39, 0.8)',
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-  },
-  goldBadgeText: {
-    fontSize: 11,
-    color: '#F9FAFB',
   },
 })

--- a/goblin_native/src/presentation/components/GoldBadge.tsx
+++ b/goblin_native/src/presentation/components/GoldBadge.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { selectGold, useBaseStore } from '@/presentation/stores/useBaseStore'
+
+interface GoldBadgeProps {
+  bottom: number
+}
+
+export const GoldBadge = memo(function GoldBadge({ bottom }: GoldBadgeProps) {
+  const gold = useBaseStore(selectGold)
+
+  return (
+    <View style={[styles.goldBadge, { bottom }]} pointerEvents="none">
+      <Text style={styles.goldText}>{gold.toLocaleString()}G</Text>
+    </View>
+  )
+})
+
+const styles = StyleSheet.create({
+  goldBadge: {
+    position: 'absolute',
+    right: 12,
+    backgroundColor: 'rgba(17, 24, 39, 0.8)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  goldText: {
+    fontSize: 11,
+    color: '#F9FAFB',
+  },
+})


### PR DESCRIPTION
## 概要
- 所持ゴールド表示をタブ共通レイアウトへ移設
- 拠点画面だけに出ていた表示を削除し、全タブで右下表示に統一
- ゴールド表示用の共通コンポーネントを追加

## テスト
- npx tsc --noEmit