### PR TITLE
style(formation): tighten PT card spacing

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -77,7 +77,7 @@ const PartyCard = memo(function PartyCard({
 
   const partyRewardText = useMemo(() => {
     const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
-    return `G ${formatMultiplier(multipliers.gold)}倍  レア ${formatMultiplier(multipliers.rare)}倍  称号 ${formatMultiplier(multipliers.title)}倍`
+    return `G${formatMultiplier(multipliers.gold)}倍　レア${formatMultiplier(multipliers.rare)}倍　称号${formatMultiplier(multipliers.title)}倍`
   }, [party.rewardMultipliers])
 
   // 6スロット分の配列を作成
@@ -444,8 +444,8 @@ const styles = StyleSheet.create({
   partyCard: {
     backgroundColor: '#FFFFFF',
     borderRadius: 12,
-    padding: 16,
-    marginBottom: 16,
+    padding: 12,
+    marginBottom: 12,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
@@ -500,17 +500,17 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 16,
+    marginBottom: 6,
   },
   partyName: {
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 'bold',
     color: '#1F2937',
   },
   partyRewardText: {
     fontSize: 13,
     color: '#6B7280',
-    marginBottom: 12,
+    marginBottom: 6,
   },
   expeditionBadge: {
     backgroundColor: '#3B82F6',

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -127,7 +127,7 @@ export default function ExpeditionPreparationScreen() {
   const partyRewardText = useMemo(() => {
     if (!party) return ''
     const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
-    return `G ${formatMultiplier(multipliers.gold)}倍  レア ${formatMultiplier(multipliers.rare)}倍  称号 ${formatMultiplier(multipliers.title)}倍`
+    return `G${formatMultiplier(multipliers.gold)}倍　レア${formatMultiplier(multipliers.rare)}倍　称号${formatMultiplier(multipliers.title)}倍`
   }, [party])
 
   // 6スロット分の配列を作成
@@ -532,7 +532,7 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: '#FFFFFF',
     borderRadius: 12,
-    padding: 16,
+    padding: 12,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.1,
@@ -540,22 +540,22 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   partyName: {
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: 'bold',
     color: '#1F2937',
-    marginBottom: 6,
+    marginBottom: 4,
   },
   partyRewardText: {
     fontSize: 13,
     color: '#6B7280',
-    marginBottom: 16,
+    marginBottom: 6,
   },
   membersRow: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
     flexWrap: 'wrap',
     gap: 8,
-    marginBottom: 16,
+    marginBottom: 12,
   },
   memberSlot: {
     alignItems: 'center',


### PR DESCRIPTION
## 概要
- PTカードのPT名フォントサイズと上下余白を詰めました
- 冒険準備画面のパーティカードも同じ密度に揃えました
- 倍率表示を `Gx.x倍　レアx.x倍　称号x.x倍` に統一しました

## テスト
- 未実施（表示調整のため）