### PR TITLE
[codex] Add party info and row bonus

### DIFF
--- a/goblin_native/app/(tabs)/formation/_layout.tsx
+++ b/goblin_native/app/(tabs)/formation/_layout.tsx
@@ -31,6 +31,13 @@ export default function FormationLayout() {
         }}
       />
       <Stack.Screen
+        name="party-info"
+        options={{
+          title: 'PTの情報',
+          presentation: 'card',
+        }}
+      />
+      <Stack.Screen
         name="equipment"
         options={{
           title: '装備変更',

--- a/goblin_native/app/(tabs)/formation/party-info.tsx
+++ b/goblin_native/app/(tabs)/formation/party-info.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Stack, router, useLocalSearchParams } from 'expo-router'
+import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
+import { getExpForNextLevel } from '@/core/services/ExperienceSystem'
+import { getRowDamageMultiplierFromSkills, getUniqueSkillsById } from '@/shared/data/characterSkills'
+import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
+import { EquipmentService } from '@/core/services/EquipmentService'
+import type { CharacterSkill, Goblin, Party } from '@/shared/types'
+
+function getExpRateText(): string {
+  return '1.00倍'
+}
+
+function getAttackTypeLabel(skills: CharacterSkill[]): string {
+  const uniqueSkills = getUniqueSkillsById(skills)
+  const hasMelee = uniqueSkills.some((skill) => skill.enablesMeleeRowDamagePenalty)
+  const hasRanged = uniqueSkills.some((skill) => skill.enablesRangedRowDamagePenalty)
+
+  if (hasMelee && hasRanged) return '遠距離武器'
+  if (hasMelee) return '近接武器'
+  if (hasRanged) return '遠距離武器'
+  return 'スキルなし'
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
+export default function PartyInfoScreen() {
+  const { partyId } = useLocalSearchParams<{ partyId: string }>()
+  const { parties, isLoading: partiesLoading, getPartyById } = usePartyStore()
+  const goblins = useGoblinStore((state) => state.goblins)
+  const goblinsLoading = useGoblinStore((state) => state.isLoading)
+  const [party, setParty] = useState<Party | null>(null)
+  const [memberSkillsById, setMemberSkillsById] = useState<Record<number, CharacterSkill[]>>({})
+
+  useEffect(() => {
+    if (!partyId) {
+      setParty(null)
+      return
+    }
+
+    void getPartyById(parseInt(partyId, 10))
+      .then(setParty)
+      .catch(() => setParty(null))
+  }, [partyId, parties, getPartyById])
+
+  const partyMembers = useMemo(() => {
+    if (!party) return []
+
+    return party.memberIds
+      .map((id) => goblins.find((goblin) => goblin.id === id))
+      .filter((goblin): goblin is Goblin => goblin !== undefined)
+  }, [goblins, party])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadMemberSkills = async (): Promise<void> => {
+      if (partyMembers.length === 0) {
+        setMemberSkillsById({})
+        return
+      }
+
+      const repository = SQLiteEquipmentRepository.getInstance()
+      const entries = await Promise.all(
+        partyMembers.map(async (goblin) => {
+          const equippedItems = await repository.getByGoblinId(goblin.id)
+          const equipmentSkills = EquipmentService.collectGrantedSkills(equippedItems)
+          return [goblin.id, [...goblin.skills, ...equipmentSkills]] as const
+        }),
+      )
+
+      if (cancelled) return
+
+      setMemberSkillsById(
+        entries.reduce<Record<number, CharacterSkill[]>>((acc, [goblinId, skills]) => {
+          acc[goblinId] = [...skills]
+          return acc
+        }, {}),
+      )
+    }
+
+    void loadMemberSkills()
+
+    return () => {
+      cancelled = true
+    }
+  }, [partyMembers])
+
+  const handleBack = useCallback(() => {
+    router.back()
+  }, [])
+
+  if (partiesLoading || goblinsLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#10B981" />
+        <Text style={styles.loadingText}>読み込み中...</Text>
+      </View>
+    )
+  }
+
+  if (!party) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={styles.errorText}>パーティが見つかりません</Text>
+        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+          <Text style={styles.backButtonText}>戻る</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: 'PTの情報',
+          headerLeft: () => (
+            <TouchableOpacity onPress={handleBack}>
+              <Text style={styles.headerButton}>← 戻る</Text>
+            </TouchableOpacity>
+          ),
+        }}
+      />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <Text style={styles.partyName}>{party.name}</Text>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Lv / 次のLvに必要な経験値</Text>
+          {partyMembers.map((goblin) => {
+            const expForNext = getExpForNextLevel(goblin.level)
+            const remainingExp = Math.max(0, expForNext - goblin.experience)
+
+            return (
+              <View key={goblin.id} style={styles.memberRow}>
+                <Image source={getGoblinDisplayImage(goblin)} style={styles.avatar} />
+                <View style={styles.memberInfo}>
+                  <Text style={styles.memberName}>{goblin.name}</Text>
+                  <Text style={styles.memberSubText}>
+                    {`Lv${goblin.level} 次のLvまで ${remainingExp} (${getExpRateText()})`}
+                  </Text>
+                </View>
+              </View>
+            )
+          })}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>隊列による攻撃能力補正</Text>
+          {partyMembers.map((goblin, index) => {
+            const memberSkills = memberSkillsById[goblin.id] ?? goblin.skills
+            const multiplier = getRowDamageMultiplierFromSkills(memberSkills, index)
+            const attackTypeLabel = getAttackTypeLabel(memberSkills)
+
+            return (
+              <View key={`row-${goblin.id}`} style={styles.memberRow}>
+                <Image source={getGoblinDisplayImage(goblin)} style={styles.avatar} />
+                <View style={styles.attackInfoRow}>
+                  <Text style={styles.memberName}>{goblin.name}</Text>
+                  <Text style={styles.attackModifierText}>
+                    {`補正: ${formatPercent(multiplier)} (${attackTypeLabel})`}
+                  </Text>
+                </View>
+              </View>
+            )
+          })}
+        </View>
+      </ScrollView>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+  },
+  content: {
+    padding: 16,
+    gap: 16,
+    paddingBottom: 88,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F3F4F6',
+    padding: 24,
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#111827',
+  },
+  backButton: {
+    backgroundColor: '#10B981',
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  headerButton: {
+    color: '#10B981',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  partyName: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#111827',
+    paddingHorizontal: 4,
+  },
+  section: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 2,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+  },
+  memberInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  memberName: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  memberSubText: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+  attackInfoRow: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  attackModifierText: {
+    flexShrink: 1,
+    textAlign: 'right',
+    fontSize: 13,
+    color: '#374151',
+  },
+})

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -164,6 +164,13 @@ export default function ExpeditionPreparationScreen() {
     })
   }, [partyId])
 
+  const handleOpenPartyInfo = useCallback(() => {
+    router.push({
+      pathname: '/formation/party-info',
+      params: { partyId },
+    })
+  }, [partyId])
+
   const handleOpenEquipmentList = useCallback(() => {
     router.push({
       pathname: '/formation/equipment-list',
@@ -331,14 +338,16 @@ export default function ExpeditionPreparationScreen() {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>パーティ</Text>
           <View style={styles.card}>
-            <Text style={styles.partyName}>{party.name}</Text>
-            <Text style={styles.partyRewardText}>{partyRewardText}</Text>
+            <TouchableOpacity style={styles.partyInfoButton} onPress={handleOpenPartyInfo} activeOpacity={0.8}>
+              <Text style={styles.partyName}>{party.name}</Text>
+              <Text style={styles.partyRewardText}>{partyRewardText}</Text>
 
-            <View style={styles.membersRow}>
-              {slots.map((goblin, index) => (
-                <MemberSlot key={index} goblin={goblin} isEmpty={!goblin} slotSize={slotSize} avatarSize={avatarSize} />
-              ))}
-            </View>
+              <View style={styles.membersRow}>
+                {slots.map((goblin, index) => (
+                  <MemberSlot key={index} goblin={goblin} isEmpty={!goblin} slotSize={slotSize} avatarSize={avatarSize} />
+                ))}
+              </View>
+            </TouchableOpacity>
 
             <TouchableOpacity style={styles.editButton} onPress={handleEditParty}>
               <Text style={styles.editButtonText}>メンバーを変更する</Text>
@@ -629,6 +638,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 2,
     elevation: 2,
+  },
+  partyInfoButton: {
+    marginBottom: 4,
   },
   partyName: {
     fontSize: 14,

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -6,6 +6,7 @@ import {
   getLearnedSpellsFromSkills,
   getPhysicalDamageReductionFromSkills,
   getRearProtectionMultiplierFromSkills,
+  getRowDamageMultiplierFromSkills,
   hasCoverLowHpAllySkill,
   hasSurviveLethalDamageAtHp1Skill,
 } from '../../shared/data/characterSkills'
@@ -312,6 +313,7 @@ export class BattleSystem {
               unit,
               unit.isAlly ? allyUnits : enemyUnits,
             )
+            const rowDamageMultiplier = getRowDamageMultiplierFromSkills(unit.skills, unit.row)
 
             // スキル由来の物理ダメージ軽減を適用
             const reductionFactor = 1 - target.damageReduction / 100
@@ -319,7 +321,7 @@ export class BattleSystem {
             const protectionFactor = this.getRearGuardReductionFactor(target, allyUnits)
             const damage = Math.max(
               1,
-              Math.floor((baseDamage * dmgMod * rearDamageMultiplier + additionalDamage) * reductionFactor * physicalReductionFactor * protectionFactor),
+              Math.floor((baseDamage * dmgMod * rearDamageMultiplier * rowDamageMultiplier + additionalDamage) * reductionFactor * physicalReductionFactor * protectionFactor),
             )
 
             this.applyDamage(target, damage)

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -5,6 +5,7 @@ import { ExpeditionEngine } from '../ExpeditionEngine'
 import { getDefaultSkillsForRace } from '../../../shared/data/raceSkills'
 import { getBloodlineCombatStats } from '../../../shared/data/equipmentConfig'
 import { EquipmentService } from '../EquipmentService'
+import { getEquipmentTemplate } from '../../../shared/data/equipmentPoolLoader'
 import type { Goblin, Enemy } from '../../../shared/types'
 
 /**
@@ -314,6 +315,18 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
     EquipmentService.unequip(equipment, goblin)
 
     expect(goblin.skills.some((skill) => skill.statBonuses?.attackCount === 8)).toBe(false)
+  })
+
+  it('melee武器には[武器]近距離攻撃スキルが付与される', () => {
+    const template = getEquipmentTemplate('sword_cypress_stick')
+
+    expect(template?.grantedSkills?.some((skill) => skill.id === 'weapon_melee_attack')).toBe(true)
+  })
+
+  it('ranged武器には[武器]遠距離攻撃スキルが付与される', () => {
+    const template = getEquipmentTemplate('bow_short')
+
+    expect(template?.grantedSkills?.some((skill) => skill.id === 'weapon_ranged_attack')).toBe(true)
   })
 })
 
@@ -787,6 +800,125 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const plainDamage = plainResult.detailedLog.find((log) => log.action === 'マジックアロー' && !log.isAlly)!.targets[0].totalDamage
 
     expect(reducedDamage).toBe(plainDamage)
+  })
+
+  it('近距離攻撃持ちは後列ほど通常攻撃ダメージが下がる', () => {
+    const enemy = [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]]
+    const frontAttacker = createTestGoblin({
+      id: 1,
+      skills: [{ id: 'weapon_melee_attack', name: '[武器]近距離攻撃', enablesMeleeRowDamagePenalty: true }],
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const rearAttacker = createTestGoblin({
+      id: 2,
+      skills: [{ id: 'weapon_melee_attack', name: '[武器]近距離攻撃', enablesMeleeRowDamagePenalty: true }],
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+
+    const frontResult = new BattleSystem().executeBattle([frontAttacker], [100], enemy, createSeededRng(21), 1)
+    const rearResult = new BattleSystem().executeBattle(
+      [
+        createTestGoblin({ id: 99, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 98, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 97, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 96, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 95, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        rearAttacker,
+      ],
+      [1, 1, 1, 1, 1, 100],
+      [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]],
+      createSeededRng(21),
+      1,
+    )
+
+    const frontDamage = frontResult.detailedLog.find((log) => log.actorId === '1' && log.action === '通常攻撃')!.targets[0].totalDamage
+    const rearDamage = rearResult.detailedLog.find((log) => log.actorId === '2' && log.action === '通常攻撃')!.targets[0].totalDamage
+
+    expect(rearDamage).toBeLessThan(frontDamage)
+  })
+
+  it('遠距離攻撃持ちは後列ほど通常攻撃ダメージが上がる', () => {
+    const frontAttacker = createTestGoblin({
+      id: 1,
+      skills: [{ id: 'weapon_ranged_attack', name: '[武器]遠距離攻撃', enablesRangedRowDamagePenalty: true }],
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const rearAttacker = createTestGoblin({
+      id: 2,
+      skills: [{ id: 'weapon_ranged_attack', name: '[武器]遠距離攻撃', enablesRangedRowDamagePenalty: true }],
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+
+    const frontResult = new BattleSystem().executeBattle(
+      [frontAttacker],
+      [100],
+      [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]],
+      createSeededRng(22),
+      1,
+    )
+    const rearResult = new BattleSystem().executeBattle(
+      [
+        createTestGoblin({ id: 99, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 98, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 97, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 96, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 95, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        rearAttacker,
+      ],
+      [1, 1, 1, 1, 1, 100],
+      [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]],
+      createSeededRng(22),
+      1,
+    )
+
+    const frontDamage = frontResult.detailedLog.find((log) => log.actorId === '1' && log.action === '通常攻撃')!.targets[0].totalDamage
+    const rearDamage = rearResult.detailedLog.find((log) => log.actorId === '2' && log.action === '通常攻撃')!.targets[0].totalDamage
+
+    expect(rearDamage).toBeGreaterThan(frontDamage)
+  })
+
+  it('遠近両方持ちは全列で同じ通常攻撃ダメージ補正になる', () => {
+    const dualSkills = [
+      { id: 'weapon_melee_attack', name: '[武器]近距離攻撃', enablesMeleeRowDamagePenalty: true },
+      { id: 'weapon_ranged_attack', name: '[武器]遠距離攻撃', enablesRangedRowDamagePenalty: true },
+    ]
+    const frontAttacker = createTestGoblin({
+      id: 1,
+      skills: dualSkills,
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const rearAttacker = createTestGoblin({
+      id: 2,
+      skills: dualSkills,
+      stats: { hp: 100, atk: 100, spd: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+
+    const frontResult = new BattleSystem().executeBattle(
+      [frontAttacker],
+      [100],
+      [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]],
+      createSeededRng(23),
+      1,
+    )
+    const rearResult = new BattleSystem().executeBattle(
+      [
+        createTestGoblin({ id: 99, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 98, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 97, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 96, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        createTestGoblin({ id: 95, stats: { hp: 1, atk: 1, spd: 1, def: 999, attackCount: 0, accuracy: 0, evasion: 999 } }),
+        rearAttacker,
+      ],
+      [1, 1, 1, 1, 1, 100],
+      [[createTestEnemy({ hp: 9999, def: 0, spd: 1, evasion: 0 })]],
+      createSeededRng(23),
+      1,
+    )
+
+    const frontDamage = frontResult.detailedLog.find((log) => log.actorId === '1' && log.action === '通常攻撃')!.targets[0].totalDamage
+    const rearDamage = rearResult.detailedLog.find((log) => log.actorId === '2' && log.action === '通常攻撃')!.targets[0].totalDamage
+
+    expect(rearDamage).toBe(frontDamage)
   })
 })
 

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -6,6 +6,7 @@ import {
   getPhysicalDamageReductionFromSkills,
   getRearAllyDamageMultiplierFromSkills,
   getRearProtectionMultiplierFromSkills,
+  getRowDamageMultiplierFromSkills,
   getSkillStatBonuses,
   getSkillStatMultipliers,
   hasCoverLowHpAllySkill,
@@ -75,6 +76,34 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     ]
 
     expect(getRearAllyDamageMultiplierFromSkills(skills)).toBe(1.5)
+  })
+
+  it('近距離攻撃スキルは前列ほど高い隊列補正を返す', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'weapon_melee_attack', name: '[武器]近距離攻撃', enablesMeleeRowDamagePenalty: true },
+    ]
+
+    expect(getRowDamageMultiplierFromSkills(skills, 0)).toBeCloseTo(1.0)
+    expect(getRowDamageMultiplierFromSkills(skills, 5)).toBeCloseTo(0.44)
+  })
+
+  it('遠距離攻撃スキルは後列ほど高い隊列補正を返す', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'weapon_ranged_attack', name: '[武器]遠距離攻撃', enablesRangedRowDamagePenalty: true },
+    ]
+
+    expect(getRowDamageMultiplierFromSkills(skills, 0)).toBeCloseTo(0.44)
+    expect(getRowDamageMultiplierFromSkills(skills, 5)).toBeCloseTo(1.0)
+  })
+
+  it('遠近両方ある場合は全列で0.44倍になる', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'weapon_melee_attack', name: '[武器]近距離攻撃', enablesMeleeRowDamagePenalty: true },
+      { id: 'weapon_ranged_attack', name: '[武器]遠距離攻撃', enablesRangedRowDamagePenalty: true },
+    ]
+
+    expect(getRowDamageMultiplierFromSkills(skills, 0)).toBeCloseTo(0.44)
+    expect(getRowDamageMultiplierFromSkills(skills, 5)).toBeCloseTo(0.44)
   })
 
   it('ステータス倍率スキルを集計できる', () => {

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -118,6 +118,29 @@ export function getAdditionalDamageFromSkills(skills: CharacterSkill[]): number 
   return getUniqueSkillsById(skills).reduce((sum, skill) => sum + (skill.additionalDamage ?? 0), 0)
 }
 
+const MELEE_ROW_DAMAGE_MULTIPLIERS = [1.0, 0.85, 0.72, 0.61, 0.52, 0.44] as const
+const RANGED_ROW_DAMAGE_MULTIPLIERS = [...MELEE_ROW_DAMAGE_MULTIPLIERS].reverse() as readonly number[]
+const BOTH_RANGE_ROW_DAMAGE_MULTIPLIER = 0.44
+
+export function getRowDamageMultiplierFromSkills(skills: CharacterSkill[], row: number): number {
+  const uniqueSkills = getUniqueSkillsById(skills)
+  const hasMelee = uniqueSkills.some((skill) => skill.enablesMeleeRowDamagePenalty)
+  const hasRanged = uniqueSkills.some((skill) => skill.enablesRangedRowDamagePenalty)
+
+  if (hasMelee && hasRanged) {
+    return BOTH_RANGE_ROW_DAMAGE_MULTIPLIER
+  }
+
+  if (!hasMelee && !hasRanged) {
+    return 1
+  }
+
+  const clampedRow = Math.max(0, Math.min(row, MELEE_ROW_DAMAGE_MULTIPLIERS.length - 1))
+  return hasMelee
+    ? MELEE_ROW_DAMAGE_MULTIPLIERS[clampedRow]
+    : RANGED_ROW_DAMAGE_MULTIPLIERS[clampedRow]
+}
+
 export function getRearProtectionMultiplierFromSkills(skills: CharacterSkill[]): number {
   return getUniqueSkillsById(skills).reduce(
     (product, skill) => product * (skill.protectRearAllyNormalAttackMultiplier ?? 1),

--- a/goblin_native/src/shared/data/equipmentPoolLoader.ts
+++ b/goblin_native/src/shared/data/equipmentPoolLoader.ts
@@ -1,4 +1,5 @@
-import type { EquipmentTemplate } from '../types/Equipment'
+import type { CharacterSkill } from '../types/CharacterSkill'
+import type { EquipmentTemplate, WeaponRange } from '../types/Equipment'
 import equipmentPoolJson from './equipmentPool.json'
 
 interface EquipmentPoolData {
@@ -8,8 +9,57 @@ interface EquipmentPoolData {
 
 const data = equipmentPoolJson as EquipmentPoolData
 
+const WEAPON_RANGE_SKILLS: Record<WeaponRange, CharacterSkill> = {
+  melee: {
+    id: 'weapon_melee_attack',
+    name: '[武器]近距離攻撃',
+    enablesMeleeRowDamagePenalty: true,
+  },
+  ranged: {
+    id: 'weapon_ranged_attack',
+    name: '[武器]遠距離攻撃',
+    enablesRangedRowDamagePenalty: true,
+  },
+}
+
+function cloneSkill(skill: CharacterSkill): CharacterSkill {
+  return {
+    ...skill,
+    statBonuses: skill.statBonuses ? { ...skill.statBonuses } : undefined,
+    statMultipliers: skill.statMultipliers ? { ...skill.statMultipliers } : undefined,
+    equipmentCategoryMultiplier: skill.equipmentCategoryMultiplier
+      ? { ...skill.equipmentCategoryMultiplier }
+      : undefined,
+    equipmentStatMultipliers: skill.equipmentStatMultipliers
+      ? { ...skill.equipmentStatMultipliers }
+      : undefined,
+  }
+}
+
+function buildGrantedSkills(template: EquipmentTemplate): CharacterSkill[] | undefined {
+  const grantedSkills = template.grantedSkills?.map(cloneSkill) ?? []
+
+  if (template.category === 'weapon' && template.range) {
+    grantedSkills.unshift(cloneSkill(WEAPON_RANGE_SKILLS[template.range]))
+  }
+
+  return grantedSkills.length > 0 ? grantedSkills : undefined
+}
+
+function normalizeTemplate(template: EquipmentTemplate): EquipmentTemplate {
+  return {
+    ...template,
+    statBonuses: template.statBonuses.map((bonus) => ({ ...bonus })),
+    weaponStats: template.weaponStats ? { ...template.weaponStats } : undefined,
+    effects: template.effects?.map((effect) => ({ ...effect })),
+    grantedSkills: buildGrantedSkills(template),
+  }
+}
+
 // コメント行を除外し、IDで高速検索するためのマップを構築
-const templates = data.templates.filter((t) => t.id !== undefined)
+const templates = data.templates
+  .filter((t) => t.id !== undefined)
+  .map(normalizeTemplate)
 const templateMap = new Map<string, EquipmentTemplate>(
   templates.map((t) => [t.id, t])
 )

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -8,6 +8,8 @@ export interface CharacterSkill {
   statMultipliers?: Partial<Record<keyof GoblinStats, number>>
   equipmentCategoryMultiplier?: Partial<Record<EquipmentCategory, number>>
   equipmentStatMultipliers?: Partial<Record<EquipmentStat, number>>
+  enablesMeleeRowDamagePenalty?: boolean
+  enablesRangedRowDamagePenalty?: boolean
   physicalDamageReductionPercent?: number
   additionalDamage?: number
   protectRearAllyNormalAttackMultiplier?: number


### PR DESCRIPTION
## Summary
- 冒険準備画面から遷移できる `PTの情報` 画面を追加
- パーティメンバーごとの経験値情報と隊列による攻撃能力補正を表示
- 武器レンジに応じたスキル付与と通常攻撃ダメージ補正を実装

## What Changed
- `party-info` 画面を追加し、PT名、経験値、隊列補正を表示
- 冒険準備画面のPTカード上部タップで `party-info` へ遷移
- `melee` / `ranged` 武器に応じて `[武器]近距離攻撃` / `[武器]遠距離攻撃` を自動付与
- 通常攻撃ダメージに隊列補正を適用

## Validation
- `npx tsc --noEmit`
- `npx jest src/shared/data/__tests__/characterSkills.test.ts src/core/services/__tests__/CombatStats.test.ts --runInBand`
