### PR TITLE
[codex] ホブゴブリンの気合い再発動を修正

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -530,7 +530,7 @@ export class BattleSystem {
   private applyDamage(target: BattleUnit, damage: number): void {
     const nextHP = target.currentHP - damage
 
-    if (nextHP <= 0 && target.currentHP > 0 && hasSurviveLethalDamageAtHp1Skill(target.skills)) {
+    if (nextHP <= 0 && target.currentHP > 1 && hasSurviveLethalDamageAtHp1Skill(target.skills)) {
       target.currentHP = 1
       return
     }

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1392,6 +1392,26 @@ describe('BattleSystem — ジョブ系スキル', () => {
     expect(result.allyHPDelta[0]).toBe(1 - hobgoblin.stats.hp)
     expect(result.outcome).not.toBe('lose')
   })
+
+  it('気合い持ちでもHP1の状態で致死ダメージを受けたら倒れる', () => {
+    const battleSystem = new BattleSystem()
+    const hobgoblin = createTestGoblin({
+      id: 1,
+      race: 'ホブゴブリン',
+      stats: { hp: 100, atk: 10, spd: 50, def: 10, attackCount: 1, accuracy: 999, evasion: 0 },
+    })
+    const enemy = createTestEnemy({
+      atk: 999,
+      accuracy: 999,
+      evasion: 0,
+      spd: 100,
+    })
+
+    const result = battleSystem.executeBattle([hobgoblin], [1], [[enemy]], createSeededRng(2), 1)
+
+    expect(result.allyHPDelta[0]).toBe(-1)
+    expect(result.outcome).toBe('lose')
+  })
 })
 
 // =========================================================================


### PR DESCRIPTION
## 概要
- ホブゴブリンの気合いがHP1から再発動して不死身になる不具合を修正
- 気合いはHP2以上から致死ダメージを受けたときだけHP1で耐えるよう変更
- HP1の状態で致死ダメージを受けた場合に倒れるテストを追加

## 原因
- 致死ダメージ耐えの条件が `currentHP > 0` になっており、すでにHP1でも再度発動していた

## 検証
- `npx jest src/core/services/__tests__/CombatStats.test.ts -t "気合い"`
