### PR TITLE
[codex] 現行構成に合わせてエージェント文書を更新

### DIFF
--- a/goblin_native/AGENTS.md
+++ b/goblin_native/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+## 概要
+
+- このリポジトリは `goblin_native` 単体の Expo / React Native アプリです。
+- 旧構成の `goblin_ink` や `goblin_web` は存在しません。作業時は現在のディレクトリ構成のみを前提にしてください。
+
+## コミュニケーション
+
+- すべて日本語で、簡潔かつ丁寧に記述してください。
+- 提案やレビューでは、実ファイルと実装済み構成に基づいて説明してください。
+
+## プロジェクト構成
+
+```text
+app/                    Expo Router の画面
+assets/                 画像などの静的アセット
+docs/                   仕様・設計ドキュメント
+src/
+  config/               Firebase 設定
+  core/                 ドメイン / サービス / ユースケース
+  infrastructure/       SQLite / Repository 実装
+  presentation/         components / contexts / hooks / stores
+  shared/               constants / data / types / utils
+  types/                型拡張
+ios/                    Expo prebuild 済み iOS プロジェクト
+```
+
+## 技術スタック
+
+- Expo SDK 54
+- React Native 0.81
+- React 19
+- TypeScript
+- Expo Router
+- expo-sqlite
+- Zustand
+- Jest + ts-jest
+
+## 主要コマンド
+
+```bash
+npm start
+npm run ios
+npm run android
+npm run web
+npm test
+npx tsc --noEmit
+```
+
+## 実装ルール
+
+- `src/core` はプラットフォーム非依存を維持し、React Native / Expo 依存を入れないでください。
+- 依存方向は `presentation -> core -> infrastructure` を崩さないでください。
+- パスエイリアスは `@/* -> src/*` です。
+- 画面遷移は Expo Router のファイルベースルーティングに従ってください。
+- 永続化は SQLite 前提です。Repository 実装は `src/infrastructure/repositories` に集約してください。
+- UI 状態は Context と Zustand store が混在しているため、責務と更新頻度に応じて配置を選んでください。
+
+## 参照先
+
+- 画面仕様: [`docs/screen_reference.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/screen_reference.md)
+- 全体構成: [`docs/project_structure.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/project_structure.md)
+- 実装ガイド: [`docs/implementation_guide.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/implementation_guide.md)
+- 残タスク: [`docs/remaining_tasks.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/remaining_tasks.md)
+- SQLite: [`docs/sqlite_migration.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/sqlite_migration.md)
+
+## 注意点
+
+- `dist/`, `.expo/`, `ios/Pods/`, `ios/build/` などの生成物は通常編集しません。
+- 構成変更時は `app.json`, `babel.config.js`, `metro.config.js`, `jest.config.js`, `tsconfig.json` の整合性を確認してください。
+- 古いドキュメントを更新する際は、存在しないディレクトリ名や画面名を残さないでください。

--- a/goblin_native/CLAUDE.md
+++ b/goblin_native/CLAUDE.md
@@ -1,155 +1,102 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code when working in this repository.
 
-## プロジェクト概要
+## 概要
 
-ゴブリンキングダムRPG — ゴブリンを管理しダンジョンへの遠征を行うモバイルゲーム。
-React Native (Expo SDK 54) + TypeScript で実装。データ永続化は SQLite (expo-sqlite)。
+- このリポジトリは `goblin_native` 単体の Expo / React Native アプリです。
+- ゴブリンを管理し、パーティを編成して遠征・戦闘を行うモバイルゲームを実装しています。
+- 技術構成は Expo SDK 54 / React Native 0.81 / React 19 / TypeScript / Expo Router / SQLite / Zustand / Jest です。
+
+## コミュニケーション
+
+- 返信、レビュー、提案、コミットメッセージ案は日本語で簡潔かつ丁寧に記述してください。
+- 以前の `goblin_ink` / `goblin_web` 前提の説明は無視し、このリポジトリの現行構成だけを参照してください。
 
 ## よく使うコマンド
 
 ```bash
-# 開発サーバー起動
-npm start              # expo start --port 8082
+# 開発サーバー
+npm start
 
-# iOS / Android 実行
+# ネイティブ実行
 npm run ios
 npm run android
 
-# テスト (Jest + ts-jest)
-npm test                                          # 全テスト
-npx jest src/core/services/__tests__/XxxTest.ts   # 単一テスト
+# Web 確認
+npm run web
 
-# TypeScript 型チェック
+# テスト
+npm test
+
+# 型チェック
 npx tsc --noEmit
 ```
 
+## 主要構成
+
+```text
+app/                    Expo Router 画面
+  (tabs)/               タブ配下の主要画面
+  base/                 拠点関連画面
+  goblin/               ゴブリン詳細・装備画面
+assets/                 画像などの静的アセット
+docs/                   仕様・設計ドキュメント
+src/
+  config/               Firebase 設定
+  core/                 ドメイン・サービス・ユースケース
+  infrastructure/       SQLite / Repository 実装
+  presentation/         UI 用 hooks / contexts / stores / components
+  shared/               型・定数・マスターデータ・ユーティリティ
+  types/                型拡張
+ios/                    Expo prebuild 済み iOS ネイティブプロジェクト
+```
+
+## 画面構成
+
+- `app/_layout.tsx`
+  - ルートレイアウト。DB 初期化や Provider 設定の起点です。
+- `app/(tabs)/_layout.tsx`
+  - タブ構成の定義です。
+- `app/(tabs)/index.tsx`
+  - ゴブリン一覧のメイン画面です。
+- `app/(tabs)/base.tsx`
+  - 拠点トップ画面です。
+- `app/base/training.tsx`, `app/base/upgrade.tsx`
+  - 拠点機能の個別画面です。
+- `app/(tabs)/formation/`
+  - 編成、遠征準備、再生、ログ、結果、装備変更を含む遠征フローです。
+- `app/goblin/detail.tsx`, `app/goblin/equipment.tsx`
+  - ゴブリン詳細と装備変更画面です。
+
 ## アーキテクチャ
 
-クリーンアーキテクチャ。`core/` はプラットフォーム非依存で将来的なUnity等への移植を想定。
+- ベースは Clean Architecture です。
+- 依存方向は `presentation -> core/usecases -> core/domain|services -> repositories interface -> infrastructure` を保ちます。
+- `src/core` には React Native / Expo 依存を持ち込まないでください。
+- Repository 実装は `src/infrastructure/repositories` に置き、永続化は SQLite を前提にしています。
+- 画面側では Context と Zustand store が共存しているため、新規 state は更新頻度と責務に応じて配置を選んでください。
 
-```
-src/
-├── core/                # プラットフォーム非依存
-│   ├── domain/          # エンティティ (GoblinEntity, PartyEntity, EnemyEntity)
-│   ├── repositories/    # リポジトリIF (IGoblinRepository等)
-│   ├── services/        # ゲームロジック (BattleSystem, ExpeditionEngine等)
-│   └── usecases/        # ユースケース (StartExpeditionUseCase等)
-├── infrastructure/      # データ永続化
-│   ├── database/        # SQLiteスキーマ・マイグレーション
-│   └── repositories/    # SQLiteリポジトリ実装 (シングルトン, getInstance())
-├── presentation/        # React Native UI層
-│   ├── contexts/        # AuthContext, ExpeditionStateContext, ResetContext
-│   └── hooks/           # useGoblinService, usePartyService, useExpeditionFlow等
-├── shared/              # 共通
-│   ├── types/           # 型定義 (Goblin, Party, Expedition, Battle, Equipment, Mod, Factor等)
-│   ├── data/            # マスターデータ (敵, エリア, 因子, Mod, 装備)
-│   ├── constants/       # colors.ts
-│   └── utils/           # 画像マッピング, ステータス計算
-└── config/              # firebase.ts
-```
+## 実装上の要点
 
-### パスエイリアス
+- パスエイリアスは `@/* -> src/*` です。
+- ルーティングは Expo Router のファイルベースです。
+- Jest は `ts-jest` を使い、`src/` 配下を対象にしています。
+- SVG は `react-native-svg-transformer` で扱います。
+- Expo 設定は [`app.json`](/Users/astapi/projects/goblinKingdom/goblin_native/app.json) を参照してください。
+- Firebase 設定は [`src/config/firebase.ts`](/Users/astapi/projects/goblinKingdom/goblin_native/src/config/firebase.ts) にあります。
 
-`@/*` → `src/*` (tsconfig.json で設定、jest.config.js でも対応済み)
+## 優先して見る場所
 
-### ルーティング (Expo Router, ファイルベース)
+- 画面仕様: [`docs/screen_reference.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/screen_reference.md)
+- 全体構成: [`docs/project_structure.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/project_structure.md)
+- 実装ガイド: [`docs/implementation_guide.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/implementation_guide.md)
+- 残タスク: [`docs/remaining_tasks.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/remaining_tasks.md)
+- SQLite 関連: [`docs/sqlite_migration.md`](/Users/astapi/projects/goblinKingdom/goblin_native/docs/sqlite_migration.md)
 
-```
-app/
-├── _layout.tsx            # ルート: Provider初期化, DB初期化
-├── (tabs)/
-│   ├── _layout.tsx        # 4タブ: index(一覧), formation, base, settings
-│   ├── index.tsx          # ゴブリン一覧
-│   ├── base.tsx           # 拠点管理
-│   ├── settings.tsx       # 設定
-│   └── formation/         # 遠征フロー (ネストStack)
-│       ├── index.tsx      # パーティ一覧
-│       ├── preparation.tsx # ダンジョン選択
-│       ├── edit.tsx       # パーティ編成
-│       ├── playback.tsx   # 遠征再生
-│       ├── result.tsx     # 遠征結果
-│       ├── log.tsx        # 遠征ログ
-│       └── battle-log.tsx # 戦闘ログ詳細
-└── goblin/                # ゴブリン詳細 (ネストStack)
-    ├── detail.tsx         # ゴブリン詳細
-    └── equipment.tsx      # 装備変更 (モーダル)
-```
+## 作業時の注意
 
-### データフロー
-
-```
-画面(app/) → hooks → UseCases → Domain Entities → Repositories(IF) → SQLite実装
-```
-
-- リポジトリは全てシングルトン (`getInstance()`)、`app/_layout.tsx` で初期化
-- hooks が UseCase を組成し画面にデータを提供
-
-### コアゲームシステム
-
-- **ExpeditionEngine**: シード値ベースの決定論的遠征シミュレーション。TimelineEvent配列を生成
-- **BattleSystem**: ターン制戦闘。DamageCalculator / CombatantManager と連携
-- **ModStatCalculator**: 因子・Modによる実効ステータス計算
-- **ExperienceSystem**: 経験値・レベルアップ処理
-- **GoblinBirthService**: ゴブリン生成・種族決定・因子継承
-- **BaseRankSystem**: 拠点ランク・容量管理
-- **EquipmentService / EquipmentTitleService**: 装備・称号システム
-
-### 帰還ポリシー
-
-遠征の帰還条件: `never`, `until_floor2`, `until_floor3`, `if_any_ko`, `if_two_ko`, `last_one`
-
-### SQLite マイグレーション
-
-- `infrastructure/database/migrations/` にバージョン別ファイル (v1.ts, v2.ts)
-- `app_metadata` テーブルでスキーマバージョン管理
-- `getDatabase()` 呼び出し時に自動マイグレーション
-
-## 設計上の注意
-
-- `core/` 内のコードは React Native / Expo に依存させない
-- SVGファイルは `react-native-svg-transformer` 経由でコンポーネントとしてインポート可能 (metro.config.js)
-- Firebase設定は `.env.local` から環境変数 `EXPO_PUBLIC_FIREBASE_*` で読み込み
-- 遠征システムはシード値ベースのため、同じシードで同じ結果を再現可能
-
-## React Native 実装ガイド（react-native-best-practices）
-
-### 基本方針
-
-- パフォーマンス問題は必ず **計測 → 改善 → 再計測** の順で進める。体感だけで最適化しない
-- `presentation/` の改善でも、まず「再レンダー過多」「長いJS処理」「リスト描画」「入力遅延」のどれかを切り分ける
-- 新しい抽象化や共通化は、可読性だけでなく起動時間・再レンダー範囲・依存サイズへの影響も見る
-
-### UI / 再レンダー
-
-- `ScrollView` に大量の要素を直接 `map()` する実装は避け、件数が増える一覧は `FlatList` か `FlashList` を優先する
-- 固定高の行は `getItemLayout`、`FlashList` では `estimatedItemSize` を設定してレイアウト計算コストを下げる
-- 画面全体の state をむやみに持ち上げず、変更頻度の高い state はできるだけ局所化する
-- 重い計算やフィルタは render 中に毎回実行せず、`useMemo` や事前計算で render コストを抑える
-- 入力値や選択状態の変更で一覧全体が再描画されないよう、`renderItem`・`keyExtractor`・props の安定性を保つ
-
-### TextInput / フォーム
-
-- `TextInput` は必要以上に完全制御しない。単純入力は `value` より `defaultValue` ベースの非制御運用を検討する
-- 1文字ごとのバリデーションや整形が必要な場合だけ制御コンポーネントにする
-- 検索入力などで重い処理を即時実行しない。絞り込み・検索・集計は debounce や遅延実行を挟む
-
-### バンドル / 起動時間
-
-- バレル export (`index.ts` でまとめて export) の乱用は避け、内部実装では直接 import を優先する
-- 依存追加時は「便利か」だけでなく「bundle size / 起動時間 / ネイティブ依存の重さ」を確認する
-- Android の起動速度改善のための Hermes / `noCompress` などの設定は、Expo / React Native のバージョン差異を確認してから適用する
-
-### Native / Expo 境界
-
-- ネイティブモジュールや重いネイティブSDK導入は最後の手段にし、まず既存の Expo / React Native 標準機能で解決できるか確認する
-- ネイティブ側の重い同期処理は UI スレッドを詰まらせるため避ける。同期APIより非同期APIを優先する
-- Expo managed workflow で永続化したいネイティブ設定変更は、手作業の `prebuild` 差分放置ではなく、必要なら config plugin 化も検討する
-
-### このリポジトリで特に意識する点
-
-- `core/` のシミュレーションや計算処理は UI スレッド体感に直結するため、画面描画中に大きな同期処理を走らせない
-- 遠征ログ、戦闘ログ、ゴブリン一覧など件数が伸びる画面は、まず仮想化リスト前提で設計する
-- Context は便利だが更新範囲が広がりやすい。高頻度更新データを `presentation/contexts/` に集約しすぎない
-- 画像・SVG・マスターデータは「読み込みやすさ」だけでなく、初回描画コストとメモリ使用量も考慮して扱う
+- `dist/`, `.expo/`, `ios/Pods/`, `ios/build/` などの生成物は原則として編集対象にしません。
+- 設定や構成を変更する場合は、Expo managed workflow と prebuild 済み iOS プロジェクトの両方への影響を確認してください。
+- 大きい一覧やログ画面は、再レンダー範囲と描画コストを意識して実装してください。
+- ドキュメント更新時は、存在しない旧ディレクトリや旧ファイル名を参照しないでください。


### PR DESCRIPTION
## 概要
- `AGENTS.md` を新規追加して、現行の `goblin_native` 単体構成を明記
- `CLAUDE.md` を現在の Expo Router / SQLite / Clean Architecture 構成に合わせて更新
- 旧 `goblin_ink` / `goblin_web` 前提の古い説明を削除

## 変更理由
- リポジトリの実態とエージェント向けドキュメントにズレがあったため
- 存在しない旧構成の案内を避け、今のプロジェクトを前提に作業できるようにするため

## 確認
- ドキュメント変更のみのためテスト未実行
