### PR TITLE
fix(equipment): apply title and equipped stats

### DIFF
--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -11,7 +11,7 @@ import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndRe
 import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
-import { ModStatCalculator } from '@/core/services/ModStatCalculator'
+import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
 
@@ -152,13 +152,13 @@ export default function ExpeditionPlaybackScreen() {
           goldGained: event.enemy.gold,
           members: partyMembers.map((memberId, idx) => {
             const goblin = partyGoblins[idx]
-            const preHP = partyHpRef.current[idx] ?? (goblin ? ModStatCalculator.calculate(goblin).hp : 100)
+            const preHP = partyHpRef.current[idx] ?? (goblin ? getEffectiveStats(goblin).hp : 100)
             return {
               name: goblin?.name ?? `ID:${memberId}`,
               currentHP: event.combat.allyHPDelta[idx] !== undefined
                 ? Math.max(0, preHP + event.combat.allyHPDelta[idx])
                 : 0,
-              maxHP: goblin ? ModStatCalculator.calculate(goblin).hp : 100,
+              maxHP: goblin ? getEffectiveStats(goblin).hp : 100,
               level: goblin?.level ?? 1,
               xpEach: xpPerMember,
               expMultiplier: 1,
@@ -284,7 +284,7 @@ export default function ExpeditionPlaybackScreen() {
     }
 
     const initialPartyHp = partyGoblins.map(goblin => {
-      return goblin ? ModStatCalculator.calculate(goblin).hp : 100
+      return goblin ? getEffectiveStats(goblin).hp : 100
     })
     let tempHp = [...initialPartyHp]
     partyHpRef.current = [...initialPartyHp]
@@ -435,7 +435,7 @@ export default function ExpeditionPlaybackScreen() {
       <View style={styles.partyGrid}>
         {replay.meta.party.map((memberId, index) => {
           const goblin = partyGoblins[index]
-          const maxHp = goblin ? ModStatCalculator.calculate(goblin).hp : 100
+          const maxHp = goblin ? getEffectiveStats(goblin).hp : 100
           const currentHp = partyHp[index] ?? maxHp
           return (
             <View key={memberId} style={styles.partyCard}>

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -7,7 +7,7 @@ import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionStore } from '@/presentation/stores/useExpeditionStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { areasData } from '@/shared/data'
-import { ModStatCalculator } from '@/core/services/ModStatCalculator'
+import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import type { ExpeditionRecord, Goblin, TimelineEvent, TreasureDrop } from '@/shared/types'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
@@ -69,7 +69,7 @@ export default function ExpeditionResultScreen() {
   const endHpMap = useMemo(() => {
     if (!replay || partySnapshot.length === 0) return new Map<number, number>()
 
-    const hpValues = partySnapshot.map(g => ModStatCalculator.calculate(g).hp)
+    const hpValues = partySnapshot.map(g => getEffectiveStats(g).hp)
 
     for (const event of replay.events) {
       if ((event.type === 'battle' || event.type === 'boss') && event.combat.allyHPDelta) {
@@ -192,7 +192,7 @@ export default function ExpeditionResultScreen() {
 
         <View style={styles.section}>
           {partySnapshot.map(goblin => {
-            const maxHp = ModStatCalculator.calculate(goblin).hp
+            const maxHp = getEffectiveStats(goblin).hp
             const currentHp = endHpMap.get(goblin.id) ?? maxHp
             const levelUp = levelUpMap.get(goblin.id)
             const dead = currentHp === 0

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -11,7 +11,6 @@ import { GoblinCard } from '@/presentation/components/GoblinCard'
 import type { Goblin } from '@/shared/types'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
-import { ModStatCalculator } from '@/core/services/ModStatCalculator'
 import { getModTemplate } from '@/shared/data/modPoolLoader'
 
 const STAT_LABELS: Record<string, string> = {
@@ -247,7 +246,7 @@ export default function GoblinListScreen() {
           </TouchableOpacity>
         </View>
         {pendingGoblins.map((goblin) => {
-          const effectiveStats = ModStatCalculator.calculate(goblin)
+          const effectiveStats = getEffectiveStats(goblin)
           return (
             <View key={goblin.id} style={styles.pendingCard}>
               <View style={styles.pendingRow}>

--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -16,6 +16,7 @@ import { getModTemplate } from '@/shared/data/modPoolLoader'
 import { describeCharacterSkill, getUniqueSkillsById } from '@/shared/data/characterSkills'
 import { getGoblinJobDefinition } from '@/shared/data/goblinJobs'
 import { getGoblinBaseAttributes } from '@/shared/utils/goblinHp'
+import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getFactorName, getRaceLabel, getSkillLabel, getStatLabel } from '@/shared/i18n/entityLocalization'
 
 export default function GoblinDetailScreen() {
@@ -50,7 +51,7 @@ export default function GoblinDetailScreen() {
   }, [goblin, parentNav])
 
   const effectiveStats = useMemo(
-    () => goblin ? ModStatCalculator.calculate(goblin) : null,
+    () => goblin ? getEffectiveStats(goblin) : null,
     [goblin]
   )
   const expForNext = goblin ? getExpForNextLevel(goblin.level) : 0

--- a/goblin_native/app/goblin/equipment.tsx
+++ b/goblin_native/app/goblin/equipment.tsx
@@ -53,6 +53,14 @@ function formatBonus(stat: string, value: number): string {
   return `${value > 0 ? '+' : ''}${value}${isPercent ? '%' : ''}`
 }
 
+function getDisplayBonuses(eq: EquipmentInstance) {
+  return EquipmentService.calculateEquipmentBonuses([eq])
+}
+
+function getDisplayEffects(eq: EquipmentInstance) {
+  return EquipmentService.collectEquipmentEffects([eq])
+}
+
 /** カテゴリ→定義順→称号レア度（低→高）でソート */
 function sortEquipment(items: EquipmentInstance[]): EquipmentInstance[] {
   const allTemplates = getEquipmentTemplates()
@@ -112,6 +120,9 @@ function EquippedItemDetail({
   onClose: () => void
   onUnequip: () => void
 }) {
+  const displayBonuses = getDisplayBonuses(equipment)
+  const displayEffects = getDisplayEffects(equipment)
+
   return (
     <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
       <View style={styles.overlayBackground}>
@@ -128,7 +139,7 @@ function EquippedItemDetail({
           )}
 
           <View style={styles.detailBonuses}>
-            {template.statBonuses.map((bonus, i) => (
+            {displayBonuses.map((bonus, i) => (
               <View key={i} style={styles.bonusBadge}>
                 <Text style={styles.bonusBadgeText}>
                   {STAT_LABELS[bonus.stat] ?? bonus.stat} {formatBonus(bonus.stat, bonus.value)}
@@ -144,9 +155,9 @@ function EquippedItemDetail({
             ))}
           </View>
 
-          {template.effects && template.effects.length > 0 && (
+          {displayEffects.length > 0 && (
             <View style={styles.detailEffects}>
-              {template.effects.map((effect, i) => (
+              {displayEffects.map((effect, i) => (
                 <Text key={i} style={styles.effectText}>
                   {effect.type}: {effect.value}
                 </Text>
@@ -182,6 +193,8 @@ function EquipmentRow({
   highlighted?: boolean
   count?: number
 }) {
+  const displayBonuses = getDisplayBonuses(eq)
+
   return (
     <TouchableOpacity
       style={[styles.itemRow, highlighted && styles.itemRowHighlighted]}
@@ -192,7 +205,7 @@ function EquipmentRow({
           {count && count > 1 ? `x${count} ${getDisplayName(eq, template)}` : getDisplayName(eq, template)}
         </Text>
         <View style={styles.itemBonusRow}>
-          {template.statBonuses.map((bonus, i) => (
+          {displayBonuses.map((bonus, i) => (
             <View key={i} style={styles.itemBonusBadge}>
               <Text style={styles.itemBonusText}>
                 {STAT_LABELS[bonus.stat] ?? bonus.stat} {formatBonus(bonus.stat, bonus.value)}

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -16,6 +16,7 @@ import { CombatantManager } from './CombatantManager'
 import { DamageCalculator } from './DamageCalculator'
 import { ModStatCalculator } from './ModStatCalculator'
 import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
+import { getEffectiveStats } from '../../shared/utils/goblinStats'
 import i18n from '../../shared/i18n'
 import { getSpellLabel } from '../../shared/i18n/entityLocalization'
 import type {
@@ -572,7 +573,7 @@ export class BattleSystem {
     const combatant = this.combatantManager.fromGoblin(goblin)
     const actionOrderAgility = (goblin as Goblin & { agility?: number }).agility
     // Mod適用後のステータスを使用
-    const effectiveStats = ModStatCalculator.calculate(goblin)
+    const effectiveStats = getEffectiveStats(goblin)
     const hp = initialHP ?? effectiveStats.hp
     const damageReduction = ModStatCalculator.getDamageReduction(goblin)
     const physicalDamageReduction = getPhysicalDamageReductionFromSkills(goblin.skills)

--- a/goblin_native/src/core/services/CombatantManager.ts
+++ b/goblin_native/src/core/services/CombatantManager.ts
@@ -1,11 +1,10 @@
 import type { Enemy, Goblin } from '../../shared/types'
 import type { Combatant } from './DamageCalculator'
-import { ModStatCalculator } from './ModStatCalculator'
+import { getEffectiveStats } from '../../shared/utils/goblinStats'
 
 export class CombatantManager {
   public fromGoblin(goblin: Goblin): Combatant {
-    // Mod適用後のステータスを使用
-    const effectiveStats = ModStatCalculator.calculate(goblin)
+    const effectiveStats = getEffectiveStats(goblin)
     return {
       id: goblin.id.toString(),
       name: goblin.name,

--- a/goblin_native/src/core/services/EquipmentService.ts
+++ b/goblin_native/src/core/services/EquipmentService.ts
@@ -4,11 +4,29 @@ import type { EquipmentInstance, EquipmentStatBonus, EquipmentEffect } from '../
 import { calculateSlotCount } from '../../shared/data/equipmentConfig'
 import { getEquipmentTemplate } from '../../shared/data/equipmentPoolLoader'
 import { cloneCharacterSkill } from '../../shared/data/characterSkills'
+import { EquipmentTitleService } from './EquipmentTitleService'
 
 /**
  * 装備の着脱・バリデーション・ステータスボーナス計算を担当するサービス
  */
 export class EquipmentService {
+  private static scaleValueByTitle(value: number, equipment: EquipmentInstance): number {
+    if (value === 0 || !equipment.titleId) {
+      return value
+    }
+
+    const titleDef = EquipmentTitleService.getTitleDef(equipment.titleId)
+    if (!titleDef) {
+      return value
+    }
+
+    if (value > 0) {
+      return Math.floor(value * titleDef.plusMultiplier)
+    }
+
+    return -Math.floor(Math.abs(value) * titleDef.minusMultiplier)
+  }
+
   /**
    * ゴブリンが利用可能なスロット数を取得
    */
@@ -95,6 +113,7 @@ export class EquipmentService {
       for (const bonus of template.statBonuses) {
         bonuses.push({
           ...bonus,
+          value: this.scaleValueByTitle(bonus.value, eq),
           sourceCategory: template.category,
         })
       }
@@ -119,6 +138,7 @@ export class EquipmentService {
       for (const effect of template.effects) {
         effects.push({
           ...effect,
+          value: this.scaleValueByTitle(effect.value, eq),
           sourceCategory: template.category,
         })
       }

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -22,6 +22,7 @@ import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
 import { normalizePartyRewardMultipliers } from '../../shared/types'
 import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
+import { getEffectiveStats } from '../../shared/utils/goblinStats'
 
 /** 全エリア共通の宝箱ドロップ確率（敵1体ごと） */
 const DROP_CHANCE = 0.15
@@ -338,7 +339,7 @@ export class ExpeditionEngine {
     return party.map(goblin => {
       // 基礎ステータスを保存（因子・Mod適用はModStatCalculatorで行う）
       // currentHP/maxHPは因子・Mod適用後の値を使用（戦闘中のHP管理のため）
-      const effectiveStats = ModStatCalculator.calculate(goblin)
+      const effectiveStats = getEffectiveStats(goblin)
       return {
         id: goblin.id.toString(),
         name: goblin.name,

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -294,6 +294,39 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
     expect(bonuses[0].sourceCategory).toBe('weapon')
   })
 
+  it('EquipmentServiceは称号付き装備のプラス補正を倍率適用する', () => {
+    const bonuses = EquipmentService.calculateEquipmentBonuses([
+      { id: 'eq1', templateId: 'sword_broad', slotIndex: 0, goblinId: 1, titleId: 'masterwork' },
+    ])
+
+    expect(bonuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({ stat: 'atk_flat', value: 15, sourceCategory: 'weapon' }),
+      expect.objectContaining({ stat: 'def_flat', value: 3, sourceCategory: 'weapon' }),
+    ]))
+  })
+
+  it('EquipmentServiceは称号付き装備のマイナス補正を倍率適用する', () => {
+    const bonuses = EquipmentService.calculateEquipmentBonuses([
+      { id: 'eq1', templateId: 'armor_armor', slotIndex: 0, goblinId: 1, titleId: 'masterwork' },
+    ])
+
+    expect(bonuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({ stat: 'critical_rate_percent', value: -2, sourceCategory: 'armor' }),
+      expect.objectContaining({ stat: 'def_flat', value: 13, sourceCategory: 'armor' }),
+      expect.objectContaining({ stat: 'hp_flat', value: 19, sourceCategory: 'armor' }),
+    ]))
+  })
+
+  it('EquipmentServiceは称号付き装備の特殊効果にも倍率適用する', () => {
+    const effects = EquipmentService.collectEquipmentEffects([
+      { id: 'eq1', templateId: 'sword_broad', slotIndex: 0, goblinId: 1, titleId: 'masterwork' },
+    ])
+
+    expect(effects).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'def_to_hp', value: 2, sourceCategory: 'weapon' }),
+    ]))
+  })
+
   it('EquipmentServiceは装備に応じた物理ダメージ軽減スキルを付与・解除する', () => {
     const goblin = createTestGoblin({ skills: [] })
     const equipment = { id: 'eq1', templateId: 'armor_armor', slotIndex: -1, goblinId: null }

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -56,7 +56,7 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     const normalizedGoblin = syncGoblinDerivedStats(normalizeGoblinJobSkills(goblin))
     const persistedGoblin: Goblin = {
       ...normalizedGoblin,
-      effectiveStats: ModStatCalculator.calculate(normalizedGoblin),
+      effectiveStats: normalizedGoblin.effectiveStats ?? ModStatCalculator.calculate(normalizedGoblin),
     }
     const db = await getDatabase()
     await db.runAsync(
@@ -140,7 +140,7 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     const normalizedGoblin = syncGoblinDerivedStats(goblin)
     return {
       ...normalizedGoblin,
-      effectiveStats: ModStatCalculator.calculate(normalizedGoblin),
+      effectiveStats: normalizedGoblin.effectiveStats ?? ModStatCalculator.calculate(normalizedGoblin),
     }
   }
 }

--- a/goblin_native/src/presentation/hooks/useEquipmentService.ts
+++ b/goblin_native/src/presentation/hooks/useEquipmentService.ts
@@ -4,6 +4,7 @@ import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQL
 import { EquipmentService } from '../../core/services/EquipmentService'
 import type { Goblin } from '../../shared/types'
 import { useGoblinStore } from '../stores/useGoblinStore'
+import { calculateGoblinEffectiveStats } from '../../shared/utils/goblinStats'
 
 export const useEquipmentService = () => {
   const [equippedItems, setEquippedItems] = useState<EquipmentInstance[]>([])
@@ -32,7 +33,11 @@ export const useEquipmentService = () => {
       if (result.unequipped) {
         await repository.save(result.unequipped)
       }
-      await saveGoblin({ ...goblin })
+      const updatedEquipped = await repository.getByGoblinId(goblin.id)
+      await saveGoblin({
+        ...goblin,
+        effectiveStats: calculateGoblinEffectiveStats(goblin, updatedEquipped),
+      })
       await refreshEquipment(goblin.id)
       return { success: true }
     },
@@ -43,7 +48,11 @@ export const useEquipmentService = () => {
     async (goblin: Goblin, equipment: EquipmentInstance) => {
       const unequipped = EquipmentService.unequip(equipment, goblin)
       await repository.save(unequipped)
-      await saveGoblin({ ...goblin })
+      const updatedEquipped = await repository.getByGoblinId(goblin.id)
+      await saveGoblin({
+        ...goblin,
+        effectiveStats: calculateGoblinEffectiveStats(goblin, updatedEquipped),
+      })
       await refreshEquipment(goblin.id)
     },
     [repository, refreshEquipment, saveGoblin],

--- a/goblin_native/src/presentation/stores/useGoblinStore.ts
+++ b/goblin_native/src/presentation/stores/useGoblinStore.ts
@@ -5,6 +5,7 @@ import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQL
 import type { IGoblinRepository, IEquipmentRepository } from '../../core/repositories'
 import { DeleteGoblinUseCase, GetGoblinListUseCase } from '../../core/usecases'
 import { usePartyStore } from './usePartyStore'
+import { calculateGoblinEffectiveStats } from '../../shared/utils/goblinStats'
 
 interface GoblinState {
   goblins: Goblin[]
@@ -25,17 +26,42 @@ const equipmentRepository: IEquipmentRepository = SQLiteEquipmentRepository.getI
 const getGoblinListUseCase = new GetGoblinListUseCase(repository)
 const deleteGoblinUseCase = new DeleteGoblinUseCase(repository, equipmentRepository)
 
+async function attachEquipmentEffectiveStats(goblin: Goblin): Promise<Goblin> {
+  const equippedItems = await equipmentRepository.getByGoblinId(goblin.id)
+  return {
+    ...goblin,
+    effectiveStats: calculateGoblinEffectiveStats(goblin, equippedItems),
+  }
+}
+
+async function attachEquipmentEffectiveStatsToList(goblins: Goblin[]): Promise<Goblin[]> {
+  const allEquipment = await equipmentRepository.getAll()
+  const equipmentByGoblinId = new Map<number, typeof allEquipment>()
+
+  for (const equipment of allEquipment) {
+    if (equipment.goblinId == null || equipment.slotIndex < 0) continue
+    const list = equipmentByGoblinId.get(equipment.goblinId) ?? []
+    list.push(equipment)
+    equipmentByGoblinId.set(equipment.goblinId, list)
+  }
+
+  return goblins.map((goblin) => ({
+    ...goblin,
+    effectiveStats: calculateGoblinEffectiveStats(goblin, equipmentByGoblinId.get(goblin.id) ?? []),
+  }))
+}
+
 export const useGoblinStore = create<GoblinState & GoblinActions>()((set) => ({
   goblins: [],
   isLoading: true,
 
   initialize: async () => {
-    const goblins = await getGoblinListUseCase.execute()
+    const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins, isLoading: false })
   },
 
   refresh: async () => {
-    const goblins = await getGoblinListUseCase.execute()
+    const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins })
   },
 
@@ -44,12 +70,12 @@ export const useGoblinStore = create<GoblinState & GoblinActions>()((set) => ({
     if (!goblin) {
       throw new Error(`ID ${goblinId} のゴブリンが見つかりません`)
     }
-    return goblin
+    return attachEquipmentEffectiveStats(goblin)
   },
 
   saveGoblin: async (goblin: Goblin) => {
     await repository.saveGoblin(goblin)
-    const goblins = await getGoblinListUseCase.execute()
+    const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins })
   },
 
@@ -60,13 +86,13 @@ export const useGoblinStore = create<GoblinState & GoblinActions>()((set) => ({
       throw new Error(`${assignedParty.name}に編成中のため追放できません`)
     }
     await deleteGoblinUseCase.execute(goblinId)
-    const goblins = await getGoblinListUseCase.execute()
+    const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins })
   },
 
   updateGoblinLevel: async (goblinId: number, level: number) => {
     await repository.updateGoblinLevel(goblinId, level)
-    const goblins = await getGoblinListUseCase.execute()
+    const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins })
   },
 }))

--- a/goblin_native/src/shared/utils/goblinStats.ts
+++ b/goblin_native/src/shared/utils/goblinStats.ts
@@ -1,7 +1,17 @@
-import type { Goblin, GoblinStats } from '../types'
+import type { Goblin, GoblinStats, EquipmentInstance } from '../types'
 import { ModStatCalculator } from '@/core/services/ModStatCalculator'
+import { EquipmentService } from '@/core/services/EquipmentService'
 import { calculateGoblinDerivedStats, getGoblinBaseAttributes } from './goblinHp'
 import { getLegacyRaceName, normalizeGoblinRaceId } from '../types/Race'
+
+export function calculateGoblinEffectiveStats(
+  goblin: Goblin,
+  equippedItems: EquipmentInstance[] = [],
+): GoblinStats {
+  const equipmentBonuses = EquipmentService.calculateEquipmentBonuses(equippedItems)
+  const equipmentEffects = EquipmentService.collectEquipmentEffects(equippedItems)
+  return ModStatCalculator.calculate(goblin, equipmentBonuses, equipmentEffects)
+}
 
 /**
  * ゴブリンの実効ステータス（因子+MOD適用後）を取得
@@ -11,7 +21,7 @@ export function getEffectiveStats(goblin: Goblin): GoblinStats {
   if (goblin.effectiveStats) {
     return goblin.effectiveStats
   }
-  return ModStatCalculator.calculate(goblin)
+  return calculateGoblinEffectiveStats(goblin)
 }
 
 export function syncGoblinDerivedStats<T extends Goblin>(goblin: T): T {


### PR DESCRIPTION
## 概要
- 称号補正を装備ステータスと特殊効果へ反映
- 装備一覧と詳細で称号補正後の数値を表示
- ゴブリンの実効ステータスを装備込みで再計算し、装備変更後も表示と戦闘へ反映

## テスト
- npx tsc --noEmit
- npm test -- --runInBand src/core/services/__tests__/CombatStats.test.ts