### PR TITLE
refactor(equipment): weaponStats/effectsを廃止しbonuses/grantedSkillsに統合

### DIFF
--- a/goblin_native/app/goblin/equipment.tsx
+++ b/goblin_native/app/goblin/equipment.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal, Alert } from 'react-native'
+import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal, Alert, ScrollView } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams } from 'expo-router'
 import type { EquipmentInstance, EquipmentTemplate, EquipmentCategory } from '@/shared/types'
@@ -8,15 +8,9 @@ import { useEquipmentService } from '@/presentation/hooks/useEquipmentService'
 import { EquipmentService } from '@/core/services/EquipmentService'
 import { getEquipmentTemplate, getEquipmentTemplates } from '@/shared/data/equipmentPoolLoader'
 import { EQUIPMENT_TITLE_DEFS } from '@/shared/data/equipmentTitleConfig'
-import { describeCharacterSkill } from '@/shared/data/characterSkills'
+import { describeCharacterSkill, getCharacterSkillDescription } from '@/shared/data/characterSkills'
 import { getEquipmentDescription, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import type { Goblin } from '@/shared/types'
-
-const CATEGORY_LABELS: Record<EquipmentCategory, string> = {
-  weapon: '武器',
-  armor: '防具',
-  accessory: '装飾',
-}
 
 const CATEGORY_ORDER: Record<EquipmentCategory, number> = {
   weapon: 0,
@@ -49,16 +43,34 @@ type InventoryGroup = {
 }
 
 function formatBonus(stat: string, value: number): string {
+  const displayValue = Number.isInteger(value)
+    ? value
+    : Math.trunc(value * 10) / 10
   const isPercent = stat.includes('percent') || stat === 'damage_reduction'
-  return `${value > 0 ? '+' : ''}${value}${isPercent ? '%' : ''}`
+  return `${displayValue > 0 ? '+' : ''}${displayValue}${isPercent ? '%' : ''}`
+}
+
+function getInlineBonusLabel(stat: string, value: number): string {
+  const label = STAT_LABELS[stat] ?? stat
+  return `${label}${formatBonus(stat, value)}`
+}
+
+function getDetailBonusLabel(stat: string, value: number): string {
+  const label = STAT_LABELS[stat] ?? stat
+  return `${label} ${formatBonus(stat, value)}`
 }
 
 function getDisplayBonuses(eq: EquipmentInstance) {
-  return EquipmentService.calculateEquipmentBonuses([eq])
+  return EquipmentService.calculateEquipmentBonuses([eq]).filter((bonus) => {
+    const displayValue = Number.isInteger(bonus.value)
+      ? bonus.value
+      : Math.trunc(bonus.value * 10) / 10
+    return displayValue !== 0
+  })
 }
 
-function getDisplayEffects(eq: EquipmentInstance) {
-  return EquipmentService.collectEquipmentEffects([eq])
+function getDisplaySkills(eq: EquipmentInstance) {
+  return EquipmentService.collectGrantedSkills([eq])
 }
 
 /** カテゴリ→定義順→称号レア度（低→高）でソート */
@@ -107,7 +119,7 @@ function groupInventory(items: EquipmentInstance[]): InventoryGroup[] {
 }
 
 /** 装備済みアイテムの詳細モーダル */
-function EquippedItemDetail({
+function ItemDetail({
   equipment,
   template,
   visible,
@@ -118,57 +130,60 @@ function EquippedItemDetail({
   template: EquipmentTemplate
   visible: boolean
   onClose: () => void
-  onUnequip: () => void
+  onUnequip?: () => void
 }) {
   const displayBonuses = getDisplayBonuses(equipment)
-  const displayEffects = getDisplayEffects(equipment)
+  const displaySkills = getDisplaySkills(equipment)
 
   return (
     <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
       <View style={styles.overlayBackground}>
         <View style={styles.detailCard}>
-          <Text style={styles.detailName}>
-            {getDisplayName(equipment, template)}
-          </Text>
-          <Text style={styles.detailCategory}>
-            {CATEGORY_LABELS[template.category]}
-          </Text>
+          <ScrollView
+            style={styles.detailScroll}
+            contentContainerStyle={styles.detailScrollContent}
+            showsVerticalScrollIndicator={true}
+          >
+            <Text style={styles.detailName}>
+              {getDisplayName(equipment, template)}
+            </Text>
+            {getDisplayDescription(template) && (
+              <Text style={styles.detailDescription}>{getDisplayDescription(template)}</Text>
+            )}
 
-          {getDisplayDescription(template) && (
-            <Text style={styles.detailDescription}>{getDisplayDescription(template)}</Text>
-          )}
-
-          <View style={styles.detailBonuses}>
-            {displayBonuses.map((bonus, i) => (
-              <View key={i} style={styles.bonusBadge}>
-                <Text style={styles.bonusBadgeText}>
-                  {STAT_LABELS[bonus.stat] ?? bonus.stat} {formatBonus(bonus.stat, bonus.value)}
+            <View style={styles.detailList}>
+              {displayBonuses.map((bonus, i) => (
+                <Text key={`bonus-${i}`} style={styles.detailListText}>
+                  {getDetailBonusLabel(bonus.stat, bonus.value)}
                 </Text>
-              </View>
-            ))}
-            {template.grantedSkills?.map((skill, i) => (
-              <View key={`skill-${i}`} style={styles.bonusBadge}>
-                <Text style={styles.bonusBadgeText}>
+              ))}
+              {displaySkills.map((skill, i) => (
+                <Text key={`skill-name-${i}`} style={styles.detailListText}>
                   {describeCharacterSkill(skill)}
-                </Text>
-              </View>
-            ))}
-          </View>
-
-          {displayEffects.length > 0 && (
-            <View style={styles.detailEffects}>
-              {displayEffects.map((effect, i) => (
-                <Text key={i} style={styles.effectText}>
-                  {effect.type}: {effect.value}
                 </Text>
               ))}
             </View>
-          )}
+
+            {displaySkills.length > 0 && (
+              <View style={styles.detailSkillDescriptionSection}>
+                {displaySkills.map((skill, i) => (
+                  <View key={`skill-detail-${i}`} style={styles.detailSkillDescriptionBlock}>
+                    <Text style={styles.detailSkillName}>{describeCharacterSkill(skill)}</Text>
+                    <Text style={styles.detailSkillDescription}>
+                      {getCharacterSkillDescription(skill)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </ScrollView>
 
           <View style={styles.detailActions}>
-            <TouchableOpacity style={styles.unequipButton} onPress={onUnequip}>
-              <Text style={styles.unequipButtonText}>外す</Text>
-            </TouchableOpacity>
+            {onUnequip && (
+              <TouchableOpacity style={styles.unequipButton} onPress={onUnequip}>
+                <Text style={styles.unequipButtonText}>外す</Text>
+              </TouchableOpacity>
+            )}
             <TouchableOpacity style={styles.detailCloseButton} onPress={onClose}>
               <Text style={styles.detailCloseButtonText}>閉じる</Text>
             </TouchableOpacity>
@@ -184,16 +199,19 @@ function EquipmentRow({
   eq,
   template,
   onPress,
+  onShowDetail,
   highlighted,
   count,
 }: {
   eq: EquipmentInstance
   template: EquipmentTemplate
   onPress: () => void
+  onShowDetail: () => void
   highlighted?: boolean
   count?: number
 }) {
   const displayBonuses = getDisplayBonuses(eq)
+  const inlineStats = displayBonuses.map((bonus) => getInlineBonusLabel(bonus.stat, bonus.value)).join('  ')
 
   return (
     <TouchableOpacity
@@ -201,26 +219,22 @@ function EquipmentRow({
       onPress={onPress}
     >
       <View style={styles.itemInfo}>
+        <Text style={styles.itemStats} numberOfLines={1}>
+          {inlineStats}
+        </Text>
         <Text style={styles.itemName} numberOfLines={1}>
           {count && count > 1 ? `x${count} ${getDisplayName(eq, template)}` : getDisplayName(eq, template)}
         </Text>
-        <View style={styles.itemBonusRow}>
-          {displayBonuses.map((bonus, i) => (
-            <View key={i} style={styles.itemBonusBadge}>
-              <Text style={styles.itemBonusText}>
-                {STAT_LABELS[bonus.stat] ?? bonus.stat} {formatBonus(bonus.stat, bonus.value)}
-              </Text>
-            </View>
-          ))}
-          {template.grantedSkills?.map((skill, i) => (
-            <View key={`skill-${i}`} style={styles.itemBonusBadge}>
-              <Text style={styles.itemBonusText}>
-                {describeCharacterSkill(skill)}
-              </Text>
-            </View>
-          ))}
-        </View>
       </View>
+      <TouchableOpacity
+        style={styles.itemTipsButton}
+        onPress={(event) => {
+          event.stopPropagation()
+          onShowDetail()
+        }}
+      >
+        <Text style={styles.itemTipsButtonText}>i</Text>
+      </TouchableOpacity>
     </TouchableOpacity>
   )
 }
@@ -236,7 +250,7 @@ export default function EquipmentScreenPage() {
   const { equippedItems, inventoryItems, refreshEquipment, equipItem, unequipItem } =
     useEquipmentService()
   const [goblin, setGoblin] = useState<Goblin | null>(null)
-  const [selectedEquipped, setSelectedEquipped] = useState<EquipmentInstance | null>(null)
+  const [selectedDetail, setSelectedDetail] = useState<EquipmentInstance | null>(null)
 
   useEffect(() => {
     if (!goblinId) return
@@ -308,16 +322,12 @@ export default function EquipmentScreenPage() {
     [equippedItems, maxSlots, goblin, equipItem],
   )
 
-  const handleUnequip = useCallback(async () => {
-    if (!selectedEquipped || !goblin) return
+  const handleUnequip = useCallback(async (equipment: EquipmentInstance) => {
+    if (!goblin) return
     pendingScrollRestoreRef.current = true
-    await unequipItem(goblin, selectedEquipped)
-    setSelectedEquipped(null)
-  }, [selectedEquipped, goblin, unequipItem])
-
-  const selectedEquippedTemplate = selectedEquipped
-    ? getEquipmentTemplate(selectedEquipped.templateId)
-    : null
+    await unequipItem(goblin, equipment)
+    setSelectedDetail(null)
+  }, [goblin, unequipItem])
 
   if (!goblin) return null
 
@@ -339,6 +349,7 @@ export default function EquipmentScreenPage() {
             eq={item.equipment}
             template={item.template}
             onPress={() => handleEquip(item.equipment)}
+            onShowDetail={() => setSelectedDetail(item.equipment)}
             highlighted={emptySlots > 0}
             count={item.count}
           />
@@ -361,7 +372,8 @@ export default function EquipmentScreenPage() {
                       key={eq.id}
                       eq={eq}
                       template={template}
-                      onPress={() => setSelectedEquipped(eq)}
+                      onPress={() => setSelectedDetail(eq)}
+                      onShowDetail={() => setSelectedDetail(eq)}
                     />
                   )
                 })}
@@ -389,13 +401,13 @@ export default function EquipmentScreenPage() {
         ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
       />
 
-      {selectedEquipped && selectedEquippedTemplate && (
-        <EquippedItemDetail
-          equipment={selectedEquipped}
-          template={selectedEquippedTemplate}
+      {selectedDetail && getEquipmentTemplate(selectedDetail.templateId) && (
+        <ItemDetail
+          equipment={selectedDetail}
+          template={getEquipmentTemplate(selectedDetail.templateId)!}
           visible={true}
-          onClose={() => setSelectedEquipped(null)}
-          onUnequip={handleUnequip}
+          onClose={() => setSelectedDetail(null)}
+          onUnequip={selectedDetail.goblinId != null && selectedDetail.slotIndex >= 0 ? () => handleUnequip(selectedDetail) : undefined}
         />
       )}
     </SafeAreaView>
@@ -454,27 +466,29 @@ const styles = StyleSheet.create({
   itemInfo: {
     flex: 1,
   },
+  itemStats: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginBottom: 4,
+  },
   itemName: {
     fontSize: 14,
     fontWeight: '600',
     color: '#1F2937',
   },
-  itemBonusRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 4,
-    marginTop: 4,
+  itemTipsButton: {
+    backgroundColor: '#E5E7EB',
+    borderRadius: 999,
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: 12,
   },
-  itemBonusBadge: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 4,
-    backgroundColor: '#DCFCE7',
-  },
-  itemBonusText: {
-    fontSize: 10,
-    color: '#166534',
-    fontWeight: '600',
+  itemTipsButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#4B5563',
   },
   emptySlot: {
     flexDirection: 'row',
@@ -508,56 +522,64 @@ const styles = StyleSheet.create({
   detailCard: {
     backgroundColor: '#FFFFFF',
     borderRadius: 16,
-    padding: 24,
     width: '100%',
     maxWidth: 340,
+    maxHeight: '80%',
+    overflow: 'hidden',
+  },
+  detailScroll: {
+    flexGrow: 0,
+  },
+  detailScrollContent: {
+    padding: 24,
+    paddingBottom: 16,
   },
   detailName: {
     fontSize: 18,
     fontWeight: '700',
     color: '#1F2937',
-    marginBottom: 4,
-  },
-  detailCategory: {
-    fontSize: 13,
-    color: '#6B7280',
     marginBottom: 12,
   },
   detailDescription: {
     fontSize: 13,
     color: '#4B5563',
-    marginBottom: 12,
+    marginBottom: 6,
     lineHeight: 18,
   },
-  detailBonuses: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-    marginBottom: 12,
+  detailList: {
+    marginBottom: 10,
   },
-  bonusBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
-    backgroundColor: '#DCFCE7',
-  },
-  bonusBadgeText: {
+  detailListText: {
     fontSize: 12,
-    color: '#166534',
+    color: '#1F2937',
     fontWeight: '600',
+    lineHeight: 16,
   },
-  detailEffects: {
-    marginBottom: 12,
+  detailSkillDescriptionSection: {
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+    paddingTop: 10,
   },
-  effectText: {
+  detailSkillDescriptionBlock: {
+    marginBottom: 8,
+  },
+  detailSkillName: {
     fontSize: 12,
-    color: '#7C3AED',
-    marginBottom: 4,
+    fontWeight: '600',
+    color: '#1F2937',
+    marginBottom: 2,
+  },
+  detailSkillDescription: {
+    fontSize: 12,
+    lineHeight: 16,
+    color: '#4B5563',
   },
   detailActions: {
     flexDirection: 'row',
     gap: 10,
-    marginTop: 4,
+    marginTop: 0,
+    paddingHorizontal: 24,
+    paddingBottom: 20,
   },
   unequipButton: {
     flex: 1,

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -116,6 +116,14 @@ export function getAccuracyModifier(attackNumber: number): number {
 }
 
 /**
+ * 命中率計算に使う乱数係数
+ * 0.95 <= rand < 1.05 に収め、式全体を過度に変動させないようにする
+ */
+export function getHitRateRandomModifier(rng: () => number): number {
+  return 0.95 + rng() * 0.1
+}
+
+/**
  * 隊列の狙われ率の重みを取得
  * row 0→1/2, row 1→1/4, ... 最後2列は同率
  * totalRows: 生存列数
@@ -400,6 +408,7 @@ export class BattleSystem {
   /**
    * 命中率を計算
    * 命中率 = 乱数A × (命中精度 × 攻撃回数補正 − 回避能力 × 残りHP補正)
+   * 乱数A は 0.95 以上 1.05 未満
    * clamp(5, 95)
    */
   private calculateHitRate(
@@ -409,7 +418,7 @@ export class BattleSystem {
     rng: () => number,
   ): number {
     const accMod = getAccuracyModifier(attackNumber)
-    const rand = rng()
+    const rand = getHitRateRandomModifier(rng)
 
     // 残りHP補正 = 0.5 * (1 + 残りHP / 最大HP)
     const hpRatio = defender.maxHP > 0 ? defender.currentHP / defender.maxHP : 0

--- a/goblin_native/src/core/services/EquipmentService.ts
+++ b/goblin_native/src/core/services/EquipmentService.ts
@@ -1,6 +1,6 @@
 import type { Goblin } from '../../shared/types/Goblin'
 import type { CharacterSkill } from '../../shared/types/CharacterSkill'
-import type { EquipmentInstance, EquipmentStatBonus, EquipmentEffect } from '../../shared/types/Equipment'
+import type { EquipmentInstance, EquipmentStatBonus } from '../../shared/types/Equipment'
 import { calculateSlotCount } from '../../shared/data/equipmentConfig'
 import { getEquipmentTemplate } from '../../shared/data/equipmentPoolLoader'
 import { cloneCharacterSkill } from '../../shared/data/characterSkills'
@@ -21,10 +21,31 @@ export class EquipmentService {
     }
 
     if (value > 0) {
+      if (!Number.isInteger(value)) {
+        return Number((value * titleDef.plusMultiplier).toFixed(4))
+      }
       return Math.floor(value * titleDef.plusMultiplier)
     }
 
+    if (!Number.isInteger(value)) {
+      return -Number((Math.abs(value) * titleDef.minusMultiplier).toFixed(4))
+    }
+
     return -Math.floor(Math.abs(value) * titleDef.minusMultiplier)
+  }
+
+  private static scaleGrantedSkillByTitle(skill: CharacterSkill, equipment: EquipmentInstance): CharacterSkill {
+    const scaled = cloneCharacterSkill(skill)
+
+    if (scaled.defToHpPercent !== undefined) {
+      scaled.defToHpPercent = this.scaleValueByTitle(scaled.defToHpPercent, equipment)
+    }
+
+    if (scaled.criticalDamageBonusPercent !== undefined) {
+      scaled.criticalDamageBonusPercent = this.scaleValueByTitle(scaled.criticalDamageBonusPercent, equipment)
+    }
+
+    return scaled
   }
 
   /**
@@ -71,13 +92,13 @@ export class EquipmentService {
     let unequipped: EquipmentInstance | undefined
     if (existing) {
       unequipped = this.unequip(existing)
-      this.removeGrantedSkills(goblin, existing.templateId)
+      this.removeGrantedSkills(goblin, existing)
     }
 
     // 装備を装着
     equipment.goblinId = goblin.id
     equipment.slotIndex = slotIndex
-    this.addGrantedSkills(goblin, equipment.templateId)
+    this.addGrantedSkills(goblin, equipment)
 
     return { success: true, unequipped }
   }
@@ -87,7 +108,7 @@ export class EquipmentService {
    */
   static unequip(equipment: EquipmentInstance, goblin?: Goblin): EquipmentInstance {
     if (goblin) {
-      this.removeGrantedSkills(goblin, equipment.templateId)
+      this.removeGrantedSkills(goblin, equipment)
     }
 
     return {
@@ -122,31 +143,6 @@ export class EquipmentService {
     return bonuses
   }
 
-  /**
-   * ゴブリンの装備から特殊効果を収集
-   * ModStatCalculator に渡してステータス確定後に適用
-   */
-  static collectEquipmentEffects(
-    equipped: EquipmentInstance[]
-  ): EquipmentEffect[] {
-    const effects: EquipmentEffect[] = []
-
-    for (const eq of equipped) {
-      const template = getEquipmentTemplate(eq.templateId)
-      if (!template?.effects) continue
-
-      for (const effect of template.effects) {
-        effects.push({
-          ...effect,
-          value: this.scaleValueByTitle(effect.value, eq),
-          sourceCategory: template.category,
-        })
-      }
-    }
-
-    return effects
-  }
-
   static collectGrantedSkills(equipped: EquipmentInstance[]): CharacterSkill[] {
     const skills: CharacterSkill[] = []
 
@@ -155,27 +151,21 @@ export class EquipmentService {
       if (!template?.grantedSkills) continue
 
       for (const skill of template.grantedSkills) {
-        skills.push(cloneCharacterSkill(skill))
+        skills.push(this.scaleGrantedSkillByTitle(skill, eq))
       }
     }
 
     return skills
   }
 
-  private static addGrantedSkills(goblin: Goblin, templateId: string): void {
-    const template = getEquipmentTemplate(templateId)
-    if (!template?.grantedSkills?.length) return
-
-    for (const skill of template.grantedSkills) {
-      goblin.skills.push(cloneCharacterSkill(skill))
+  private static addGrantedSkills(goblin: Goblin, equipment: EquipmentInstance): void {
+    for (const skill of this.collectGrantedSkills([equipment])) {
+      goblin.skills.push(skill)
     }
   }
 
-  private static removeGrantedSkills(goblin: Goblin, templateId: string): void {
-    const template = getEquipmentTemplate(templateId)
-    if (!template?.grantedSkills?.length) return
-
-    for (const grantedSkill of template.grantedSkills) {
+  private static removeGrantedSkills(goblin: Goblin, equipment: EquipmentInstance): void {
+    for (const grantedSkill of this.collectGrantedSkills([equipment])) {
       const index = goblin.skills.findIndex((skill) => this.isSameSkill(skill, grantedSkill))
       if (index >= 0) {
         goblin.skills.splice(index, 1)

--- a/goblin_native/src/core/services/ModStatCalculator.ts
+++ b/goblin_native/src/core/services/ModStatCalculator.ts
@@ -1,10 +1,11 @@
 import type { Goblin, GoblinStats } from '../../shared/types/Goblin'
 import type { ModInstance } from '../../shared/types/Mod'
-import type { EquipmentStatBonus, EquipmentEffect } from '../../shared/types/Equipment'
+import type { CharacterSkill } from '../../shared/types/CharacterSkill'
+import type { EquipmentStatBonus } from '../../shared/types/Equipment'
 import { getModTemplate, getDamageReductionCap } from '../../shared/data/modPoolLoader'
 import {
   applySkillBonusesToEquipmentBonuses,
-  applySkillBonusesToEquipmentEffects,
+  getUniqueSkillsById,
   getSkillStatBonuses,
   getSkillStatMultipliers,
 } from '../../shared/data/characterSkills'
@@ -32,7 +33,6 @@ export class ModStatCalculator {
   static calculate(
     goblin: Goblin,
     equipmentBonuses?: EquipmentStatBonus[],
-    equipmentEffects?: EquipmentEffect[]
   ): GoblinStats {
     const base = {
       ...goblin.stats,
@@ -59,7 +59,6 @@ export class ModStatCalculator {
     const skillBonuses = getSkillStatBonuses(goblin.skills)
     const skillMultipliers = getSkillStatMultipliers(goblin.skills)
     const adjustedEquipmentBonuses = applySkillBonusesToEquipmentBonuses(goblin.skills, equipmentBonuses ?? [])
-    const adjustedEquipmentEffects = applySkillBonusesToEquipmentEffects(goblin.skills, equipmentEffects ?? [])
     const equipFlat = this.aggregateEquipmentFlat(adjustedEquipmentBonuses)
     const equipPercent = this.aggregateEquipmentPercent(adjustedEquipmentBonuses)
 
@@ -88,8 +87,8 @@ export class ModStatCalculator {
       evasion: withMultiplier('evasion'),
     }
 
-    // 6. 装備特殊効果を適用（ステータス確定後）
-    this.applyEquipmentEffects(result, adjustedEquipmentEffects)
+    // 6. パッシブスキル由来の最終効果を適用（ステータス確定後）
+    this.applyPassiveSkillEffects(result, goblin.skills)
 
     return result
   }
@@ -217,21 +216,13 @@ export class ModStatCalculator {
     return result
   }
 
-  /**
-   * 装備特殊効果をステータス確定後に適用
-   * - def_to_hp: 最終防御力のX%をHPに加算
-   * - critical_damage_bonus / accuracy_boost: BattleSystem側で処理（ステータス計算には影響しない）
-   */
-  private static applyEquipmentEffects(
+  private static applyPassiveSkillEffects(
     stats: GoblinStats,
-    effects: EquipmentEffect[]
+    skills: CharacterSkill[],
   ): void {
-    for (const effect of effects) {
-      switch (effect.type) {
-        case 'def_to_hp':
-          stats.hp += Math.floor(stats.def * effect.value / 100)
-          break
-        // critical_damage_bonus, accuracy_boost は戦闘時に参照（BattleSystem未実装）
+    for (const skill of getUniqueSkillsById(skills)) {
+      if (skill.defToHpPercent !== undefined) {
+        stats.hp += Math.floor(stats.def * skill.defToHpPercent / 100)
       }
     }
   }

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1,6 +1,6 @@
 import { GoblinBirthService } from '../GoblinBirthService'
 import { ModStatCalculator } from '../ModStatCalculator'
-import { BattleSystem, getDamageModifier, getAccuracyModifier, getRowWeight, selectTarget } from '../BattleSystem'
+import { BattleSystem, getDamageModifier, getAccuracyModifier, getHitRateRandomModifier, getRowWeight, selectTarget } from '../BattleSystem'
 import { ExpeditionEngine } from '../ExpeditionEngine'
 import { getDefaultSkillsForRace } from '../../../shared/data/raceSkills'
 import { getBloodlineAttackCountBonus } from '../../../shared/data/equipmentConfig'
@@ -112,6 +112,20 @@ describe('getAccuracyModifier', () => {
 
   it('10回目は0.6 * 0.9^8 ≈ 0.2583', () => {
     expect(getAccuracyModifier(10)).toBeCloseTo(0.6 * Math.pow(0.9, 8), 4)
+  })
+})
+
+describe('getHitRateRandomModifier', () => {
+  it('rng=0 のとき 0.95 になる', () => {
+    expect(getHitRateRandomModifier(() => 0)).toBeCloseTo(0.95, 5)
+  })
+
+  it('rng=0.5 のとき 1.0 になる', () => {
+    expect(getHitRateRandomModifier(() => 0.5)).toBeCloseTo(1.0, 5)
+  })
+
+  it('rng が 1 未満なら 1.05 未満に収まる', () => {
+    expect(getHitRateRandomModifier(() => 0.999999)).toBeLessThan(1.05)
   })
 })
 
@@ -317,13 +331,24 @@ describe('ModStatCalculator — 戦闘ステータス計算', () => {
     ]))
   })
 
-  it('EquipmentServiceは称号付き装備の特殊効果にも倍率適用する', () => {
-    const effects = EquipmentService.collectEquipmentEffects([
+  it('EquipmentServiceは武器能力値を通常ボーナスとして扱う', () => {
+    const bonuses = EquipmentService.calculateEquipmentBonuses([
+      { id: 'eq1', templateId: 'sword_broad', slotIndex: 0, goblinId: 1 },
+    ])
+
+    expect(bonuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({ stat: 'accuracy_flat', value: 32, sourceCategory: 'weapon' }),
+      expect.objectContaining({ stat: 'attackCount_flat', value: -0.2, sourceCategory: 'weapon' }),
+    ]))
+  })
+
+  it('EquipmentServiceは称号付き装備のパッシブスキルにも倍率適用する', () => {
+    const skills = EquipmentService.collectGrantedSkills([
       { id: 'eq1', templateId: 'sword_broad', slotIndex: 0, goblinId: 1, titleId: 'masterwork' },
     ])
 
-    expect(effects).toEqual(expect.arrayContaining([
-      expect.objectContaining({ type: 'def_to_hp', value: 2, sourceCategory: 'weapon' }),
+    expect(skills).toEqual(expect.arrayContaining([
+      expect.objectContaining({ defToHpPercent: 2 }),
     ]))
   })
 
@@ -664,7 +689,7 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const rear = result.detailedLog.find(log => log.action === '通常攻撃' && !log.isAlly)!.targets.find(target => target.targetId === '3')
 
     expect(rear).toBeDefined()
-    expect(rear!.totalDamage).toBe(203)
+    expect(rear!.totalDamage).toBe(239)
   })
 
   it('遠征戦闘でもスライムゴブリンの後列防護が適用される', () => {

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -1,7 +1,6 @@
 import type {
   CharacterSkill,
   EquipmentCategory,
-  EquipmentEffect,
   EquipmentStat,
   EquipmentStatBonus,
   GoblinStats,
@@ -77,6 +76,14 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
     return i18n.t('battle.additionalDamage', { value: skill.additionalDamage })
   }
 
+  if (skill.defToHpPercent !== undefined) {
+    return skill.name
+  }
+
+  if (skill.criticalDamageBonusPercent !== undefined) {
+    return skill.name
+  }
+
   if (skill.protectRearAllyNormalAttackMultiplier !== undefined) {
     const reducedRate = Math.round((1 - skill.protectRearAllyNormalAttackMultiplier) * 100)
     return i18n.t('battle.rearProtection', { value: reducedRate })
@@ -99,6 +106,18 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
   }
 
   return getSkillLabel(skill)
+}
+
+export function getCharacterSkillDescription(skill: CharacterSkill): string {
+  if (skill.enablesMeleeRowDamagePenalty) {
+    return '隊列の後ろに行くほど通常攻撃のダメージが低下します。'
+  }
+
+  if (skill.enablesRangedRowDamagePenalty) {
+    return '隊列の前に行くほど通常攻撃のダメージが低下します。'
+  }
+
+  return describeCharacterSkill(skill)
 }
 
 export function getSkillStatBonuses(skills: CharacterSkill[]): Partial<Record<keyof GoblinStats, number>> {
@@ -239,17 +258,4 @@ export function applySkillBonusesToEquipmentBonuses(
     ...bonus,
     value: bonus.value * getEquipmentValueMultiplier(skills, bonus.sourceCategory, bonus.stat),
   }))
-}
-
-export function applySkillBonusesToEquipmentEffects(
-  skills: CharacterSkill[],
-  effects: EquipmentEffect[],
-): EquipmentEffect[] {
-  return effects.map((effect) => {
-    const statKey = effect.type === 'accuracy_boost' ? 'accuracy_flat' : undefined
-    return {
-      ...effect,
-      value: effect.value * getEquipmentValueMultiplier(skills, effect.sourceCategory, statKey),
-    }
-  })
 }

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -13,12 +13,12 @@
         {
           "stat": "atk_flat",
           "value": 2
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 8
         }
       ],
-      "weaponStats": {
-        "accuracy": 8,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 5,
       "unlockRank": 1,
@@ -39,12 +39,16 @@
         {
           "stat": "def_flat",
           "value": 1
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 16
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.1
         }
       ],
-      "weaponStats": {
-        "accuracy": 16,
-        "attackCountModifier": -0.1
-      },
       "range": "melee",
       "price": 15,
       "unlockRank": 1,
@@ -65,17 +69,18 @@
         {
           "stat": "def_flat",
           "value": 2
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 24
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 24,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 1
-        }
+      "grantedSkillIds": [
+        "def_to_hp_1"
       ],
       "range": "melee",
       "price": 30,
@@ -97,17 +102,18 @@
         {
           "stat": "def_flat",
           "value": 3
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 32
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 32,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 2
-        }
+      "grantedSkillIds": [
+        "def_to_hp_2"
       ],
       "range": "melee",
       "price": 60,
@@ -129,17 +135,18 @@
         {
           "stat": "def_flat",
           "value": 4
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 48
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 48,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 3
-        }
+      "grantedSkillIds": [
+        "def_to_hp_3"
       ],
       "range": "melee",
       "price": 100,
@@ -161,17 +168,18 @@
         {
           "stat": "def_flat",
           "value": 6
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 72
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 72,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 4
-        }
+      "grantedSkillIds": [
+        "def_to_hp_4"
       ],
       "range": "melee",
       "price": 500,
@@ -192,17 +200,18 @@
         {
           "stat": "def_flat",
           "value": 8
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 96
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 96,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 5
-        }
+      "grantedSkillIds": [
+        "def_to_hp_5"
       ],
       "range": "melee",
       "price": 2500,
@@ -223,17 +232,18 @@
         {
           "stat": "def_flat",
           "value": 10
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 144
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 144,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 6
-        }
+      "grantedSkillIds": [
+        "def_to_hp_6"
       ],
       "range": "melee",
       "price": 12500,
@@ -255,17 +265,18 @@
         {
           "stat": "def_flat",
           "value": 12
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 192
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.2
         }
       ],
-      "weaponStats": {
-        "accuracy": 192,
-        "attackCountModifier": -0.2
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 7
-        }
+      "grantedSkillIds": [
+        "def_to_hp_7"
       ],
       "range": "melee",
       "price": 60000,
@@ -287,17 +298,18 @@
         {
           "stat": "def_flat",
           "value": 24
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 288
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.4
         }
       ],
-      "weaponStats": {
-        "accuracy": 288,
-        "attackCountModifier": -0.4
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 8
-        }
+      "grantedSkillIds": [
+        "def_to_hp_8"
       ],
       "range": "melee",
       "price": 240000,
@@ -318,17 +330,18 @@
         {
           "stat": "def_flat",
           "value": 36
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 384
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
         }
       ],
-      "weaponStats": {
-        "accuracy": 384,
-        "attackCountModifier": -0.6
-      },
-      "effects": [
-        {
-          "type": "def_to_hp",
-          "value": 9
-        }
+      "grantedSkillIds": [
+        "def_to_hp_9"
       ],
       "range": "melee",
       "price": 720000,
@@ -348,12 +361,12 @@
         {
           "stat": "atk_flat",
           "value": 1
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 16
         }
       ],
-      "weaponStats": {
-        "accuracy": 16,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 5,
       "unlockRank": 1,
@@ -373,12 +386,12 @@
         {
           "stat": "atk_flat",
           "value": 3
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 24
         }
       ],
-      "weaponStats": {
-        "accuracy": 24,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 15,
       "unlockRank": 1,
@@ -398,12 +411,12 @@
         {
           "stat": "atk_flat",
           "value": 5
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 32
         }
       ],
-      "weaponStats": {
-        "accuracy": 32,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 30,
       "unlockRank": 1,
@@ -423,12 +436,12 @@
         {
           "stat": "atk_flat",
           "value": 7
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 40
         }
       ],
-      "weaponStats": {
-        "accuracy": 40,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 60,
       "unlockRank": 1,
@@ -448,12 +461,12 @@
         {
           "stat": "atk_flat",
           "value": 10
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 56
         }
       ],
-      "weaponStats": {
-        "accuracy": 56,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 100,
       "unlockRank": 1,
@@ -473,12 +486,12 @@
         {
           "stat": "atk_flat",
           "value": 14
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 80
         }
       ],
-      "weaponStats": {
-        "accuracy": 80,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 500,
       "dropLevelMin": 20,
@@ -497,12 +510,12 @@
         {
           "stat": "atk_flat",
           "value": 18
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 104
         }
       ],
-      "weaponStats": {
-        "accuracy": 104,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 2500,
       "dropLevelMin": 35,
@@ -521,12 +534,12 @@
         {
           "stat": "atk_flat",
           "value": 26
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 152
         }
       ],
-      "weaponStats": {
-        "accuracy": 152,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 12500,
       "unlockRank": 3,
@@ -546,12 +559,12 @@
         {
           "stat": "atk_flat",
           "value": 34
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 208
         }
       ],
-      "weaponStats": {
-        "accuracy": 208,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 60000,
       "unlockRank": 5,
@@ -571,12 +584,12 @@
         {
           "stat": "atk_flat",
           "value": 48
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 304
         }
       ],
-      "weaponStats": {
-        "accuracy": 304,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 240000,
       "dropLevelMin": 95,
@@ -595,12 +608,12 @@
         {
           "stat": "atk_flat",
           "value": 64
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 400
         }
       ],
-      "weaponStats": {
-        "accuracy": 400,
-        "attackCountModifier": 0
-      },
       "range": "melee",
       "price": 720000,
       "dropLevelMin": 120,
@@ -622,12 +635,12 @@
         {
           "stat": "atk_flat",
           "value": 3
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 16
         }
       ],
-      "weaponStats": {
-        "accuracy": 16,
-        "attackCountModifier": 0
-      },
       "range": "ranged",
       "price": 10,
       "unlockRank": 1,
@@ -644,12 +657,16 @@
         {
           "stat": "atk_flat",
           "value": 6
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 32
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.1
         }
       ],
-      "weaponStats": {
-        "accuracy": 32,
-        "attackCountModifier": -0.1
-      },
       "range": "ranged",
       "price": 40,
       "unlockRank": 1,
@@ -666,22 +683,22 @@
         {
           "stat": "atk_flat",
           "value": 20
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 64,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -8
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 6
         },
         {
-          "type": "accuracy_boost",
-          "value": 30
+          "stat": "accuracy_flat",
+          "value": 94
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -8
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_6"
       ],
       "range": "ranged",
       "price": 1000,
@@ -699,22 +716,22 @@
         {
           "stat": "atk_flat",
           "value": 30
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 96,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -12
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 7
         },
         {
-          "type": "accuracy_boost",
-          "value": 50
+          "stat": "accuracy_flat",
+          "value": 146
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -12
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_7"
       ],
       "range": "ranged",
       "price": 5000,
@@ -731,22 +748,22 @@
         {
           "stat": "atk_flat",
           "value": 45
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 128,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -16
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 8
         },
         {
-          "type": "accuracy_boost",
-          "value": 70
+          "stat": "accuracy_flat",
+          "value": 198
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -16
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_8"
       ],
       "range": "ranged",
       "price": 25000,
@@ -763,22 +780,22 @@
         {
           "stat": "atk_flat",
           "value": 60
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 192,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -24
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 9
         },
         {
-          "type": "accuracy_boost",
-          "value": 90
+          "stat": "accuracy_flat",
+          "value": 282
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -24
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_9"
       ],
       "range": "ranged",
       "price": 125000,
@@ -796,22 +813,22 @@
         {
           "stat": "atk_flat",
           "value": 90
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 256,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -32
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 10
         },
         {
-          "type": "accuracy_boost",
-          "value": 110
+          "stat": "accuracy_flat",
+          "value": 366
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -32
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_10"
       ],
       "range": "ranged",
       "price": 500000,
@@ -829,22 +846,22 @@
         {
           "stat": "atk_flat",
           "value": 120
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 320,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -40
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 11
         },
         {
-          "type": "accuracy_boost",
-          "value": 130
+          "stat": "accuracy_flat",
+          "value": 450
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -40
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_11"
       ],
       "range": "ranged",
       "price": 1500000,
@@ -861,22 +878,22 @@
         {
           "stat": "atk_flat",
           "value": 160
-        }
-      ],
-      "weaponStats": {
-        "accuracy": 400,
-        "attackCountModifier": -0.6,
-        "evasionModifier": -50
-      },
-      "effects": [
-        {
-          "type": "critical_damage_bonus",
-          "value": 12
         },
         {
-          "type": "accuracy_boost",
-          "value": 150
+          "stat": "accuracy_flat",
+          "value": 550
+        },
+        {
+          "stat": "attackCount_flat",
+          "value": -0.6
+        },
+        {
+          "stat": "evasion_flat",
+          "value": -50
         }
+      ],
+      "grantedSkillIds": [
+        "critical_damage_bonus_12"
       ],
       "range": "ranged",
       "price": 3000000,

--- a/goblin_native/src/shared/data/equipmentPoolLoader.ts
+++ b/goblin_native/src/shared/data/equipmentPoolLoader.ts
@@ -47,8 +47,6 @@ function normalizeTemplate(template: EquipmentTemplate): EquipmentTemplate {
   return {
     ...template,
     statBonuses: template.statBonuses.map((bonus) => ({ ...bonus })),
-    weaponStats: template.weaponStats ? { ...template.weaponStats } : undefined,
-    effects: template.effects?.map((effect) => ({ ...effect })),
     grantedSkills: buildGrantedSkills(template),
   }
 }

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -24,6 +24,22 @@ function createAttackCountUpSkill(value: number): CharacterSkill {
   }
 }
 
+function createDefToHpSkill(value: number): CharacterSkill {
+  return {
+    id: `def_to_hp_${value}`,
+    name: `防御力の${value}%をHPに加算`,
+    defToHpPercent: value,
+  }
+}
+
+function createCriticalDamageBonusSkill(value: number): CharacterSkill {
+  return {
+    id: `critical_damage_bonus_${value}`,
+    name: `会心威力+${value}%`,
+    criticalDamageBonusPercent: value,
+  }
+}
+
 function createPhysicalReductionSkill(value: number): CharacterSkill {
   return {
     id: `physical_reduction_${value}`,
@@ -78,6 +94,24 @@ export const CHARACTER_SKILL_CATALOG = {
     name: 'かばう',
     coverLowHpAlly: true,
   },
+
+  critical_damage_bonus_6: createCriticalDamageBonusSkill(6),
+  critical_damage_bonus_7: createCriticalDamageBonusSkill(7),
+  critical_damage_bonus_8: createCriticalDamageBonusSkill(8),
+  critical_damage_bonus_9: createCriticalDamageBonusSkill(9),
+  critical_damage_bonus_10: createCriticalDamageBonusSkill(10),
+  critical_damage_bonus_11: createCriticalDamageBonusSkill(11),
+  critical_damage_bonus_12: createCriticalDamageBonusSkill(12),
+
+  def_to_hp_1: createDefToHpSkill(1),
+  def_to_hp_2: createDefToHpSkill(2),
+  def_to_hp_3: createDefToHpSkill(3),
+  def_to_hp_4: createDefToHpSkill(4),
+  def_to_hp_5: createDefToHpSkill(5),
+  def_to_hp_6: createDefToHpSkill(6),
+  def_to_hp_7: createDefToHpSkill(7),
+  def_to_hp_8: createDefToHpSkill(8),
+  def_to_hp_9: createDefToHpSkill(9),
 
   equipment_accuracy_200: {
     id: 'equipment_accuracy_200',

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -6,6 +6,8 @@ export interface CharacterSkill {
   name: string
   statBonuses?: Partial<Record<keyof GoblinStats, number>>
   statMultipliers?: Partial<Record<keyof GoblinStats, number>>
+  defToHpPercent?: number
+  criticalDamageBonusPercent?: number
   actionOrderMultiplier?: number
   equipmentCategoryMultiplier?: Partial<Record<EquipmentCategory, number>>
   equipmentStatMultipliers?: Partial<Record<EquipmentStat, number>>

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -45,29 +45,6 @@ export interface EquipmentStatBonus {
 }
 
 /**
- * 装備の特殊効果
- * - def_to_hp: 最終防御力のX%をHPに加算（剣の付加効果）
- * - critical_damage_bonus: 必殺威力の増減%（弓の付加効果）
- * - accuracy_boost: 命中精度アップ（弓の付加効果）
- */
-export type EquipmentEffectType = 'def_to_hp' | 'critical_damage_bonus' | 'accuracy_boost'
-
-export interface EquipmentEffect {
-  type: EquipmentEffectType
-  value: number // def_to_hp: %, critical_damage_bonus: %, accuracy_boost: フラット値
-  sourceCategory?: EquipmentCategory
-}
-
-/**
- * 武器固有ステータス（戦闘システム用）
- */
-export interface WeaponStats {
-  accuracy: number             // 命中精度
-  attackCountModifier: number  // 攻撃回数補正（-0.2 = 重い武器で攻撃頻度低下）
-  evasionModifier?: number     // 回避能力補正（-8 = 弓装備時の回避低下）
-}
-
-/**
  * 装備テンプレート定義（JSONから読み込み）
  */
 export interface EquipmentTemplate {
@@ -78,8 +55,6 @@ export interface EquipmentTemplate {
   statBonuses: EquipmentStatBonus[]
   grantedSkillIds?: string[]
   grantedSkills?: CharacterSkill[]
-  weaponStats?: WeaponStats
-  effects?: EquipmentEffect[]
   range?: WeaponRange
   price: number
   unlockRank?: number  // 店売り解放に必要な拠点ランク（未設定=店売りなし）

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -40,9 +40,6 @@ export type {
   WeaponRange,
   EquipmentStat,
   EquipmentStatBonus,
-  EquipmentEffectType,
-  EquipmentEffect,
-  WeaponStats,
   EquipmentTemplate,
   EquipmentInstance,
 } from "./Equipment"

--- a/goblin_native/src/shared/utils/goblinStats.ts
+++ b/goblin_native/src/shared/utils/goblinStats.ts
@@ -9,8 +9,11 @@ export function calculateGoblinEffectiveStats(
   equippedItems: EquipmentInstance[] = [],
 ): GoblinStats {
   const equipmentBonuses = EquipmentService.calculateEquipmentBonuses(equippedItems)
-  const equipmentEffects = EquipmentService.collectEquipmentEffects(equippedItems)
-  return ModStatCalculator.calculate(goblin, equipmentBonuses, equipmentEffects)
+  const equipmentSkills = EquipmentService.collectGrantedSkills(equippedItems)
+  return ModStatCalculator.calculate({
+    ...goblin,
+    skills: [...goblin.skills, ...equipmentSkills],
+  }, equipmentBonuses)
 }
 
 /**


### PR DESCRIPTION
## Summary
- 武器固有ステータス(`weaponStats.accuracy`, `attackCountModifier`)を通常の`bonuses`配列(`accuracy_flat`, `attackCount_flat`)に統合
- 装備特殊効果(`EquipmentEffect`: `def_to_hp`, `critical_damage_bonus`)を`CharacterSkill`のプロパティ(`defToHpPercent`, `criticalDamageBonusPercent`)に移行し、`grantedSkillIds`経由で付与
- 命中率計算の乱数係数を0.95〜1.05に制約（`getHitRateRandomModifier`）
- 装備詳細モーダルを`ItemDetail`に統一し、スキル説明・infoボタンを追加

## Test plan
- [ ] `npm test` で既存テストがパスすることを確認
- [ ] 装備画面で各カテゴリの装備・解除が正常に動作する
- [ ] 装備詳細モーダルでボーナスとスキル説明が正しく表示される
- [ ] 称号付き装備のスキル値にも倍率が適用されている
- [ ] 遠征戦闘で命中率・ダメージが期待通り計算される

🤖 Generated with [Claude Code](https://claude.com/claude-code)