### PR TITLE
feat(expedition): ダンジョンティアシステムを追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -9,8 +9,8 @@ import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
-import { normalizePartyRewardMultipliers } from '@/shared/types'
-import type { ExpeditionRequest, Goblin, Dungeon, Party } from '@/shared/types'
+import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierDisplayName } from '@/shared/types'
+import type { ExpeditionRequest, Goblin, Dungeon, Party, DungeonTier } from '@/shared/types'
 import { getDungeonDescription, getDungeonName, getReturnPolicyLabel } from '@/shared/i18n/entityLocalization'
 
 type ReturnPolicy = ExpeditionRequest['returnPolicy']
@@ -64,6 +64,7 @@ export default function ExpeditionPreparationScreen() {
     isLoading: partiesLoading,
     getPartyById,
     setDungeon,
+    setDungeonTier,
     setReturnPolicy,
     setTargetFloor,
     updateName,
@@ -99,6 +100,7 @@ export default function ExpeditionPreparationScreen() {
   }, [party, partiesLoading, partyId, retryCount, refreshParties])
 
   const [selectedDungeonId, setSelectedDungeonId] = useState<string | undefined>(party?.dungeonId)
+  const [selectedTier, setSelectedTier] = useState<DungeonTier>(party?.dungeonTier ?? 0)
   const [selectedReturnPolicy, setSelectedReturnPolicy] = useState<ReturnPolicy>(party?.returnPolicy ?? 'never')
   const [selectedTargetFloor, setSelectedTargetFloor] = useState<number | null>(party?.targetFloor ?? null)
   const [isDungeonModalVisible, setIsDungeonModalVisible] = useState(false)
@@ -111,6 +113,7 @@ export default function ExpeditionPreparationScreen() {
   useEffect(() => {
     if (party) {
       setSelectedDungeonId(party.dungeonId)
+      setSelectedTier(party.dungeonTier ?? 0)
       setSelectedReturnPolicy(party.returnPolicy ?? 'never')
       setSelectedTargetFloor(party.targetFloor ?? null)
       setEditingPartyName(party.name)
@@ -204,12 +207,40 @@ export default function ExpeditionPreparationScreen() {
     }
   }, [editingPartyName, partyId, updateName])
 
+  // 選択中ダンジョンの最大解放ティアを計算
+  const maxUnlockedTier = useMemo((): DungeonTier => {
+    if (!selectedDungeon) return 0
+    const maxCleared = selectedDungeon.maxClearedTier ?? 0
+    // maxClearedTier=1 → 通常クリア済み → 魔性(tier=1)まで解放
+    // maxClearedTier=0 → 未クリア → 通常(tier=0)のみ
+    return Math.min(maxCleared, 3) as DungeonTier
+  }, [selectedDungeon])
+
+  // ダンジョン変更時にティアをデフォルト選択
+  const autoSelectTier = useCallback((dungeon: Dungeon) => {
+    const maxCleared = dungeon.maxClearedTier ?? 0
+    // 魔性以上が解放されている場合は最高解放ティアをデフォルト選択
+    const defaultTier = Math.min(maxCleared, 3) as DungeonTier
+    setSelectedTier(defaultTier)
+    if (partyId) {
+      void setDungeonTier(parseInt(partyId, 10), defaultTier)
+    }
+  }, [partyId, setDungeonTier])
+
   const handleSelectDungeon = useCallback((dungeon: Dungeon) => {
     setSelectedDungeonId(dungeon.id)
     if (partyId) {
       void setDungeon(parseInt(partyId, 10), dungeon.id)
     }
-  }, [partyId, setDungeon])
+    autoSelectTier(dungeon)
+  }, [partyId, setDungeon, autoSelectTier])
+
+  const handleSelectTier = useCallback((tier: DungeonTier) => {
+    setSelectedTier(tier)
+    if (partyId) {
+      void setDungeonTier(parseInt(partyId, 10), tier)
+    }
+  }, [partyId, setDungeonTier])
 
   const handleSelectReturnPolicy = useCallback((policy: ReturnPolicy) => {
     setSelectedReturnPolicy(policy)
@@ -240,6 +271,7 @@ export default function ExpeditionPreparationScreen() {
           party,
           dungeon: selectedDungeon,
           returnPolicy: selectedReturnPolicy,
+          tier: selectedTier,
         })
 
         router.dismissAll()
@@ -270,6 +302,7 @@ export default function ExpeditionPreparationScreen() {
     selectedDungeon,
     selectedDungeonId,
     selectedReturnPolicy,
+    selectedTier,
     partyMembers.length,
     startExpedition,
     t,
@@ -377,7 +410,9 @@ export default function ExpeditionPreparationScreen() {
               >
                 {selectedDungeon ? (
                   <>
-                    <Text style={styles.settingValueText}>{formatDungeonLabel(selectedDungeon)}</Text>
+                    <Text style={styles.settingValueText}>
+                      {getDungeonTierDisplayName(formatDungeonLabel(selectedDungeon), selectedTier)}
+                    </Text>
                     <Text style={styles.settingValueDescription}>{getDungeonDescription(selectedDungeon)}</Text>
                   </>
                 ) : (
@@ -385,6 +420,40 @@ export default function ExpeditionPreparationScreen() {
                 )}
               </TouchableOpacity>
             </View>
+
+            {/* ティア（称号） */}
+            {selectedDungeon && (
+              <View style={styles.settingItem}>
+                <Text style={styles.settingLabel}>{t('ui.formation.preparation.dungeonTier')}</Text>
+                <View style={styles.tierSelector}>
+                  {DUNGEON_TIER_META.map((meta) => {
+                    const isUnlocked = meta.tier <= maxUnlockedTier
+                    const isSelected = selectedTier === meta.tier
+                    return (
+                      <TouchableOpacity
+                        key={meta.tier}
+                        style={[
+                          styles.tierButton,
+                          isSelected && styles.tierButtonSelected,
+                          !isUnlocked && styles.tierButtonLocked,
+                        ]}
+                        onPress={() => isUnlocked && handleSelectTier(meta.tier as DungeonTier)}
+                        disabled={!isUnlocked}
+                      >
+                        <Text style={[
+                          styles.tierButtonText,
+                          isSelected && styles.tierButtonTextSelected,
+                          !isUnlocked && styles.tierButtonTextLocked,
+                        ]}>
+                          {t(meta.labelKey)}
+                        </Text>
+                        {!isUnlocked && <Text style={styles.tierLockIcon}>🔒</Text>}
+                      </TouchableOpacity>
+                    )
+                  })}
+                </View>
+              </View>
+            )}
 
             {/* 目標階数 */}
             <View style={styles.settingItem}>
@@ -721,6 +790,44 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#1D4ED8',
+  },
+  tierSelector: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  tierButton: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+    backgroundColor: '#F3F4F6',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  tierButtonSelected: {
+    backgroundColor: '#DBEAFE',
+    borderColor: '#3B82F6',
+  },
+  tierButtonLocked: {
+    backgroundColor: '#F9FAFB',
+    borderColor: '#E5E7EB',
+    opacity: 0.5,
+  },
+  tierButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#374151',
+  },
+  tierButtonTextSelected: {
+    color: '#1D4ED8',
+  },
+  tierButtonTextLocked: {
+    color: '#9CA3AF',
+  },
+  tierLockIcon: {
+    fontSize: 10,
+    marginTop: 2,
   },
   settingItem: {
     marginBottom: 12,

--- a/goblin_native/src/core/repositories/IPartyRepository.ts
+++ b/goblin_native/src/core/repositories/IPartyRepository.ts
@@ -1,4 +1,4 @@
-import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
+import type { Party, PartyStatus, ExpeditionRequest, DungeonTier } from '../../shared/types'
 
 export interface IPartyRepository {
   getParties(): Promise<Party[]>
@@ -8,6 +8,7 @@ export interface IPartyRepository {
   updatePartyStatus(id: number, status: PartyStatus): Promise<void>
   getPartiesByStatus(status: PartyStatus): Promise<Party[]>
   updateDungeonSettings(id: number, dungeonId: string): Promise<void>
+  updateDungeonTier(id: number, tier: DungeonTier): Promise<void>
   updateFloorTarget(id: number, targetFloor: number | null): Promise<void>
   updateReturnPolicy(id: number, returnPolicy: ExpeditionRequest['returnPolicy']): Promise<void>
 }

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -20,7 +20,7 @@ import { getEquipmentTemplate, getEquipmentByDungeonLevel } from '../../shared/d
 import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
-import { normalizePartyRewardMultipliers } from '../../shared/types'
+import { normalizePartyRewardMultipliers, DUNGEON_TIER_SCALING } from '../../shared/types'
 import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
 import { getEffectiveStats } from '../../shared/utils/goblinStats'
 
@@ -58,6 +58,8 @@ export class ExpeditionEngine {
   ): Promise<ExpeditionReplay> {
     console.log('ExpeditionEngine: Starting generateExpedition', { request, partySize: party.length })
     const normalizedRewardMultipliers = normalizePartyRewardMultipliers(rewardMultipliers)
+    const tier = request.tier ?? 0
+    const tierScaling = DUNGEON_TIER_SCALING[tier] ?? DUNGEON_TIER_SCALING[0]
     // ダンジョンIDからエリアIDにマッピング
     const dungeonToAreaMap: Record<string, string> = {
       "1": "forest_outskirts",
@@ -125,9 +127,9 @@ export class ExpeditionEngine {
         switch (eventType) {
           case "battle": {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
-            const enemies = this.getEnemiesFromPattern(pattern, enemyDatabase.enemies)
+            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = area.rewards.xpFloor[currentFloor - 1] || 10
+            const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
 
             events.push({
               type: "battle",
@@ -187,9 +189,9 @@ export class ExpeditionEngine {
             console.warn(`Unknown event type: ${eventType}, treating as battle`)
             // battleとして処理
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
-            const enemies = this.getEnemiesFromPattern(pattern, enemyDatabase.enemies)
+            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = area.rewards.xpFloor[currentFloor - 1] || 10
+            const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
 
             events.push({
               type: "battle",
@@ -257,10 +259,10 @@ export class ExpeditionEngine {
 
       if (bossPatterns.length > 0) {
         const bossPattern = this.selectEnemyPattern(enemyDatabase.patterns, area.floors, true)
-        const bossEnemies = this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies)
+        const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
 
         const bossCombat = this.resolveCombat(partyState, bossEnemies, area, true)
-        const bossXp = area.rewards.xpBoss ?? 0
+        const bossXp = Math.floor((area.rewards.xpBoss ?? 0) * tierScaling.rewardScale)
 
         // 規定時間の終端でボス戦を行う（最後の秒で戦闘開始）
         const bossTime = adjustedDuration
@@ -327,6 +329,7 @@ export class ExpeditionEngine {
         partySnapshot: party.map(g => ({ ...g })),
         partyRewardMultipliers: normalizedRewardMultipliers,
         returnPolicy: request.returnPolicy,
+        tier: tier || undefined,
         seed: this.seed
       },
       durationSec: adjustedDuration,
@@ -411,6 +414,20 @@ export class ExpeditionEngine {
       throw new Error(`No enemy pattern found for floor ${floor}`)
     }
     return availablePatterns[Math.floor(this.rng() * availablePatterns.length)]
+  }
+
+  private applyTierScaling(enemies2D: Enemy[][], lvScale: number): Enemy[][] {
+    if (lvScale === 1.0) return enemies2D
+    return enemies2D.map(row =>
+      row.map(enemy => ({
+        ...enemy,
+        level: Math.floor(enemy.level * lvScale),
+        hp: Math.floor(enemy.hp * lvScale),
+        atk: Math.floor(enemy.atk * lvScale),
+        def: Math.floor(enemy.def * lvScale),
+        gold: Math.floor(enemy.gold * lvScale),
+      }))
+    )
   }
 
   private getEnemiesFromPattern(pattern: EnemyPattern, enemyList: Enemy[]): Enemy[][] {

--- a/goblin_native/src/core/usecases/ConfigurePartyUseCase.ts
+++ b/goblin_native/src/core/usecases/ConfigurePartyUseCase.ts
@@ -1,4 +1,4 @@
-import type { ExpeditionRequest, Party } from '../../shared/types'
+import type { ExpeditionRequest, Party, DungeonTier } from '../../shared/types'
 import type { IPartyRepository } from '../repositories'
 
 export class ConfigurePartyUseCase {
@@ -26,6 +26,11 @@ export class ConfigurePartyUseCase {
 
   public async setDungeon(partyId: number, dungeonId: string): Promise<Party> {
     await this.partyRepository.updateDungeonSettings(partyId, dungeonId)
+    return this.requireParty(partyId)
+  }
+
+  public async setDungeonTier(partyId: number, tier: DungeonTier): Promise<Party> {
+    await this.partyRepository.updateDungeonTier(partyId, tier)
     return this.requireParty(partyId)
   }
 

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -118,6 +118,7 @@ function createMockPartyRepository(parties: Party[]): IPartyRepository {
     updatePartyStatus: jest.fn(async () => {}),
     getPartiesByStatus: jest.fn(async () => []),
     updateDungeonSettings: jest.fn(async () => {}),
+    updateDungeonTier: jest.fn(async () => {}),
     updateFloorTarget: jest.fn(async () => {}),
     updateReturnPolicy: jest.fn(async () => {}),
   }

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -10,9 +10,10 @@ import { migrateV4 } from './migrations/v4'
 import { migrateV5 } from './migrations/v5'
 import { migrateV6 } from './migrations/v6'
 import { migrateV7 } from './migrations/v7'
+import { migrateV8 } from './migrations/v8'
 
 const DB_NAME = 'goblin_kingdom.db'
-const CURRENT_SCHEMA_VERSION = 7
+const CURRENT_SCHEMA_VERSION = 8
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -122,6 +123,13 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
     await migrateV7(database)
     await setSchemaVersion(database, 7)
     console.log('[DB] Migration v7 completed')
+  }
+
+  if (currentVersion < 8) {
+    console.log('[DB] Running migration v8...')
+    await migrateV8(database)
+    await setSchemaVersion(database, 8)
+    console.log('[DB] Migration v8 completed')
   }
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v8.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v8.ts
@@ -1,0 +1,17 @@
+import type * as SQLite from 'expo-sqlite'
+
+export const migrateV8 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  // dungeon_progress に max_cleared_tier カラムを追加
+  const dpColumns = await database.getAllAsync<{ name: string }>('PRAGMA table_info(dungeon_progress)')
+  if (!dpColumns.some(c => c.name === 'max_cleared_tier')) {
+    await database.execAsync('ALTER TABLE dungeon_progress ADD COLUMN max_cleared_tier INTEGER NOT NULL DEFAULT 0')
+    // 既存の cleared=1 レコードを max_cleared_tier=1 に変換
+    await database.runAsync('UPDATE dungeon_progress SET max_cleared_tier = 1 WHERE cleared = 1')
+  }
+
+  // parties に dungeon_tier カラムを追加
+  const partyColumns = await database.getAllAsync<{ name: string }>('PRAGMA table_info(parties)')
+  if (!partyColumns.some(c => c.name === 'dungeon_tier')) {
+    await database.execAsync('ALTER TABLE parties ADD COLUMN dungeon_tier INTEGER NOT NULL DEFAULT 0')
+  }
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -59,6 +59,7 @@ export const SCHEMA = {
       member_ids_json TEXT NOT NULL,
       status TEXT DEFAULT 'idle',
       dungeon_id TEXT,
+      dungeon_tier INTEGER NOT NULL DEFAULT 0,
       target_floor INTEGER,
       return_policy TEXT,
       gold_multiplier REAL NOT NULL DEFAULT 1.0,
@@ -125,6 +126,7 @@ export const SCHEMA = {
       unlocked INTEGER NOT NULL DEFAULT 0,
       cleared INTEGER NOT NULL DEFAULT 0,
       unlock_notified INTEGER NOT NULL DEFAULT 0,
+      max_cleared_tier INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `,

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -10,6 +10,7 @@ interface DungeonProgressRow {
   unlocked: number
   cleared: number
   unlock_notified: number
+  max_cleared_tier: number
   updated_at: string
 }
 
@@ -17,6 +18,7 @@ interface DungeonProgress {
   unlocked: boolean
   cleared: boolean
   unlockNotified: boolean
+  maxClearedTier: number
 }
 
 export interface IDungeonProgressRepository {
@@ -24,7 +26,7 @@ export interface IDungeonProgressRepository {
   get(dungeonId: string): Promise<DungeonProgress | null>
   save(dungeonId: string, progress: DungeonProgress): Promise<void>
   unlock(dungeonId: string): Promise<void>
-  markCleared(dungeonId: string): Promise<void>
+  markCleared(dungeonId: string, tier?: number): Promise<void>
 }
 
 export class SQLiteDungeonProgressRepository implements IDungeonProgressRepository {
@@ -47,6 +49,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
         unlocked: row.unlocked === 1,
         cleared: row.cleared === 1,
         unlockNotified: row.unlock_notified === 1,
+        maxClearedTier: row.max_cleared_tier ?? 0,
       }
     }
     return result
@@ -65,6 +68,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
       unlocked: row.unlocked === 1,
       cleared: row.cleared === 1,
       unlockNotified: row.unlock_notified === 1,
+      maxClearedTier: row.max_cleared_tier ?? 0,
     }
   }
 
@@ -72,24 +76,32 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO dungeon_progress
-       (dungeon_id, unlocked, cleared, unlock_notified, updated_at)
-       VALUES (?, ?, ?, ?, datetime('now'))`,
+       (dungeon_id, unlocked, cleared, unlock_notified, max_cleared_tier, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
       [
         dungeonId,
         progress.unlocked ? 1 : 0,
         progress.cleared ? 1 : 0,
         progress.unlockNotified ? 1 : 0,
+        progress.maxClearedTier,
       ]
     )
   }
 
   async unlock(dungeonId: string): Promise<void> {
-    const current = await this.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false }
+    const current = await this.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false, maxClearedTier: 0 }
     await this.save(dungeonId, { ...current, unlocked: true })
   }
 
-  async markCleared(dungeonId: string): Promise<void> {
-    const current = await this.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false }
-    await this.save(dungeonId, { ...current, unlocked: true, cleared: true })
+  async markCleared(dungeonId: string, tier?: number): Promise<void> {
+    const current = await this.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false, maxClearedTier: 0 }
+    const clearedTierValue = tier !== undefined ? tier + 1 : 1
+    const newMaxClearedTier = Math.max(current.maxClearedTier, clearedTierValue)
+    await this.save(dungeonId, {
+      ...current,
+      unlocked: true,
+      cleared: true,
+      maxClearedTier: newMaxClearedTier,
+    })
   }
 }

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -5,7 +5,7 @@
 import {
   normalizePartyRewardMultipliers,
 } from '../../shared/types'
-import type { Party, PartyStatus, ExpeditionRequest } from '../../shared/types'
+import type { Party, PartyStatus, ExpeditionRequest, DungeonTier } from '../../shared/types'
 import type { IPartyRepository } from '../../core/repositories/IPartyRepository'
 import { getDatabase } from '../database'
 
@@ -15,6 +15,7 @@ interface PartyRow {
   member_ids_json: string
   status: string | null
   dungeon_id: string | null
+  dungeon_tier: number | null
   target_floor: number | null
   return_policy: string | null
   gold_multiplier: number | null
@@ -51,15 +52,16 @@ export class SQLitePartyRepository implements IPartyRepository {
     const rewardMultipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
     await db.runAsync(
       `INSERT OR REPLACE INTO parties
-       (id, name, member_ids_json, status, dungeon_id, target_floor, return_policy,
+       (id, name, member_ids_json, status, dungeon_id, dungeon_tier, target_floor, return_policy,
         gold_multiplier, rare_multiplier, title_multiplier, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
       [
         party.id,
         party.name,
         JSON.stringify(party.memberIds),
         party.status ?? 'idle',
         party.dungeonId ?? null,
+        party.dungeonTier ?? 0,
         party.targetFloor ?? null,
         party.returnPolicy ?? null,
         rewardMultipliers.gold,
@@ -96,6 +98,14 @@ export class SQLitePartyRepository implements IPartyRepository {
     )
   }
 
+  async updateDungeonTier(id: number, tier: DungeonTier): Promise<void> {
+    const db = await getDatabase()
+    await db.runAsync(
+      "UPDATE parties SET dungeon_tier = ?, updated_at = datetime('now') WHERE id = ?",
+      [tier, id]
+    )
+  }
+
   async updateFloorTarget(id: number, targetFloor: number | null): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
@@ -119,6 +129,7 @@ export class SQLitePartyRepository implements IPartyRepository {
       memberIds: JSON.parse(row.member_ids_json),
       status: (row.status as PartyStatus) ?? undefined,
       dungeonId: row.dungeon_id ?? undefined,
+      dungeonTier: (row.dungeon_tier ?? 0) as DungeonTier,
       targetFloor: row.target_floor ?? undefined,
       returnPolicy: (row.return_policy as ExpeditionRequest['returnPolicy']) ?? undefined,
       rewardMultipliers: normalizePartyRewardMultipliers({

--- a/goblin_native/src/presentation/hooks/useDatabaseInit.ts
+++ b/goblin_native/src/presentation/hooks/useDatabaseInit.ts
@@ -20,6 +20,7 @@ async function ensureDefaults(): Promise<void> {
         unlocked: dungeon.unlocked ?? index === 0,
         cleared: dungeon.cleared ?? false,
         unlockNotified: false,
+        maxClearedTier: 0,
       })
     }
   }

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Alert } from 'react-native'
 import type {
   Dungeon,
+  DungeonTier,
   ExpeditionReplay,
   ExpeditionRequest,
   ExpeditionRecord,
@@ -30,6 +31,7 @@ interface StartExpeditionInput {
   party: Party
   dungeon: Dungeon
   returnPolicy: ExpeditionRequest['returnPolicy']
+  tier?: DungeonTier
 }
 
 interface StartExpeditionResult {
@@ -97,7 +99,8 @@ export const useExpeditionFlow = ({
       record.replay.summary.maxFloorReached >= dungeon.floors
     if (!cleared) return
 
-    await markDungeonCleared(dungeon, true)
+    const tier = record.replay.meta.tier as DungeonTier | undefined
+    await markDungeonCleared(dungeon, true, tier)
 
     const nextId = await getNextGoblinId()
     const areaLevel = dungeon.areaLevel ?? 1
@@ -185,13 +188,14 @@ export const useExpeditionFlow = ({
   }, [])
 
   const startExpedition = useCallback(
-    async ({ party, dungeon, returnPolicy }: StartExpeditionInput): Promise<StartExpeditionResult> => {
+    async ({ party, dungeon, returnPolicy, tier }: StartExpeditionInput): Promise<StartExpeditionResult> => {
       setIsProcessing(true)
       try {
         const durationSec = estimateExplorationTime(dungeon, returnPolicy)
         const request: ExpeditionRequest = {
           partyId: party.id.toString(),
           areaId: dungeon.id,
+          tier,
           returnPolicy,
           clientVersion: 'native',
           durationSec,

--- a/goblin_native/src/presentation/stores/useDungeonStore.ts
+++ b/goblin_native/src/presentation/stores/useDungeonStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { SQLiteDungeonProgressRepository } from '../../infrastructure/repositories/SQLiteDungeonProgressRepository'
 import { areasData } from '../../shared/data'
-import type { Dungeon } from '../../shared/types'
+import type { Dungeon, DungeonTier } from '../../shared/types'
 import type { DungeonProgressState } from '../../shared/types/DungeonProgress'
 
 const repository = SQLiteDungeonProgressRepository.getInstance()
@@ -13,6 +13,7 @@ const buildDefaultProgress = (): DungeonProgressState => {
       unlocked: dungeon.unlocked ?? index === 0,
       cleared: dungeon.cleared ?? false,
       unlockNotified: false,
+      maxClearedTier: 0,
     }
   })
   return defaults
@@ -23,6 +24,7 @@ const buildDungeons = (progress: DungeonProgressState): Dungeon[] =>
     ...dungeon,
     cleared: progress[dungeon.id]?.cleared ?? dungeon.cleared ?? false,
     unlocked: progress[dungeon.id]?.unlocked ?? dungeon.unlocked ?? false,
+    maxClearedTier: progress[dungeon.id]?.maxClearedTier ?? 0,
   }))
 
 interface DungeonStoreState {
@@ -35,7 +37,7 @@ interface DungeonStoreActions {
   initialize: () => Promise<void>
   refresh: () => Promise<void>
   updateProgress: (updater: (prev: DungeonProgressState) => DungeonProgressState) => Promise<void>
-  markDungeonCleared: (dungeon: Dungeon, cleared: boolean) => Promise<void>
+  markDungeonCleared: (dungeon: Dungeon, cleared: boolean, tier?: DungeonTier) => Promise<void>
   markUnlockNotified: (dungeonId: string) => Promise<void>
 }
 
@@ -77,25 +79,33 @@ export const useDungeonStore = create<DungeonStoreState & DungeonStoreActions>()
     refresh,
     updateProgress,
 
-    markDungeonCleared: async (dungeon: Dungeon, cleared: boolean) => {
+    markDungeonCleared: async (dungeon: Dungeon, cleared: boolean, tier?: DungeonTier) => {
       await updateProgress(prev => {
         const nextProgress: DungeonProgressState = { ...prev }
         const current = nextProgress[dungeon.id] ?? {
           unlocked: dungeon.unlocked ?? false,
           cleared: false,
           unlockNotified: false,
+          maxClearedTier: 0,
         }
+
+        const clearedTierValue = tier !== undefined ? tier + 1 : 1
+        const newMaxClearedTier = cleared
+          ? Math.max(current.maxClearedTier, clearedTierValue)
+          : current.maxClearedTier
+
         nextProgress[dungeon.id] = {
           ...current,
           unlocked: true,
           cleared: cleared || current.cleared,
+          maxClearedTier: newMaxClearedTier,
         }
 
         if (cleared && dungeon.unlockNext) {
           const target = nextProgress[dungeon.unlockNext]
           if (!target || !target.unlocked) {
             nextProgress[dungeon.unlockNext] = {
-              ...(target ?? { cleared: false, unlockNotified: false }),
+              ...(target ?? { cleared: false, unlockNotified: false, maxClearedTier: 0 }),
               unlocked: true,
             }
           }
@@ -112,6 +122,7 @@ export const useDungeonStore = create<DungeonStoreState & DungeonStoreActions>()
           unlocked: false,
           cleared: false,
           unlockNotified: false,
+          maxClearedTier: 0,
         }
         nextProgress[dungeonId] = { ...current, unlockNotified: true }
         return nextProgress

--- a/goblin_native/src/presentation/stores/usePartyStore.ts
+++ b/goblin_native/src/presentation/stores/usePartyStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { Party, ExpeditionRequest } from '../../shared/types'
+import type { Party, ExpeditionRequest, DungeonTier } from '../../shared/types'
 import { SQLitePartyRepository } from '../../infrastructure/repositories/SQLitePartyRepository'
 import type { IPartyRepository } from '../../core/repositories'
 import {
@@ -37,6 +37,7 @@ interface PartyActions {
   markExpedition: (partyId: number) => Promise<void>
   markIdle: (partyId: number) => Promise<void>
   setDungeon: (partyId: number, dungeonId: string) => Promise<Party>
+  setDungeonTier: (partyId: number, tier: DungeonTier) => Promise<Party>
   setTargetFloor: (partyId: number, targetFloor: number | null) => Promise<Party>
   setReturnPolicy: (partyId: number, returnPolicy: ExpeditionRequest['returnPolicy']) => Promise<Party>
 }
@@ -102,6 +103,12 @@ export const usePartyStore = create<PartyState & PartyActions>()((set) => {
 
     setDungeon: async (partyId: number, dungeonId: string) => {
       const updated = await configurePartyUseCase.setDungeon(partyId, dungeonId)
+      await refresh()
+      return updated
+    },
+
+    setDungeonTier: async (partyId: number, tier: DungeonTier) => {
+      const updated = await configurePartyUseCase.setDungeonTier(partyId, tier)
       await refresh()
       return updated
     },

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -221,6 +221,7 @@ const en = {
         renameParty: 'Rename Party',
         dungeon: 'Destination',
         dungeonUnset: 'No destination set',
+        dungeonTier: 'Title',
         targetFloor: 'Target Floor',
         targetFloorDeepest: 'Explore to the deepest floor',
         targetFloorUntil: 'Up to Floor {{floor}}',
@@ -499,6 +500,12 @@ const en = {
     accuracyMultiplier: 'Equipment-based accuracy becomes x{{value}}',
     attackCountBonus: '[+{{value}}] Attack Count',
     evasionBonus: '[+{{value}}] Evasion',
+  },
+  dungeonTier: {
+    normal: 'Normal',
+    majou: 'Demonic',
+    yadotta: 'Possessed',
+    densetsu: 'Legendary',
   },
 } as const
 

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -221,6 +221,7 @@ const ja = {
         renameParty: 'パーティ名を変更する',
         dungeon: '遠征先',
         dungeonUnset: '遠征先が未設定です',
+        dungeonTier: '称号',
         targetFloor: '目標階数',
         targetFloorDeepest: '最下層まで探索',
         targetFloorUntil: '{{floor}}階まで',
@@ -499,6 +500,12 @@ const ja = {
     accuracyMultiplier: '装備由来の命中精度補正が×{{value}}',
     attackCountBonus: '[+{{value}}]攻撃回数',
     evasionBonus: '[+{{value}}]回避能力',
+  },
+  dungeonTier: {
+    normal: '通常',
+    majou: '魔性',
+    yadotta: '宿った',
+    densetsu: '伝説',
   },
 } as const
 

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -221,6 +221,7 @@ const ko = {
         renameParty: '파티 이름 변경',
         dungeon: '원정지',
         dungeonUnset: '원정지가 설정되지 않았습니다',
+        dungeonTier: '칭호',
         targetFloor: '목표 층',
         targetFloorDeepest: '최하층까지 탐색',
         targetFloorUntil: '{{floor}}층까지',
@@ -499,6 +500,12 @@ const ko = {
     accuracyMultiplier: '장비 유래 명중 보정이 x{{value}}가 된다',
     attackCountBonus: '[+{{value}}] 공격 횟수',
     evasionBonus: '[+{{value}}] 회피',
+  },
+  dungeonTier: {
+    normal: '일반',
+    majou: '마성',
+    yadotta: '깃든',
+    densetsu: '전설',
   },
 } as const
 

--- a/goblin_native/src/shared/types/Dungeon.ts
+++ b/goblin_native/src/shared/types/Dungeon.ts
@@ -14,4 +14,5 @@ export type Dungeon = {
   areaLevel?: number                // エリアレベル（1-8）、個体値計算に使用
   isBaseCapture?: boolean           // 拠点化可能か
   rankUpTarget?: number             // このダンジョン制圧で到達するランク
+  maxClearedTier?: number           // 最大クリア済みティア（0=未クリア, 1=通常, 2=魔性, 3=宿った, 4=伝説）
 }

--- a/goblin_native/src/shared/types/DungeonProgress.ts
+++ b/goblin_native/src/shared/types/DungeonProgress.ts
@@ -1,4 +1,4 @@
 export type DungeonProgressState = Record<
   string,
-  { unlocked: boolean; cleared: boolean; unlockNotified: boolean }
+  { unlocked: boolean; cleared: boolean; unlockNotified: boolean; maxClearedTier: number }
 >

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -1,0 +1,26 @@
+/** ダンジョンティア（難易度バリエーション） */
+export type DungeonTier = 0 | 1 | 2 | 3
+
+export const DUNGEON_TIER_LIST = [0, 1, 2, 3] as const
+
+export const DUNGEON_TIER_META = [
+  { tier: 0 as const, prefix: '', labelKey: 'dungeonTier.normal' },
+  { tier: 1 as const, prefix: '魔性', labelKey: 'dungeonTier.majou' },
+  { tier: 2 as const, prefix: '宿った', labelKey: 'dungeonTier.yadotta' },
+  { tier: 3 as const, prefix: '伝説', labelKey: 'dungeonTier.densetsu' },
+] as const
+
+/** ティアごとの敵レベル倍率・報酬倍率 */
+export const DUNGEON_TIER_SCALING = [
+  { enemyLvScale: 1.0, rewardScale: 1.0 },
+  { enemyLvScale: 1.5, rewardScale: 1.3 },
+  { enemyLvScale: 2.0, rewardScale: 1.6 },
+  { enemyLvScale: 3.0, rewardScale: 2.0 },
+] as const
+
+/** ティアに応じたダンジョン表示名を返す */
+export function getDungeonTierDisplayName(baseName: string, tier: DungeonTier): string {
+  const meta = DUNGEON_TIER_META[tier]
+  if (!meta.prefix) return baseName
+  return `${meta.prefix} ${baseName}`
+}

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -3,10 +3,12 @@ import type { CombatReplay } from "./Battle"
 import type { EquipmentTitleId } from "./EquipmentTitle"
 import type { Goblin } from "./Goblin"
 import type { PartyRewardMultipliers } from "./Party"
+import type { DungeonTier } from "./DungeonTier"
 
 export interface ExpeditionRequest {
   partyId: string
   areaId: string
+  tier?: DungeonTier
   returnPolicy: "until_floor2" | "until_floor3" | "if_any_ko" | "if_two_ko" | "last_one" | "never"
   clientVersion: string
   durationSec?: number
@@ -33,6 +35,7 @@ export interface ExpeditionReplay {
     partySnapshot?: Goblin[]
     partyRewardMultipliers: PartyRewardMultipliers
     returnPolicy: ExpeditionRequest["returnPolicy"]
+    tier?: DungeonTier
     seed: number
     serverCommitHash?: string
   }

--- a/goblin_native/src/shared/types/Party.ts
+++ b/goblin_native/src/shared/types/Party.ts
@@ -1,4 +1,5 @@
 import type { ExpeditionRequest } from "./Expedition"
+import type { DungeonTier } from "./DungeonTier"
 import type { CharacterSkill } from "./CharacterSkill"
 import type { ModInstance } from "./Mod"
 import type { LearnedSpell } from "./Spell"
@@ -42,6 +43,7 @@ export type Party = {
   dungeonId?: string
   targetFloor?: number | null  // null = どこまでも進む
   returnPolicy?: ExpeditionRequest["returnPolicy"]
+  dungeonTier?: DungeonTier
   rewardMultipliers?: PartyRewardMultipliers
 }
 

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -69,6 +69,8 @@ export type {
 // Dungeon related types
 export type { Dungeon } from "./Dungeon"
 export type { DungeonProgressState } from "./DungeonProgress"
+export type { DungeonTier } from "./DungeonTier"
+export { DUNGEON_TIER_LIST, DUNGEON_TIER_META, DUNGEON_TIER_SCALING, getDungeonTierDisplayName } from "./DungeonTier"
 
 // Base related types
 export type { BaseState } from "./BaseState"


### PR DESCRIPTION
## Summary
- 同じ遠征先に通常・魔性・宿った・伝説の4段階の難易度バリエーションを追加
- 前のティアをクリアすると次のティアが解放される進行システム
- 遠征準備画面にティアセレクタUIを追加（未解放ティアはロック表示）
- 魔性以上が解放済みの場合、ダンジョン選択時に最高解放ティアをデフォルト選択
- ティアに応じた敵ステータス・報酬のスケーリング（倍率定数で調整可能）

## 主な変更
- `DungeonTier` 型・定数定義（`src/shared/types/DungeonTier.ts`）
- DBマイグレーション v8（`dungeon_progress.max_cleared_tier`, `parties.dungeon_tier`）
- `ExpeditionEngine` でティア倍率による敵スケーリング・報酬補正
- `preparation.tsx` にティアセレクタUI追加
- i18n（ja/en/ko）にティアラベル追加

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm test` 全191テスト通過
- [ ] 実機で遠征準備画面を開き、ティアセレクタの表示確認
- [ ] 通常ティアでクリア → 魔性が解放されることを確認
- [ ] 魔性解放済みダンジョン選択時にデフォルトで魔性が選ばれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)