### PR TITLE
feat(expedition): ダンジョンティアスケーリング拡張と高難度ティア追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -284,6 +284,7 @@ export default function FormationScreen() {
               party,
               dungeon,
               returnPolicy: party.returnPolicy ?? 'never',
+              tier: party.dungeonTier ?? 0,
             })
             startedCount += 1
           } catch (error) {

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -14,6 +14,7 @@ import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
+import { getDungeonTierDisplayName } from '@/shared/types'
 
 interface LogEntry {
   id: string
@@ -87,6 +88,11 @@ export default function ExpeditionPlaybackScreen() {
     const id = expeditionRecord?.dungeonId || party?.dungeonId
     return dungeons.find(d => d.id === id)
   }, [dungeons, expeditionRecord?.dungeonId, party?.dungeonId])
+
+  const dungeonDisplayName = useMemo(() => {
+    if (!dungeon) return ''
+    return getDungeonTierDisplayName(getDungeonName(dungeon), expeditionRecord?.replay?.meta.tier ?? 0)
+  }, [dungeon, expeditionRecord?.replay?.meta.tier])
 
   const [eventLog, setEventLog] = useState<LogEntry[]>([])
   const [partyHp, setPartyHp] = useState<number[]>([])
@@ -408,13 +414,13 @@ export default function ExpeditionPlaybackScreen() {
         <TouchableOpacity onPress={() => router.back()}>
           <Text style={styles.navBack}>← {t('ui.formation.common.back')}</Text>
         </TouchableOpacity>
-        <Text style={styles.navTitle}>{getDungeonName(dungeon)} - {t('ui.formation.playback.logViewTitle')}</Text>
+        <Text style={styles.navTitle}>{dungeonDisplayName} - {t('ui.formation.playback.logViewTitle')}</Text>
         <View style={styles.navSpacer} />
       </View>
 
       <View style={styles.statusBar}>
         <View style={styles.statusRow}>
-          <Text style={styles.statusTitle}>{t('ui.formation.playback.floorTitle', { name: getDungeonName(dungeon), floor: currentFloor })}</Text>
+          <Text style={styles.statusTitle}>{t('ui.formation.playback.floorTitle', { name: dungeonDisplayName, floor: currentFloor })}</Text>
           <Text style={styles.statusTimer}>{progressText}</Text>
         </View>
         <View style={styles.progressContainer}>

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -9,7 +9,7 @@ import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
-import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierDisplayName } from '@/shared/types'
+import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '@/shared/types'
 import type { ExpeditionRequest, Goblin, Dungeon, Party, DungeonTier } from '@/shared/types'
 import { getDungeonDescription, getDungeonName, getReturnPolicyLabel } from '@/shared/i18n/entityLocalization'
 
@@ -17,9 +17,9 @@ type ReturnPolicy = ExpeditionRequest['returnPolicy']
 
 const MAX_PARTY_SLOTS = 6
 
-function formatDungeonLabel(dungeon: Dungeon): string {
+function formatDungeonLabel(dungeon: Dungeon, tier: DungeonTier = 0): string {
   if (dungeon.areaLevel === undefined) return getDungeonName(dungeon)
-  return `${getDungeonName(dungeon)} / Area Lv.${dungeon.areaLevel}`
+  return `${getDungeonName(dungeon)} / Area Lv.${getDungeonTierAreaLevel(dungeon.areaLevel, tier)}`
 }
 
 function formatMultiplier(value: number): string {
@@ -213,14 +213,14 @@ export default function ExpeditionPreparationScreen() {
     const maxCleared = selectedDungeon.maxClearedTier ?? 0
     // maxClearedTier=1 → 通常クリア済み → 魔性(tier=1)まで解放
     // maxClearedTier=0 → 未クリア → 通常(tier=0)のみ
-    return Math.min(maxCleared, 3) as DungeonTier
+    return Math.min(maxCleared, 5) as DungeonTier
   }, [selectedDungeon])
 
   // ダンジョン変更時にティアをデフォルト選択
   const autoSelectTier = useCallback((dungeon: Dungeon) => {
     const maxCleared = dungeon.maxClearedTier ?? 0
     // 魔性以上が解放されている場合は最高解放ティアをデフォルト選択
-    const defaultTier = Math.min(maxCleared, 3) as DungeonTier
+    const defaultTier = Math.min(maxCleared, 5) as DungeonTier
     setSelectedTier(defaultTier)
     if (partyId) {
       void setDungeonTier(parseInt(partyId, 10), defaultTier)
@@ -411,7 +411,7 @@ export default function ExpeditionPreparationScreen() {
                 {selectedDungeon ? (
                   <>
                     <Text style={styles.settingValueText}>
-                      {getDungeonTierDisplayName(formatDungeonLabel(selectedDungeon), selectedTier)}
+                      {getDungeonTierDisplayName(formatDungeonLabel(selectedDungeon, selectedTier), selectedTier)}
                     </Text>
                     <Text style={styles.settingValueDescription}>{getDungeonDescription(selectedDungeon)}</Text>
                   </>

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -9,6 +9,7 @@ import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { areasData } from '@/shared/data'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import type { ExpeditionRecord, Goblin, TimelineEvent, TreasureDrop } from '@/shared/types'
+import { getDungeonTierDisplayName } from '@/shared/types'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
 
@@ -62,6 +63,11 @@ export default function ExpeditionResultScreen() {
     const id = expeditionRecord?.dungeonId
     return id ? dungeons.find(d => d.id === id) : null
   }, [dungeons, expeditionRecord?.dungeonId])
+
+  const dungeonDisplayName = useMemo(() => {
+    if (!dungeon) return null
+    return getDungeonTierDisplayName(getDungeonName(dungeon), replay?.meta.tier ?? 0)
+  }, [dungeon, replay?.meta.tier])
 
   const partySnapshot = replay?.meta.partySnapshot ?? []
 
@@ -124,7 +130,7 @@ export default function ExpeditionResultScreen() {
     if (!replay || !dungeon) return
     const cleared = replay.summary.success && replay.summary.maxFloorReached >= dungeon.floors
     if (cleared && !dungeon.cleared) {
-      void markDungeonCleared(dungeon, true)
+      void markDungeonCleared(dungeon, true, replay.meta.tier)
     }
   }, [dungeon, markDungeonCleared, replay])
 
@@ -185,7 +191,7 @@ export default function ExpeditionResultScreen() {
       <ScrollView style={styles.scrollView}>
         <View style={styles.headerSection}>
           <Text style={styles.headerTitle}>
-            {dungeon ? getDungeonName(dungeon) : t('ui.result.expeditionFallback')}: {getHeaderText()}
+            {dungeonDisplayName ?? t('ui.result.expeditionFallback')}: {getHeaderText()}
           </Text>
           <Text style={styles.headerSubtitle}>{getResultText()}</Text>
         </View>

--- a/goblin_native/src/core/services/BaseRankSystem.ts
+++ b/goblin_native/src/core/services/BaseRankSystem.ts
@@ -94,6 +94,13 @@ export const AREA_LEVEL_IV_RANGES: Record<number, [number, number]> = {
   8: [50, 60],    // 最終決戦（王都決戦）
 }
 
+function getAreaLevelIvRange(areaLevel: number): [number, number] {
+  const range = AREA_LEVEL_IV_RANGES[areaLevel]
+  if (range) return range
+  if (areaLevel > 8) return AREA_LEVEL_IV_RANGES[8]
+  return AREA_LEVEL_IV_RANGES[1]
+}
+
 /**
  * 拠点ランクボーナス
  */
@@ -120,7 +127,7 @@ export function calculateIndividualValue(
   random: () => number
 ): number {
   // エリアレベルのベース範囲を取得
-  const [min, max] = AREA_LEVEL_IV_RANGES[areaLevel] || [1, 8]
+  const [min, max] = getAreaLevelIvRange(areaLevel)
   const baseIV = Math.floor(min + (max - min) * random())
 
   // 拠点ランクボーナスを加算

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -47,6 +47,7 @@ interface BattleUnit {
   originalIndex: number
   damageReduction: number  // 汎用の被ダメージ軽減率（0〜100）
   physicalDamageReduction: number  // 物理ダメージ軽減率（0〜100）
+  magicDamageReduction: number  // 魔法ダメージ軽減率（0〜100）
   row: number              // 隊列の列番号（0-based）
   rowSlot: number          // 列内のスロット番号（0-based）
   level: number            // 呪文のターゲット数計算用
@@ -504,7 +505,9 @@ export class BattleSystem {
           spellSkill, DEFAULT_DAMAGE_OPTIONS, rng,
         )
         const rearDamageMultiplier = this.getRearDamageMultiplier(unit, sourceGroup)
-        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier))
+        const reductionFactor = 1 - target.damageReduction / 100
+        const magicReductionFactor = 1 - target.magicDamageReduction / 100
+        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * reductionFactor * magicReductionFactor))
 
         this.applyDamage(target, damage)
         totalHitCount++
@@ -530,7 +533,9 @@ export class BattleSystem {
           spellSkill, DEFAULT_DAMAGE_OPTIONS, rng,
         )
         const rearDamageMultiplier = this.getRearDamageMultiplier(unit, sourceGroup)
-        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier))
+        const reductionFactor = 1 - target.damageReduction / 100
+        const magicReductionFactor = 1 - target.magicDamageReduction / 100
+        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * reductionFactor * magicReductionFactor))
 
         this.applyDamage(target, damage)
         totalHitCount++
@@ -601,6 +606,7 @@ export class BattleSystem {
       originalIndex,
       damageReduction,
       physicalDamageReduction,
+      magicDamageReduction: 0,
       row: originalIndex,  // 味方は1列1体（配列順 = 列番号）
       rowSlot: 0,
       level: goblin.level,
@@ -626,7 +632,8 @@ export class BattleSystem {
       isAlly: false,
       originalIndex,
       damageReduction: 0,  // 敵は被ダメージ軽減なし
-      physicalDamageReduction: getPhysicalDamageReductionFromSkills(skills),
+      physicalDamageReduction: (enemy.physicalResistancePercent ?? 0) + getPhysicalDamageReductionFromSkills(skills),
+      magicDamageReduction: enemy.magicResistancePercent ?? 0,
       row,
       rowSlot,
       level: enemy.level,

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -20,7 +20,7 @@ import { getEquipmentTemplate, getEquipmentByDungeonLevel } from '../../shared/d
 import { BattleSystem } from './BattleSystem'
 import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
-import { normalizePartyRewardMultipliers, DUNGEON_TIER_SCALING } from '../../shared/types'
+import { normalizePartyRewardMultipliers, DUNGEON_TIER_SCALING, getDungeonTierAreaLevel } from '../../shared/types'
 import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
 import { getEffectiveStats } from '../../shared/utils/goblinStats'
 
@@ -75,6 +75,7 @@ export class ExpeditionEngine {
     if (!area) {
       throw new Error(`Area not found: ${request.areaId} (mapped to: ${areaId})`)
     }
+    const effectiveAreaLevel = getDungeonTierAreaLevel(area.areaLevel, tier)
 
     // 敵データを取得
     const enemyDatabase = getEnemyDatabase(areaId)
@@ -127,7 +128,7 @@ export class ExpeditionEngine {
         switch (eventType) {
           case "battle": {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
-            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
+            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
             const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
 
@@ -153,6 +154,7 @@ export class ExpeditionEngine {
             // 宝箱ドロップ判定（勝利時のみ）
             const treasureDrops = this.rollTreasureDrops(
               area.areaLevel,
+              effectiveAreaLevel,
               enemies.flat(),
               droppedTemplateIds,
               normalizedRewardMultipliers
@@ -189,7 +191,7 @@ export class ExpeditionEngine {
             console.warn(`Unknown event type: ${eventType}, treating as battle`)
             // battleとして処理
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
-            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
+            const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
             const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
 
@@ -214,6 +216,7 @@ export class ExpeditionEngine {
             // 宝箱ドロップ判定（勝利時のみ）
             const defaultTreasure = this.rollTreasureDrops(
               area.areaLevel,
+              effectiveAreaLevel,
               enemies.flat(),
               droppedTemplateIds,
               normalizedRewardMultipliers
@@ -259,7 +262,7 @@ export class ExpeditionEngine {
 
       if (bossPatterns.length > 0) {
         const bossPattern = this.selectEnemyPattern(enemyDatabase.patterns, area.floors, true)
-        const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling.enemyLvScale)
+        const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling)
 
         const bossCombat = this.resolveCombat(partyState, bossEnemies, area, true)
         const bossXp = Math.floor((area.rewards.xpBoss ?? 0) * tierScaling.rewardScale)
@@ -283,6 +286,7 @@ export class ExpeditionEngine {
         if (bossCombat.outcome === 'win') {
           const bossTreasure = this.rollTreasureDrops(
             area.areaLevel,
+            effectiveAreaLevel,
             bossEnemies.flat(),
             droppedTemplateIds,
             normalizedRewardMultipliers
@@ -323,6 +327,8 @@ export class ExpeditionEngine {
         expeditionId: `exp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         areaId: areaId,
         areaName: area.name,
+        areaLevel: area.areaLevel,
+        effectiveAreaLevel,
         floors: area.floors,
         baseDurationSec: adjustedDuration,
         party: party.map(g => g.id.toString()),
@@ -416,16 +422,31 @@ export class ExpeditionEngine {
     return availablePatterns[Math.floor(this.rng() * availablePatterns.length)]
   }
 
-  private applyTierScaling(enemies2D: Enemy[][], lvScale: number): Enemy[][] {
-    if (lvScale === 1.0) return enemies2D
+  private applyTierScaling(
+    enemies2D: Enemy[][],
+    scaling: (typeof DUNGEON_TIER_SCALING)[number]
+  ): Enemy[][] {
+    const statScale = scaling.statScale
+    const countScale = Math.sqrt(statScale)
+    const goldScale = Math.pow(statScale, 1.5)
     return enemies2D.map(row =>
       row.map(enemy => ({
         ...enemy,
-        level: Math.floor(enemy.level * lvScale),
-        hp: Math.floor(enemy.hp * lvScale),
-        atk: Math.floor(enemy.atk * lvScale),
-        def: Math.floor(enemy.def * lvScale),
-        gold: Math.floor(enemy.gold * lvScale),
+        level: Math.floor(enemy.level * statScale) + scaling.levelBonus,
+        hp: Math.floor(enemy.hp * scaling.hpScale),
+        atk: Math.floor(enemy.atk * statScale),
+        def: Math.floor(enemy.def * scaling.defScale),
+        magicDef: enemy.magicDef !== undefined ? Math.floor(enemy.magicDef * scaling.magicDefScale) : undefined,
+        agility: Math.round(enemy.agility * statScale),
+        attackCount: Math.max(1, Math.floor(enemy.attackCount * countScale)),
+        accuracy: Math.round(enemy.accuracy * statScale),
+        evasion: Math.round(enemy.evasion * scaling.evasionScale),
+        physicalResistancePercent: scaling.physicalResistancePercent,
+        penetrationResistancePercent: scaling.penetrationResistancePercent,
+        criticalResistancePercent: scaling.criticalResistancePercent,
+        magicResistancePercent: scaling.magicResistancePercent,
+        exp: Math.floor(enemy.exp * statScale),
+        gold: Math.floor(enemy.gold * goldScale),
       }))
     )
   }
@@ -566,6 +587,7 @@ export class ExpeditionEngine {
    * 5. ドロップ時に称号を抽選して付与
    */
   private rollTreasureDrops(
+    _areaLevel: number,
     dungeonLevel: number,
     enemies: Enemy[],
     droppedIds: Set<string>,

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1046,6 +1046,7 @@ describe('selectTarget — 隊列ターゲット選択', () => {
       originalIndex: 0,
       damageReduction: 0,
       physicalDamageReduction: 0,
+      magicDamageReduction: 0,
       row,
       rowSlot,
       level: 1,

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -1,6 +1,6 @@
 import { ExpeditionEngine } from '../ExpeditionEngine'
-import { DEFAULT_PARTY_REWARD_MULTIPLIERS } from '../../../shared/types'
-import type { TimelineEvent, PartyState } from '../../../shared/types'
+import { DEFAULT_PARTY_REWARD_MULTIPLIERS, DUNGEON_TIER_SCALING, getDungeonTierAreaLevel } from '../../../shared/types'
+import type { DungeonTier, Enemy, TimelineEvent, PartyState } from '../../../shared/types'
 
 describe('ExpeditionEngine reward multipliers', () => {
   it('goldMultiplier を報酬 gold に適用する', () => {
@@ -55,5 +55,92 @@ describe('ExpeditionEngine reward multipliers', () => {
     })
 
     expect(summary.goldGained).toBe(52)
+  })
+})
+
+describe('ExpeditionEngine dungeon tier scaling', () => {
+  const baseEnemy: Enemy = {
+    id: 'scale-test',
+    name: 'スケール確認',
+    raceTags: ['beast'],
+    level: 28,
+    hp: 100,
+    atk: 340,
+    def: 20,
+    magicDef: 8000,
+    agility: 10,
+    attackCount: 7,
+    accuracy: 284,
+    evasion: 1800,
+    exp: 200,
+    gold: 2800,
+  }
+
+  it('称号ごとの表と同じ法則で主要ステータスをスケールする', () => {
+    const engine = new ExpeditionEngine(1)
+    const expected = [
+      { level: 28, exp: 200, gold: 2800, atk: 340, accuracy: 284, attackCount: 7, evasion: 1800, magicDef: 8000 },
+      { level: 45, exp: 316, gold: 5560, atk: 537, accuracy: 449, attackCount: 8, evasion: 2844, magicDef: 12640 },
+      { level: 61, exp: 420, gold: 8520, atk: 714, accuracy: 596, attackCount: 10, evasion: 3780, magicDef: 16800 },
+      { level: 83, exp: 550, gold: 12769, atk: 935, accuracy: 781, attackCount: 11, evasion: 4950, magicDef: 22000 },
+      { level: 109, exp: 700, gold: 18334, atk: 1190, accuracy: 994, attackCount: 13, evasion: 8050, magicDef: 29750 },
+      { level: 164, exp: 1000, gold: 31304, atk: 1700, accuracy: 1420, attackCount: 15, evasion: 14000, magicDef: 45000 },
+    ]
+
+    DUNGEON_TIER_SCALING.forEach((scaling, index) => {
+      const [[scaled]] = (engine as any).applyTierScaling([[baseEnemy]], scaling)
+      expect({
+        level: scaled.level,
+        exp: scaled.exp,
+        gold: scaled.gold,
+        atk: scaled.atk,
+        accuracy: scaled.accuracy,
+        attackCount: scaled.attackCount,
+        evasion: scaled.evasion,
+        magicDef: scaled.magicDef,
+      }).toEqual(expected[index])
+    })
+  })
+
+  it('防御系ステータスと耐性も提示表どおりにスケールする', () => {
+    const engine = new ExpeditionEngine(1)
+    const defensiveEnemy: Enemy = {
+      ...baseEnemy,
+      hp: 65315,
+      def: 2500,
+      evasion: 1800,
+      magicDef: 8000,
+    }
+    const expected = [
+      { hp: 65315, def: 2500, evasion: 1800, magicDef: 8000, physicalResistancePercent: 44.2, magicResistancePercent: 42.5 },
+      { hp: 163177, def: 3950, evasion: 2844, magicDef: 12640, physicalResistancePercent: 38.0, magicResistancePercent: 36.5 },
+      { hp: 288480, def: 5250, evasion: 3780, magicDef: 16800, physicalResistancePercent: 32.7, magicResistancePercent: 34.8 },
+      { hp: 495759, def: 6875, evasion: 4950, magicDef: 22000, physicalResistancePercent: 28.3, magicResistancePercent: 33.1 },
+      { hp: 805008, def: 11550, evasion: 8050, magicDef: 29750, physicalResistancePercent: 24.3, magicResistancePercent: 31.4 },
+      { hp: 1657875, def: 22500, evasion: 14000, magicDef: 45000, physicalResistancePercent: 21.2, magicResistancePercent: 29.7 },
+    ]
+
+    DUNGEON_TIER_SCALING.forEach((scaling, index) => {
+      const [[scaled]] = (engine as any).applyTierScaling([[defensiveEnemy]], scaling)
+      expect({
+        hp: scaled.hp,
+        def: scaled.def,
+        evasion: scaled.evasion,
+        magicDef: scaled.magicDef,
+        physicalResistancePercent: scaled.physicalResistancePercent,
+        magicResistancePercent: scaled.magicResistancePercent,
+      }).toEqual(expected[index])
+      expect(scaled.penetrationResistancePercent).toBe(100)
+      expect(scaled.criticalResistancePercent).toBe(50)
+    })
+  })
+})
+
+describe('getDungeonTierAreaLevel', () => {
+  it('推奨Lv表の法則でエリアレベルをスケールする', () => {
+    const tiers = [0, 1, 2, 3, 4] as DungeonTier[]
+    expect(tiers.map(tier => getDungeonTierAreaLevel(12, tier))).toEqual([12, 22, 29, 38, 49])
+    expect(tiers.map(tier => getDungeonTierAreaLevel(1, tier))).toEqual([1, 4, 6, 8, 10])
+    expect(tiers.map(tier => getDungeonTierAreaLevel(70, tier))).toEqual([70, 113, 151, 198, 252])
   })
 })

--- a/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
+++ b/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
@@ -273,10 +273,15 @@ describe('calculateIndividualValue', () => {
     expect(ivMin).toBeGreaterThanOrEqual(1)
   })
 
-  it('未定義のareaLevelはデフォルト範囲[1,8]にフォールバック', () => {
+  it('範囲外の低areaLevelはデフォルト範囲[1,8]にフォールバック', () => {
+    const fixedZero = () => 0
+    const iv = calculateIndividualValue(0, 1, fixedZero)
+    expect(iv).toBe(1)
+  })
+
+  it('areaLevel=9以上は最高エリア帯の範囲を使う', () => {
     const fixedZero = () => 0
     const iv = calculateIndividualValue(99, 1, fixedZero)
-    // AREA_LEVEL_IV_RANGES[99] は undefined → [1,8] にフォールバック
-    expect(iv).toBe(1)
+    expect(iv).toBe(50)
   })
 })

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -19,6 +19,7 @@ import { useDungeonStore } from '../stores/useDungeonStore'
 import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQLiteEquipmentRepository'
 import { useDebugSettingsStore } from '../stores/useDebugSettingsStore'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
+import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
 import i18n from '../../shared/i18n'
 
 interface UseExpeditionFlowParams {
@@ -47,9 +48,12 @@ export interface ExpeditionHistoryDisplay {
   record: ExpeditionRecord
 }
 
-function formatDungeonLabel(dungeonName: string, areaLevel?: number): string {
-  if (areaLevel === undefined) return dungeonName
-  return `${dungeonName} / Area Lv.${areaLevel}`
+function formatDungeonLabel(dungeonName: string, areaLevel?: number, tier?: DungeonTier): string {
+  const effectiveAreaLevel = areaLevel === undefined
+    ? undefined
+    : getDungeonTierAreaLevel(areaLevel, tier ?? 0)
+  const baseLabel = effectiveAreaLevel === undefined ? dungeonName : `${dungeonName} / Area Lv.${effectiveAreaLevel}`
+  return getDungeonTierDisplayName(baseLabel, tier ?? 0)
 }
 
 export const useExpeditionFlow = ({
@@ -103,7 +107,8 @@ export const useExpeditionFlow = ({
     await markDungeonCleared(dungeon, true, tier)
 
     const nextId = await getNextGoblinId()
-    const areaLevel = dungeon.areaLevel ?? 1
+    const areaLevel = record.replay.meta.effectiveAreaLevel ??
+      getDungeonTierAreaLevel(dungeon.areaLevel ?? 1, tier ?? 0)
     const goblinBirthService = new GoblinBirthService()
     const newGoblin = goblinBirthService.createNewGoblin(
       nextId,
@@ -318,7 +323,11 @@ export const useExpeditionFlow = ({
         return {
           id: record.id,
           title,
-          subtitle: formatDungeonLabel(dungeon ? getDungeonName(dungeon) : record.dungeonName, dungeon?.areaLevel),
+          subtitle: formatDungeonLabel(
+            dungeon ? getDungeonName(dungeon) : record.dungeonName,
+            dungeon?.areaLevel,
+            record.replay?.meta.tier,
+          ),
           ongoing,
           record,
         }

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -506,6 +506,8 @@ const en = {
     majou: 'Demonic',
     yadotta: 'Possessed',
     densetsu: 'Legendary',
+    osoroshii: 'Terrifying',
+    kowareta: 'Broken',
   },
 } as const
 

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -506,6 +506,8 @@ const ja = {
     majou: '魔性',
     yadotta: '宿った',
     densetsu: '伝説',
+    osoroshii: '恐ろしい',
+    kowareta: '壊れた',
   },
 } as const
 

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -506,6 +506,8 @@ const ko = {
     majou: '마성',
     yadotta: '깃든',
     densetsu: '전설',
+    osoroshii: '무시무시한',
+    kowareta: '망가진',
   },
 } as const
 

--- a/goblin_native/src/shared/types/Dungeon.ts
+++ b/goblin_native/src/shared/types/Dungeon.ts
@@ -14,5 +14,5 @@ export type Dungeon = {
   areaLevel?: number                // エリアレベル（1-8）、個体値計算に使用
   isBaseCapture?: boolean           // 拠点化可能か
   rankUpTarget?: number             // このダンジョン制圧で到達するランク
-  maxClearedTier?: number           // 最大クリア済みティア（0=未クリア, 1=通常, 2=魔性, 3=宿った, 4=伝説）
+  maxClearedTier?: number           // 最大クリア済みティア（0=未クリア, 1=通常, 2=魔性, 3=宿った, 4=伝説, 5=恐ろしい, 6=壊れた）
 }

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -1,22 +1,107 @@
 /** ダンジョンティア（難易度バリエーション） */
-export type DungeonTier = 0 | 1 | 2 | 3
+export type DungeonTier = 0 | 1 | 2 | 3 | 4 | 5
 
-export const DUNGEON_TIER_LIST = [0, 1, 2, 3] as const
+export const DUNGEON_TIER_LIST = [0, 1, 2, 3, 4, 5] as const
 
 export const DUNGEON_TIER_META = [
   { tier: 0 as const, prefix: '', labelKey: 'dungeonTier.normal' },
   { tier: 1 as const, prefix: '魔性', labelKey: 'dungeonTier.majou' },
   { tier: 2 as const, prefix: '宿った', labelKey: 'dungeonTier.yadotta' },
   { tier: 3 as const, prefix: '伝説', labelKey: 'dungeonTier.densetsu' },
+  { tier: 4 as const, prefix: '恐ろしい', labelKey: 'dungeonTier.osoroshii' },
+  { tier: 5 as const, prefix: '壊れた', labelKey: 'dungeonTier.kowareta' },
 ] as const
 
-/** ティアごとの敵レベル倍率・報酬倍率 */
+/** ティアごとの敵ステータス倍率・Lv加算・EXP倍率 */
 export const DUNGEON_TIER_SCALING = [
-  { enemyLvScale: 1.0, rewardScale: 1.0 },
-  { enemyLvScale: 1.5, rewardScale: 1.3 },
-  { enemyLvScale: 2.0, rewardScale: 1.6 },
-  { enemyLvScale: 3.0, rewardScale: 2.0 },
+  {
+    statScale: 1.0,
+    levelBonus: 0,
+    rewardScale: 1.0,
+    hpScale: 1.0,
+    defScale: 1.0,
+    evasionScale: 1.0,
+    magicDefScale: 1.0,
+    physicalResistancePercent: 44.2,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 42.5,
+  },
+  {
+    statScale: 1.58,
+    levelBonus: 1,
+    rewardScale: 1.58,
+    hpScale: 163177 / 65315,
+    defScale: 3950 / 2500,
+    evasionScale: 2844 / 1800,
+    magicDefScale: 12640 / 8000,
+    physicalResistancePercent: 38.0,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 36.5,
+  },
+  {
+    statScale: 2.10,
+    levelBonus: 3,
+    rewardScale: 2.10,
+    hpScale: 288480 / 65315,
+    defScale: 5250 / 2500,
+    evasionScale: 3780 / 1800,
+    magicDefScale: 16800 / 8000,
+    physicalResistancePercent: 32.7,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 34.8,
+  },
+  {
+    statScale: 2.75,
+    levelBonus: 6,
+    rewardScale: 2.75,
+    hpScale: 495759 / 65315,
+    defScale: 6875 / 2500,
+    evasionScale: 4950 / 1800,
+    magicDefScale: 22000 / 8000,
+    physicalResistancePercent: 28.3,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 33.1,
+  },
+  {
+    statScale: 3.50,
+    levelBonus: 11,
+    rewardScale: 3.50,
+    hpScale: 805008 / 65315,
+    defScale: 11550 / 2500,
+    evasionScale: 8050 / 1800,
+    magicDefScale: 29750 / 8000,
+    physicalResistancePercent: 24.3,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 31.4,
+  },
+  {
+    statScale: 5.00,
+    levelBonus: 24,
+    rewardScale: 5.00,
+    hpScale: 1657875 / 65315,
+    defScale: 22500 / 2500,
+    evasionScale: 14000 / 1800,
+    magicDefScale: 45000 / 8000,
+    physicalResistancePercent: 21.2,
+    penetrationResistancePercent: 100.0,
+    criticalResistancePercent: 50.0,
+    magicResistancePercent: 29.7,
+  },
 ] as const
+
+const DUNGEON_TIER_AREA_LEVEL_FLAT_BONUS = [0, 2.8, 3.9, 5.25, 6.5, 10] as const
+
+/** ティアを反映した実効エリアレベルを返す */
+export function getDungeonTierAreaLevel(baseAreaLevel: number, tier: DungeonTier = 0): number {
+  const scaling = DUNGEON_TIER_SCALING[tier] ?? DUNGEON_TIER_SCALING[0]
+  const flatBonus = DUNGEON_TIER_AREA_LEVEL_FLAT_BONUS[tier] ?? 0
+  return Math.max(1, Math.round(baseAreaLevel * scaling.statScale + flatBonus))
+}
 
 /** ティアに応じたダンジョン表示名を返す */
 export function getDungeonTierDisplayName(baseName: string, tier: DungeonTier): string {

--- a/goblin_native/src/shared/types/Enemy.ts
+++ b/goblin_native/src/shared/types/Enemy.ts
@@ -15,10 +15,15 @@ export interface Enemy {
   hp: number
   atk: number
   def: number
+  magicDef?: number       // 魔法防御力
   agility: number
   attackCount: number  // 攻撃回数
   accuracy: number     // 命中精度
   evasion: number      // 回避能力
+  physicalResistancePercent?: number    // 物理耐性
+  penetrationResistancePercent?: number // 貫通耐性
+  criticalResistancePercent?: number    // 必殺耐性
+  magicResistancePercent?: number       // 魔法耐性
   exp: number
   gold: number
   factorDrops?: FactorDropConfig[]      // この敵を倒すと得られる可能性のある因子

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -29,6 +29,8 @@ export interface ExpeditionReplay {
     expeditionId: string
     areaId: string
     areaName: string
+    areaLevel?: number
+    effectiveAreaLevel?: number
     floors: number
     baseDurationSec: number
     party: string[]

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -70,7 +70,13 @@ export type {
 export type { Dungeon } from "./Dungeon"
 export type { DungeonProgressState } from "./DungeonProgress"
 export type { DungeonTier } from "./DungeonTier"
-export { DUNGEON_TIER_LIST, DUNGEON_TIER_META, DUNGEON_TIER_SCALING, getDungeonTierDisplayName } from "./DungeonTier"
+export {
+  DUNGEON_TIER_LIST,
+  DUNGEON_TIER_META,
+  DUNGEON_TIER_SCALING,
+  getDungeonTierAreaLevel,
+  getDungeonTierDisplayName,
+} from "./DungeonTier"
 
 // Base related types
 export type { BaseState } from "./BaseState"


### PR DESCRIPTION
## Summary
- ダンジョンティアを0-3（通常〜伝説）から0-5（通常〜壊れた）に拡張し、「恐ろしい」「壊れた」ティアを追加
- 敵ステータススケーリングを単一倍率から個別倍率方式（HP/DEF/回避/魔法防御/各種耐性）に刷新
- `getDungeonTierAreaLevel` 関数を導入し、ティアを反映した実効エリアレベル計算を実装
- Enemy型に `magicDef`・`physicalResistancePercent`・`penetrationResistancePercent`・`criticalResistancePercent`・`magicResistancePercent` フィールドを追加
- BattleSystemに魔法ダメージ軽減（`magicDamageReduction`）を追加
- 遠征画面（preparation/playback/result）をティア対応の表示に更新
- i18n辞書（ja/en/ko）に新ティア名を追加
- スケーリング・エリアレベル計算のテストを追加

## Test plan
- [ ] `npm test` で既存テスト + 新規テスト（ExpeditionEngine tier scaling, getDungeonTierAreaLevel）がパスすることを確認
- [ ] 遠征準備画面でティア4・5が選択可能か確認
- [ ] 高ティアダンジョンの敵ステータスが期待通りスケーリングされるか確認
- [ ] playback/result画面でティア付きダンジョン名が正しく表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)