### PR TITLE
fix(expedition): 戦闘敗北時に経験値が付与されないよう修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -151,10 +151,11 @@ export default function ExpeditionPlaybackScreen() {
         const label = event.type === 'boss' ? t('ui.formation.playback.boss') : t('ui.formation.playback.battle')
         const result = event.combat.outcome === 'win' ? t('ui.formation.playback.win') : t('ui.formation.playback.lose')
         const partyMembers = replay?.meta.party ?? []
-        const xpPerMember = partyMembers.length > 0 ? Math.floor(event.xp / partyMembers.length) : 0
+        const rewardedXp = event.combat.outcome === 'win' ? event.xp : 0
+        const xpPerMember = partyMembers.length > 0 ? Math.floor(rewardedXp / partyMembers.length) : 0
         const meta: BattleLogMeta = {
           outcome: event.combat.outcome,
-          xpGained: event.xp,
+          xpGained: rewardedXp,
           goldGained: event.enemy.gold,
           members: partyMembers.map((memberId, idx) => {
             const goblin = partyGoblins[idx]
@@ -178,8 +179,8 @@ export default function ExpeditionPlaybackScreen() {
             meta,
           ),
         ]
-        if (event.xp > 0) {
-          entries.push(createEntry(t('ui.formation.playback.xpGain', { value: event.xp })))
+        if (rewardedXp > 0) {
+          entries.push(createEntry(t('ui.formation.playback.xpGain', { value: rewardedXp })))
         }
         return entries
       }

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -130,7 +130,8 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
+            const baseXp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
+            const xp = combat.outcome === 'win' ? baseXp : 0
 
             events.push({
               type: "battle",
@@ -193,7 +194,8 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
+            const baseXp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
+            const xp = combat.outcome === 'win' ? baseXp : 0
 
             events.push({
               type: "battle",
@@ -265,7 +267,8 @@ export class ExpeditionEngine {
         const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling)
 
         const bossCombat = this.resolveCombat(partyState, bossEnemies, area, true)
-        const bossXp = Math.floor((area.rewards.xpBoss ?? 0) * tierScaling.rewardScale)
+        const baseBossXp = Math.floor((area.rewards.xpBoss ?? 0) * tierScaling.rewardScale)
+        const bossXp = bossCombat.outcome === 'win' ? baseBossXp : 0
 
         // 規定時間の終端でボス戦を行う（最後の秒で戦闘開始）
         const bossTime = adjustedDuration
@@ -657,7 +660,9 @@ export class ExpeditionEngine {
 
     for (const event of events) {
       if (event.type === "battle" || event.type === "boss") {
-        xpGained += event.xp
+        if (event.combat.outcome === "win") {
+          xpGained += event.xp
+        }
         baseGoldGained += event.enemy.gold
         maxFloorReached = Math.max(maxFloorReached, event.floor)
       } else if (event.type === "floor_up") {

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -54,7 +54,51 @@ describe('ExpeditionEngine reward multipliers', () => {
       gold: 1.5,
     })
 
+    expect(summary.xpGained).toBe(25)
     expect(summary.goldGained).toBe(52)
+  })
+
+  it('敗北した戦闘の経験値を報酬合計に含めない', () => {
+    const engine = new ExpeditionEngine(1)
+    const events: TimelineEvent[] = [
+      { type: 'move_start', at: 0, floor: 1 },
+      {
+        type: 'battle',
+        at: 10,
+        floor: 1,
+        enemy: { id: 'e1', name: '敵1', lvl: 1, count: 1, gold: 10 },
+        combat: { rounds: 1, outcome: 'lose', allyHPDelta: [-10], enemyDefeated: 0 },
+        xp: 100,
+      },
+      { type: 'return', at: 30, reason: 'defeated' },
+    ]
+    const partyState: PartyState[] = [
+      {
+        id: '1',
+        name: 'テスト',
+        race: 'ゴブリン',
+        currentHP: 0,
+        maxHP: 10,
+        baseHP: 10,
+        atk: 5,
+        def: 5,
+        agility: 5,
+        attackCount: 1,
+        accuracy: 10,
+        evasion: 5,
+        isKO: true,
+        isDead: true,
+        mods: [],
+        skills: [],
+        factors: [],
+        level: 1,
+        avatar: 'test.png',
+      },
+    ]
+
+    const summary = (engine as any).calculateRewardSummary(events, partyState)
+
+    expect(summary.xpGained).toBe(0)
   })
 })
 

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -78,9 +78,9 @@ export class CompleteExpeditionUseCase {
         if (currentHP[i] > 0) aliveIndices.push(i)
       }
 
-      // 生存メンバー数で経験値を分配
+      // 勝利した戦闘のみ、生存メンバー数で経験値を分配
       const aliveCount = aliveIndices.length
-      if (aliveCount > 0 && event.xp > 0) {
+      if (event.combat.outcome === 'win' && aliveCount > 0 && event.xp > 0) {
         const xpPerMember = Math.floor(event.xp / aliveCount)
         for (const idx of aliveIndices) {
           const goblinId = Number.parseInt(partyIds[idx], 10)

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -198,6 +198,32 @@ describe('CompleteExpeditionUseCase', () => {
       expect(result.updatedGoblinIds).toContain(2)
     })
 
+    it('全滅した戦闘では経験値が付与されない', async () => {
+      const goblin = createTestGoblin({ id: 1, level: 1, experience: 0 })
+      const party = createTestParty({ id: 1, memberIds: [1] })
+      const baseState = createTestBaseState()
+      const events: TimelineEvent[] = [
+        { type: 'move_start', at: 0, floor: 1 },
+        {
+          ...createBattleEvent(100, [-60], 10, 1),
+          combat: { rounds: 3, outcome: 'lose', allyHPDelta: [-60], enemyDefeated: 0 },
+        },
+        { type: 'return', at: 60, reason: 'defeated' },
+      ]
+      const replay = createTestReplay({
+        events,
+        summary: { success: false, maxFloorReached: 1, xpGained: 100, goldGained: 0, casualties: ['1'] },
+      })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, createMockPartyRepository([party]), createMockBaseStateRepository(baseState))
+      const result = await usecase.execute(1, replay)
+
+      expect(result.updatedGoblinIds).toHaveLength(0)
+      expect(result.levelUps.size).toBe(0)
+      expect(goblinRepo.saveGoblin).not.toHaveBeenCalled()
+    })
+
     it('ゴールドが加算される', async () => {
       const goblin = createTestGoblin()
       const party = createTestParty()


### PR DESCRIPTION
## Summary
- 敗北した戦闘でもXPが加算されていた不具合を修正
- ExpeditionEngine・CompleteExpeditionUseCase・playback UIの3箇所で勝利時のみXPを付与するよう統一
- 敗北時のXP非付与を検証するテストを追加

## Test plan
- [ ] `npm test` で既存テスト・新規テストがすべてパスすることを確認
- [ ] 遠征で敗北した戦闘のログにXP獲得が表示されないことを確認
- [ ] 遠征完了後、敗北戦闘分のXPがゴブリンに付与されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)