### PR TITLE
feat(ui): 負傷ゴブリンのビジュアルフィードバック改善と治療メニュー優先表示

### DIFF
--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -44,6 +44,14 @@ export default function BaseManagementScreen() {
         <View style={styles.card}>
           <Text style={styles.cardTitle}>{t('ui.base.menuTitle')}</Text>
 
+          <TouchableOpacity style={styles.menuButton} onPress={() => router.push('/base/healing')}>
+            <View style={styles.menuButtonTextGroup}>
+              <Text style={styles.menuButtonTitle}>{t('ui.base.healingTitle')}</Text>
+              <Text style={styles.menuButtonDescription}>{t('ui.base.healingDescription')}</Text>
+            </View>
+            <Text style={styles.menuButtonArrow}>›</Text>
+          </TouchableOpacity>
+
           <TouchableOpacity style={styles.menuButton} onPress={() => router.push('/base/upgrade')}>
             <View style={styles.menuButtonTextGroup}>
               <Text style={styles.menuButtonTitle}>{t('ui.base.upgradeTitle')}</Text>
@@ -56,14 +64,6 @@ export default function BaseManagementScreen() {
             <View style={styles.menuButtonTextGroup}>
               <Text style={styles.menuButtonTitle}>{t('ui.base.trainingTitle')}</Text>
               <Text style={styles.menuButtonDescription}>{t('ui.base.trainingDescription')}</Text>
-            </View>
-            <Text style={styles.menuButtonArrow}>›</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity style={styles.menuButton} onPress={() => router.push('/base/healing')}>
-            <View style={styles.menuButtonTextGroup}>
-              <Text style={styles.menuButtonTitle}>{t('ui.base.healingTitle')}</Text>
-              <Text style={styles.menuButtonDescription}>{t('ui.base.healingDescription')}</Text>
             </View>
             <Text style={styles.menuButtonArrow}>›</Text>
           </TouchableOpacity>

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -40,12 +40,20 @@ const MemberSlot = memo(function MemberSlot({ goblin, isEmpty, slotSize, avatarS
 
   const stats = getEffectiveStats(goblin)
   const currentHp = goblin.currentHp ?? stats.hp
+  const isInjured = currentHp === 0
 
   return (
     <View style={[styles.memberSlot, { width: slotSize }]}>
       <Text style={styles.memberLevel}>Lv{goblin.level}</Text>
-      <Image source={getGoblinDisplayImage(goblin)} style={[styles.memberAvatar, { width: avatarSize, height: avatarSize }]} />
-      <Text style={[styles.memberHp, currentHp === 0 && styles.memberHpInjured]}>HP{currentHp}</Text>
+      <Image
+        source={getGoblinDisplayImage(goblin)}
+        style={[
+          styles.memberAvatar,
+          { width: avatarSize, height: avatarSize },
+          isInjured && styles.memberAvatarInjured,
+        ]}
+      />
+      <Text style={[styles.memberHp, isInjured && styles.memberHpInjured]}>HP{currentHp}</Text>
     </View>
   )
 })
@@ -553,13 +561,17 @@ const styles = StyleSheet.create({
     height: 40,
     borderRadius: 4,
   },
+  memberAvatarInjured: {
+    opacity: 0.45,
+    tintColor: '#9CA3AF',
+  },
   memberHp: {
     fontSize: 10,
     color: '#6B7280',
     marginTop: 4,
   },
   memberHpInjured: {
-    color: '#DC2626',
+    color: '#9CA3AF',
     fontWeight: '700',
   },
   emptySlot: {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -46,12 +46,20 @@ function MemberSlot({ goblin, isEmpty, slotSize, avatarSize }: MemberSlotProps) 
 
   const stats = getEffectiveStats(goblin)
   const currentHp = goblin.currentHp ?? stats.hp
+  const isInjured = currentHp === 0
 
   return (
     <View style={[styles.memberSlot, { width: slotSize }]}>
       <Text style={styles.memberLevel}>Lv{goblin.level}</Text>
-      <Image source={getGoblinDisplayImage(goblin)} style={[styles.memberAvatar, { width: avatarSize, height: avatarSize }]} />
-      <Text style={[styles.memberHp, currentHp === 0 && styles.memberHpInjured]}>HP{currentHp}</Text>
+      <Image
+        source={getGoblinDisplayImage(goblin)}
+        style={[
+          styles.memberAvatar,
+          { width: avatarSize, height: avatarSize },
+          isInjured && styles.memberAvatarInjured,
+        ]}
+      />
+      <Text style={[styles.memberHp, isInjured && styles.memberHpInjured]}>HP{currentHp}</Text>
     </View>
   )
 }
@@ -745,13 +753,17 @@ const styles = StyleSheet.create({
     height: 40,
     borderRadius: 4,
   },
+  memberAvatarInjured: {
+    opacity: 0.45,
+    tintColor: '#9CA3AF',
+  },
   memberHp: {
     fontSize: 10,
     color: '#6B7280',
     marginTop: 4,
   },
   memberHpInjured: {
-    color: '#DC2626',
+    color: '#9CA3AF',
     fontWeight: '700',
   },
   emptySlot: {


### PR DESCRIPTION
## Summary
- 編成画面・準備画面でHP0のゴブリンアバターをグレーアウト表示（opacity + tintColor）に変更し、負傷状態を視覚的にわかりやすくした
- HP0の文字色を赤からグレーに統一
- 拠点メニューで治療ボタンをアップグレード・訓練より上に移動し、治療への導線を強化

## Test plan
- [ ] 編成画面でHP0のゴブリンがグレーアウト表示されることを確認
- [ ] 準備画面でHP0のゴブリンがグレーアウト表示されることを確認
- [ ] 拠点画面で治療メニューが最上位に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)