### PR TITLE
fix(goblin): ゴブリン詳細画面のデータ取得をリアクティブに改善

### DIFF
--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -22,6 +22,7 @@ import { getFactorName, getRaceLabel, getSkillLabel, getStatLabel } from '@/shar
 export default function GoblinDetailScreen() {
   const { t } = useTranslation()
   const { goblinId, source } = useLocalSearchParams<{ goblinId: string, source?: string }>()
+  const goblins = useGoblinStore((state) => state.goblins)
   const getGoblinById = useGoblinStore((state) => state.getGoblinById)
   const deleteGoblin = useGoblinStore((state) => state.deleteGoblin)
   const pendingGoblins = useBaseStore((state) => state.pendingGoblins)
@@ -29,20 +30,33 @@ export default function GoblinDetailScreen() {
   const [goblin, setGoblin] = useState<Goblin | null>(null)
   const parentNav = useNavigation()
   const isPendingGoblin = source === 'pending'
+  const parsedGoblinId = useMemo(() => {
+    if (!goblinId) return null
+    const parsed = parseInt(goblinId, 10)
+    return Number.isNaN(parsed) ? null : parsed
+  }, [goblinId])
 
   useEffect(() => {
-    if (!goblinId) return
-    const parsedGoblinId = parseInt(goblinId, 10)
+    if (parsedGoblinId == null) {
+      setGoblin(null)
+      return
+    }
 
     if (isPendingGoblin) {
       setGoblin(pendingGoblins.find((item) => item.id === parsedGoblinId) ?? null)
       return
     }
 
+    const storedGoblin = goblins.find((item) => item.id === parsedGoblinId)
+    if (storedGoblin) {
+      setGoblin(storedGoblin)
+      return
+    }
+
     void getGoblinById(parsedGoblinId)
       .then(setGoblin)
       .catch(() => setGoblin(null))
-  }, [goblinId, getGoblinById, isPendingGoblin, pendingGoblins])
+  }, [parsedGoblinId, getGoblinById, goblins, isPendingGoblin, pendingGoblins])
 
   useEffect(() => {
     if (goblin) {


### PR DESCRIPTION
## Summary
- ゴブリン詳細画面でstoreの`goblins`を直接参照し、装備変更やHP更新などの状態変化が即座に反映されるよう修正
- `goblinId`のパースを`useMemo`で最適化し、不要な再取得を防止
- storeにデータがない場合のみ`getGoblinById`でDB取得するフォールバックを維持

## Test plan
- [ ] ゴブリン詳細画面を開き、装備変更後に詳細画面に戻って変更が反映されていることを確認
- [ ] 治療後にHP更新が詳細画面に即座に反映されることを確認
- [ ] 保留中ゴブリンの詳細表示が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)