### PR TITLE
refactor(expedition): 経験値計算を敵exp合計ベースに変更しエリアrewardsを廃止

### DIFF
--- a/goblin_native/app/base/healing.tsx
+++ b/goblin_native/app/base/healing.tsx
@@ -38,7 +38,7 @@ export default function HealingScreen() {
     try {
       setProcessingIds(prev => new Set(prev).add(goblin.id))
       await updateBaseState({ gold: gold - cost })
-      await updateGoblinCurrentHp(goblin.id, getEffectiveStats(goblin).hp)
+      await updateGoblinCurrentHp(goblin.id, null)
     } catch (error) {
       console.error('[Healing] Failed to heal goblin', error)
       Alert.alert(t('ui.healing.failedTitle'), t('ui.healing.failedBody'))
@@ -62,7 +62,7 @@ export default function HealingScreen() {
       setIsBulkProcessing(true)
       await updateBaseState({ gold: gold - totalCost })
       for (const goblin of injuredGoblins) {
-        await updateGoblinCurrentHp(goblin.id, getEffectiveStats(goblin).hp)
+        await updateGoblinCurrentHp(goblin.id, null)
       }
     } catch (error) {
       console.error('[Healing] Failed to heal all goblins', error)

--- a/goblin_native/docs/expedition_system.md
+++ b/goblin_native/docs/expedition_system.md
@@ -239,8 +239,8 @@ PartyState → Goblin再構築（基礎ステータス + mods + factors）
 各戦闘イベント（battle/boss）に `xp` が設定される:
 
 ```
-通常戦闘: area.rewards.xpFloor[currentFloor - 1]  （フロアごとに定義）
-ボス戦: area.rewards.xpBoss
+通常戦闘: 出現した敵の `exp` 合計
+ボス戦: 出現した敵の `exp` 合計
 ```
 
 #### 経験値分配（CompleteExpeditionUseCase）
@@ -302,10 +302,6 @@ goldGained = Σ(各戦闘の enemy.gold)
       battle: 40,
       exploring: 50
     }
-  },
-  rewards: {
-    xpFloor: [8, 10, 12],   // フロアごとの戦闘経験値
-    xpBoss: 30               // ボス戦経験値
   },
   // 宝箱ドロップ率は全エリア一律40%（ExpeditionEngine.DROP_CHANCE定数）
   unlockNext: "goblin_village_1"  // 制圧時に解放されるダンジョン

--- a/goblin_native/src/core/repositories/IGoblinRepository.ts
+++ b/goblin_native/src/core/repositories/IGoblinRepository.ts
@@ -8,5 +8,5 @@ export interface IGoblinRepository {
   updateGoblinStats(id: number, stats: Goblin['stats']): Promise<void>
   updateGoblinLevel(id: number, level: number): Promise<void>
   updateGoblinFactors(id: number, factors: string[], effectiveStats: Goblin['stats']): Promise<void>
-  updateGoblinCurrentHp(id: number, currentHp: number): Promise<void>
+  updateGoblinCurrentHp(id: number, currentHp: number | null): Promise<void>
 }

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -130,8 +130,7 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const baseXp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
-            const xp = combat.outcome === 'win' ? baseXp : 0
+            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies) : 0
 
             events.push({
               type: "battle",
@@ -194,8 +193,7 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const baseXp = Math.floor((area.rewards.xpFloor[currentFloor - 1] || 10) * tierScaling.rewardScale)
-            const xp = combat.outcome === 'win' ? baseXp : 0
+            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies) : 0
 
             events.push({
               type: "battle",
@@ -267,8 +265,7 @@ export class ExpeditionEngine {
         const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling)
 
         const bossCombat = this.resolveCombat(partyState, bossEnemies, area, true)
-        const baseBossXp = Math.floor((area.rewards.xpBoss ?? 0) * tierScaling.rewardScale)
-        const bossXp = bossCombat.outcome === 'win' ? baseBossXp : 0
+        const bossXp = bossCombat.outcome === 'win' ? this.calculateEnemyXp(bossEnemies) : 0
 
         // 規定時間の終端でボス戦を行う（最後の秒で戦闘開始）
         const bossTime = adjustedDuration
@@ -465,6 +462,10 @@ export class ExpeditionEngine {
         return enemy
       })
     )
+  }
+
+  private calculateEnemyXp(enemies2D: Enemy[][]): number {
+    return enemies2D.flat().reduce((sum, enemy) => sum + enemy.exp, 0)
   }
 
   private createEnemySnap(enemies2D: Enemy[][], isBoss = false): EnemySnap {

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -180,6 +180,65 @@ describe('ExpeditionEngine dungeon tier scaling', () => {
   })
 })
 
+describe('ExpeditionEngine enemy XP rewards', () => {
+  it('敵ごとのexp合計を戦闘経験値として扱う', () => {
+    const engine = new ExpeditionEngine(1)
+    const enemies: Enemy[][] = [
+      [
+        {
+          id: 'slime-a',
+          name: 'スライムA',
+          raceTags: ['slime'],
+          level: 1,
+          hp: 4,
+          atk: 2,
+          def: 1,
+          agility: 6,
+          attackCount: 1,
+          accuracy: 70,
+          evasion: 9,
+          exp: 1,
+          gold: 1,
+        },
+        {
+          id: 'slime-b',
+          name: 'スライムB',
+          raceTags: ['slime'],
+          level: 1,
+          hp: 4,
+          atk: 2,
+          def: 1,
+          agility: 6,
+          attackCount: 1,
+          accuracy: 70,
+          evasion: 9,
+          exp: 1,
+          gold: 1,
+        },
+      ],
+      [
+        {
+          id: 'boss-slime',
+          name: 'ボススライム',
+          raceTags: ['slime'],
+          level: 3,
+          hp: 20,
+          atk: 3,
+          def: 2,
+          agility: 8,
+          attackCount: 1,
+          accuracy: 100,
+          evasion: 11,
+          exp: 5,
+          gold: 5,
+        },
+      ],
+    ]
+
+    expect((engine as any).calculateEnemyXp(enemies)).toBe(7)
+  })
+})
+
 describe('getDungeonTierAreaLevel', () => {
   it('推奨Lv表の法則でエリアレベルをスケールする', () => {
     const tiers = [0, 1, 2, 3, 4] as DungeonTier[]

--- a/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteGoblinRepository.ts
@@ -114,11 +114,11 @@ export class SQLiteGoblinRepository implements IGoblinRepository {
     )
   }
 
-  async updateGoblinCurrentHp(id: number, currentHp: number): Promise<void> {
+  async updateGoblinCurrentHp(id: number, currentHp: number | null): Promise<void> {
     const db = await getDatabase()
     await db.runAsync(
       `UPDATE goblins SET current_hp = ?, updated_at = datetime('now') WHERE id = ?`,
-      [Math.max(0, Math.floor(currentHp)), id]
+      [currentHp === null ? null : Math.max(0, Math.floor(currentHp)), id]
     )
   }
 

--- a/goblin_native/src/presentation/stores/useGoblinStore.ts
+++ b/goblin_native/src/presentation/stores/useGoblinStore.ts
@@ -19,7 +19,7 @@ interface GoblinActions {
   saveGoblin: (goblin: Goblin) => Promise<void>
   deleteGoblin: (goblinId: number) => Promise<void>
   updateGoblinLevel: (goblinId: number, level: number) => Promise<void>
-  updateGoblinCurrentHp: (goblinId: number, currentHp: number) => Promise<void>
+  updateGoblinCurrentHp: (goblinId: number, currentHp: number | null) => Promise<void>
 }
 
 const repository: IGoblinRepository = SQLiteGoblinRepository.getInstance()
@@ -97,7 +97,7 @@ export const useGoblinStore = create<GoblinState & GoblinActions>()((set) => ({
     set({ goblins })
   },
 
-  updateGoblinCurrentHp: async (goblinId: number, currentHp: number) => {
+  updateGoblinCurrentHp: async (goblinId: number, currentHp: number | null) => {
     await repository.updateGoblinCurrentHp(goblinId, currentHp)
     const goblins = await attachEquipmentEffectiveStatsToList(await getGoblinListUseCase.execute())
     set({ goblins })

--- a/goblin_native/src/shared/data/enemy/slime_cave.json
+++ b/goblin_native/src/shared/data/enemy/slime_cave.json
@@ -7,15 +7,15 @@
         "slime"
       ],
       "level": 1,
-      "hp": 8,
-      "atk": 5,
+      "hp": 4,
+      "atk": 2,
       "def": 1,
       "agility": 6,
       "attackCount": 1,
-      "accuracy": 180,
+      "accuracy": 70,
       "evasion": 9,
-      "exp": 3,
-      "gold": 3
+      "exp": 1,
+      "gold": 1
     },
     {
       "id": "B_SLIME",
@@ -24,15 +24,15 @@
         "slime"
       ],
       "level": 3,
-      "hp": 30,
-      "atk": 10,
-      "def": 4,
+      "hp": 20,
+      "atk": 3,
+      "def": 2,
       "agility": 8,
-      "attackCount": 2,
-      "accuracy": 220,
+      "attackCount": 1,
+      "accuracy": 100,
       "evasion": 11,
-      "exp": 12,
-      "gold": 10,
+      "exp": 5,
+      "gold": 5,
       "factorDrops": [
         {
           "factorId": "slime",
@@ -45,7 +45,8 @@
     {
       "id": "SP001",
       "floors": [
-        1
+        1,
+        2
       ],
       "enemies": [
         [
@@ -56,109 +57,10 @@
     {
       "id": "SP002",
       "floors": [
-        1
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP003",
-      "floors": [
-        1
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001",
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP004",
-      "floors": [
-        1
-      ],
-      "enemies": [
-        [
-          "S001"
-        ],
-        [
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP005",
-      "floors": [
-        1
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001"
-        ],
-        [
-          "S001",
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP006",
-      "floors": [
+        1,
         2
       ],
       "enemies": [
-        [
-          "S001",
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP007",
-      "floors": [
-        2
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001",
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP008",
-      "floors": [
-        2
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001"
-        ],
-        [
-          "S001"
-        ]
-      ]
-    },
-    {
-      "id": "SP009",
-      "floors": [
-        2
-      ],
-      "enemies": [
-        [
-          "S001",
-          "S001",
-          "S001"
-        ],
         [
           "S001",
           "S001"
@@ -171,12 +73,6 @@
         2
       ],
       "enemies": [
-        [
-          "S001",
-          "S001",
-          "S001",
-          "S001"
-        ],
         [
           "B_SLIME"
         ]

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
@@ -7,8 +7,10 @@
   "description": "坑道の入口。ドワーフ坑夫たちが工具を武器に抵抗してくる。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [40, 48] },
   "unlockNext": "dwarf_mine_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
@@ -7,8 +7,10 @@
   "description": "坑道深部。戦士やルーン鍛冶師が待ち構える。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [58, 68] },
   "unlockNext": "dwarf_mine_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
@@ -7,8 +7,10 @@
   "description": "坑道の最深部。坑道守護者と擲弾兵に守られた鍛冶王が待ち受ける。鍛冶能力をゴブリン国家に取り込め。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [80, 88], "xpBoss": 220 },
   "unlockNext": "elf_forest_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_1.json
@@ -7,8 +7,10 @@
   "description": "隠れ里の外縁。森の斥候と射手が素早い攻撃を仕掛けてくる。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 60, "exploring": 40 }
+    "eventWeights": {
+      "battle": 60,
+      "exploring": 40
+    }
   },
-  "rewards": { "xpFloor": [44, 54] },
   "unlockNext": "elf_forest_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_2.json
@@ -7,8 +7,10 @@
   "description": "里の内部。精霊使いや月の衛士が守りを固めている。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 60, "exploring": 40 }
+    "eventWeights": {
+      "battle": 60,
+      "exploring": 40
+    }
   },
-  "rewards": { "xpFloor": [64, 76] },
   "unlockNext": "elf_forest_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_3.json
@@ -7,8 +7,10 @@
   "description": "里の中枢。古樹の戦士に守られた森の番人が最後の壁として立ちはだかる。魔法の力を手に入れろ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 60, "exploring": 40 }
+    "eventWeights": {
+      "battle": 60,
+      "exploring": 40
+    }
   },
-  "rewards": { "xpFloor": [88, 95], "xpBoss": 260 },
   "unlockNext": "lizardman_swamp_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
+++ b/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
@@ -12,9 +12,5 @@
       "exploring": 50
     }
   },
-  "rewards": {
-    "xpFloor": [8, 10, 12],
-    "xpBoss": 30
-  },
   "unlockNext": "mossy_cave"
 }

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
@@ -12,8 +12,5 @@
       "exploring": 40
     }
   },
-  "rewards": {
-    "xpFloor": [10, 14]
-  },
   "unlockNext": "goblin_village_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
@@ -12,8 +12,5 @@
       "exploring": 40
     }
   },
-  "rewards": {
-    "xpFloor": [16, 20]
-  },
   "unlockNext": "goblin_village_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
@@ -12,9 +12,5 @@
       "exploring": 40
     }
   },
-  "rewards": {
-    "xpFloor": [22, 25],
-    "xpBoss": 80
-  },
   "unlockNext": "undead_ruins_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_1.json
@@ -7,8 +7,10 @@
   "description": "城塞の外壁。騎士と宮廷魔術師が城壁から迎え撃つ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [78, 92] },
   "unlockNext": "human_fortress_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_2.json
@@ -7,8 +7,10 @@
   "description": "城内へ侵入。重装騎兵と攻城兵器操手が待ち構える。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [125, 145] },
   "unlockNext": "human_fortress_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_3.json
@@ -7,8 +7,10 @@
   "description": "城塞の本丸。精鋭近衛兵に守られた城塞司令官との最終決戦。異種族の力を総動員して突破せよ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [165, 180], "xpBoss": 480 },
   "unlockNext": "royal_capital_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_village_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_village_1.json
@@ -7,8 +7,10 @@
   "description": "村の外周を攻める。民兵と猟師が迎え撃つ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [30, 38] },
   "unlockNext": "human_village_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_village_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_village_2.json
@@ -7,8 +7,10 @@
   "description": "市街地へ侵入。守備兵と簡易魔法兵器が配備されている。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [46, 54] },
   "unlockNext": "human_village_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/human_village_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_village_3.json
@@ -7,8 +7,10 @@
   "description": "村の中心部。自警団長が最後の砦として立ちはだかる。制圧してゴブリン国家の礎を築け。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [62, 68], "xpBoss": 180 },
   "unlockNext": "dwarf_mine_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
@@ -7,8 +7,10 @@
   "description": "沼砦の浅瀬。沼の戦士と毒牙兵が水際で襲いかかる。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [52, 64] },
   "unlockNext": "lizardman_swamp_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
@@ -7,8 +7,10 @@
   "description": "砦の深部。呪術師や暗殺者が潜む危険な沼地。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [78, 90] },
   "unlockNext": "lizardman_swamp_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
@@ -7,8 +7,10 @@
   "description": "砦の本拠。鱗の重装兵に守られた沼王が待ち受ける。水棲戦力を手に入れろ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 65, "exploring": 35 }
+    "eventWeights": {
+      "battle": 65,
+      "exploring": 35
+    }
   },
-  "rewards": { "xpFloor": [104, 112], "xpBoss": 320 },
   "unlockNext": "troll_canyon_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
@@ -12,8 +12,5 @@
       "exploring": 35
     }
   },
-  "rewards": {
-    "xpFloor": [18, 24]
-  },
   "unlockNext": "orc_camp_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
@@ -12,8 +12,5 @@
       "exploring": 35
     }
   },
-  "rewards": {
-    "xpFloor": [28, 34]
-  },
   "unlockNext": "orc_camp_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
@@ -11,9 +11,5 @@
       "battle": 65,
       "exploring": 35
     }
-  },
-  "rewards": {
-    "xpFloor": [38, 45],
-    "xpBoss": 120
   }
 }

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_1.json
@@ -7,8 +7,10 @@
   "description": "王都の城門を突破する。近衛騎士と大魔導師が立ちはだかる。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 75, "exploring": 25 }
+    "eventWeights": {
+      "battle": 75,
+      "exploring": 25
+    }
   },
-  "rewards": { "xpFloor": [95, 115] },
   "unlockNext": "royal_capital_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_2.json
@@ -7,8 +7,10 @@
   "description": "王城内部へ侵攻。聖騎士や王国禁衛隊が最後の防衛線を張る。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 75, "exploring": 25 }
+    "eventWeights": {
+      "battle": 75,
+      "exploring": 25
+    }
   },
-  "rewards": { "xpFloor": [160, 195] },
   "unlockNext": "royal_capital_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_3.json
@@ -7,7 +7,9 @@
   "description": "最終決戦。勇者と人間王が最後の壁として立ちはだかる。ゴブリンキングダムの完成をかけた決戦。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 75, "exploring": 25 }
-  },
-  "rewards": { "xpFloor": [240, 260], "xpBoss": 600 }
+    "eventWeights": {
+      "battle": 75,
+      "exploring": 25
+    }
+  }
 }

--- a/goblin_native/src/shared/data/expeditionArea/slime_cave.json
+++ b/goblin_native/src/shared/data/expeditionArea/slime_cave.json
@@ -12,9 +12,5 @@
       "exploring": 30
     }
   },
-  "rewards": {
-    "xpFloor": [4, 6],
-    "xpBoss": 12
-  },
   "unlockNext": "forest_outskirts"
 }

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
@@ -7,8 +7,10 @@
   "description": "討伐隊の先遣部隊が接近。正規兵と弓兵の小部隊を迎撃せよ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [24, 30] },
   "unlockNext": "subjugation_force_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
@@ -7,8 +7,10 @@
   "description": "本隊が到着。傭兵や見習い魔術師も加わり、攻勢が激化する。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [36, 44] },
   "unlockNext": "subjugation_force_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
@@ -7,8 +7,10 @@
   "description": "討伐隊長が前線に立つ。騎士候補も含む精鋭部隊との最終決戦。撃退せよ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [48, 52], "xpBoss": 140 },
   "unlockNext": "human_village_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_1.json
@@ -7,8 +7,10 @@
   "description": "峡谷の入口。トロルが単体で徘徊している。一体でも油断ならない巨躯。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [60, 72] },
   "unlockNext": "troll_canyon_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_2.json
@@ -7,8 +7,10 @@
   "description": "峡谷の深部。洞窟トロルや投石トロルが群れをなす。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [88, 105] },
   "unlockNext": "troll_canyon_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_3.json
@@ -7,8 +7,10 @@
   "description": "峡谷の最奥。巨大トロルの群れの先に、峡谷の暴君が待ち受ける。再生能力を手に入れろ。",
   "encounter": {
     "perFloorEvents": 3,
-    "eventWeights": { "battle": 70, "exploring": 30 }
+    "eventWeights": {
+      "battle": 70,
+      "exploring": 30
+    }
   },
-  "rewards": { "xpFloor": [130, 142], "xpBoss": 380 },
   "unlockNext": "human_fortress_1"
 }

--- a/goblin_native/src/shared/data/expeditionArea/undead_ruins_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/undead_ruins_1.json
@@ -12,8 +12,5 @@
       "exploring": 35
     }
   },
-  "rewards": {
-    "xpFloor": [14, 18]
-  },
   "unlockNext": "undead_ruins_2"
 }

--- a/goblin_native/src/shared/data/expeditionArea/undead_ruins_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/undead_ruins_2.json
@@ -12,8 +12,5 @@
       "exploring": 35
     }
   },
-  "rewards": {
-    "xpFloor": [22, 28]
-  },
   "unlockNext": "undead_ruins_3"
 }

--- a/goblin_native/src/shared/data/expeditionArea/undead_ruins_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/undead_ruins_3.json
@@ -12,9 +12,5 @@
       "exploring": 35
     }
   },
-  "rewards": {
-    "xpFloor": [32, 38],
-    "xpBoss": 90
-  },
   "unlockNext": "orc_camp_1"
 }

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -111,9 +111,5 @@ export interface AreaConfig {
   }
   enemyTable?: Array<{ id: string; weight: number; lvl: number }>
   boss?: { id: string; lvl: number }
-  rewards: {
-    xpFloor: number[]
-    xpBoss?: number
-  }
   unlockNext?: string
 }


### PR DESCRIPTION
## Summary
- 戦闘経験値の算出を固定値（`xpFloor`/`xpBoss`）から出現した敵の`exp`合計に変更し、敵データが経験値の唯一のソースとなる設計に統一
- 全エリアJSONから`rewards`フィールドを削除、`AreaConfig`型からも除去
- スライム洞窟の敵ステータスをバランス調整（HP/ATK/命中率等を下方修正）
- 治療時の`currentHp`を`null`（=最大HP）で表現するよう改善
- `calculateEnemyXp`のユニットテストを追加

## Test plan
- [ ] 遠征を実行し、戦闘経験値が敵のexp合計で付与されることを確認
- [ ] ボス戦の経験値が正しく計算されることを確認
- [ ] スライム洞窟のバランスが適切であることを確認
- [ ] 治療画面でゴブリンを回復後、HPが最大値に戻ることを確認
- [ ] `npm test` でテストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)