### PR TITLE
feat(playback): 遠征プレイバック中のレベルアップ表示と経験値分配の改善

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -129,9 +129,16 @@ function BattleResultSection({ meta }: { meta: BattleLogMeta }) {
 
           <Text style={styles.resultLabel}>{t('ui.formation.battleLog.gainedXp')}</Text>
           {meta.members.map((member, index) => (
-            <Text key={`xp-${index}`} style={styles.resultText}>
-              {t('ui.formation.battleLog.xpLine', { xp: member.xpEach, name: member.name, multiplier: member.expMultiplier })}
-            </Text>
+            <View key={`xp-${index}`} style={styles.memberResult}>
+              <Text style={styles.resultText}>
+                {t('ui.formation.battleLog.xpLine', { xp: member.xpEach, name: member.name, multiplier: member.expMultiplier })}
+              </Text>
+              {member.levelUp && (
+                <Text style={styles.levelUpText}>
+                  {t('ui.formation.battleLog.levelUpLine', { oldLevel: member.levelUp.oldLevel, newLevel: member.levelUp.newLevel })}
+                </Text>
+              )}
+            </View>
           ))}
         </>
       )}
@@ -262,6 +269,15 @@ const styles = StyleSheet.create({
   resultText: {
     fontSize: 12,
     color: '#374151',
+    marginTop: 2,
+  },
+  memberResult: {
+    marginBottom: 2,
+  },
+  levelUpText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#D97706',
     marginTop: 2,
   },
 })

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -15,6 +15,7 @@ import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
 import { getDungeonTierDisplayName } from '@/shared/types'
+import { addExperience } from '@/core/services/ExperienceSystem'
 
 interface LogEntry {
   id: string
@@ -114,6 +115,7 @@ export default function ExpeditionPlaybackScreen() {
   const hasCompletedRef = useRef(false)
   const logIdRef = useRef(0)
   const partyHpRef = useRef<number[]>([])
+  const partyExpRef = useRef<Array<{ level: number; experience: number }>>([])
 
   const formatTime = useCallback((seconds: number): string => {
     const minutes = Math.floor(seconds / 60)
@@ -152,7 +154,33 @@ export default function ExpeditionPlaybackScreen() {
         const result = event.combat.outcome === 'win' ? t('ui.formation.playback.win') : t('ui.formation.playback.lose')
         const partyMembers = replay?.meta.party ?? []
         const rewardedXp = event.combat.outcome === 'win' ? event.xp : 0
-        const xpPerMember = partyMembers.length > 0 ? Math.floor(rewardedXp / partyMembers.length) : 0
+        const aliveIndices = partyMembers
+          .map((_, index) => index)
+          .filter(index => (partyHpRef.current[index] ?? 0) > 0)
+        const xpPerMember = aliveIndices.length > 0 ? Math.floor(rewardedXp / aliveIndices.length) : 0
+        const levelUps = new Map<number, { oldLevel: number; newLevel: number }>()
+
+        if (rewardedXp > 0 && xpPerMember > 0) {
+          const nextExpState = partyExpRef.current.map(state => ({ ...state }))
+          for (const index of aliveIndices) {
+            const current = nextExpState[index]
+            if (!current) continue
+
+            const levelUp = addExperience(current.level, current.experience, xpPerMember)
+            nextExpState[index] = {
+              level: levelUp.newLevel,
+              experience: levelUp.remainingExp,
+            }
+            if (levelUp.didLevelUp) {
+              levelUps.set(index, {
+                oldLevel: levelUp.oldLevel,
+                newLevel: levelUp.newLevel,
+              })
+            }
+          }
+          partyExpRef.current = nextExpState
+        }
+
         const meta: BattleLogMeta = {
           outcome: event.combat.outcome,
           xpGained: rewardedXp,
@@ -160,15 +188,17 @@ export default function ExpeditionPlaybackScreen() {
           members: partyMembers.map((memberId, idx) => {
             const goblin = partyGoblins[idx]
             const preHP = partyHpRef.current[idx] ?? (goblin ? getEffectiveStats(goblin).hp : 100)
+            const expState = partyExpRef.current[idx]
             return {
               name: goblin?.name ?? `ID:${memberId}`,
               currentHP: event.combat.allyHPDelta[idx] !== undefined
                 ? Math.max(0, preHP + event.combat.allyHPDelta[idx])
                 : 0,
               maxHP: goblin ? getEffectiveStats(goblin).hp : 100,
-              level: goblin?.level ?? 1,
-              xpEach: xpPerMember,
+              level: expState?.level ?? goblin?.level ?? 1,
+              xpEach: aliveIndices.includes(idx) ? xpPerMember : 0,
               expMultiplier: 1,
+              levelUp: levelUps.get(idx),
             }
           }),
         }
@@ -291,10 +321,16 @@ export default function ExpeditionPlaybackScreen() {
     }
 
     const initialPartyHp = partyGoblins.map(goblin => {
-      return goblin ? getEffectiveStats(goblin).hp : 100
+      if (!goblin) return 100
+      return goblin.currentHp === 0 ? 0 : getEffectiveStats(goblin).hp
     })
+    const initialPartyExp = partyGoblins.map(goblin => ({
+      level: goblin?.level ?? 1,
+      experience: goblin?.experience ?? 0,
+    }))
     let tempHp = [...initialPartyHp]
     partyHpRef.current = [...initialPartyHp]
+    partyExpRef.current = initialPartyExp.map(state => ({ ...state }))
     let tempFloor = 1
     const preloadedLogs: LogEntry[] = []
     let nextIndex = 0

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -19,7 +19,7 @@ function callRollTreasureDrops(
   rewardMultipliers?: Partial<PartyRewardMultipliers>
 ) {
   return (engine as any).rollTreasureDrops(
-    dungeonLevel, enemies, droppedIds, rewardMultipliers
+    dungeonLevel, dungeonLevel, enemies, droppedIds, rewardMultipliers
   )
 }
 

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -328,6 +328,7 @@ const en = {
         rewardSummary: 'Obtained {{xp}} EXP and {{gold}} gold.',
         gainedXp: '<Gained EXP>',
         xpLine: 'Exp +{{xp}} {{name}} ({{xp}} x {{multiplier}}x)',
+        levelUpLine: 'Level up! Lv{{oldLevel}} -> Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
       },
       log: {

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -328,6 +328,7 @@ const ja = {
         rewardSummary: '経験値 {{xp}} と {{gold}} gold を手に入れました。',
         gainedXp: '＜獲得経験値＞',
         xpLine: 'Exp +{{xp}} {{name}} ({{xp}} x {{multiplier}}倍)',
+        levelUpLine: 'レベルアップ！ Lv{{oldLevel}} → Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
       },
       log: {

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -328,6 +328,7 @@ const ko = {
         rewardSummary: '경험치 {{xp}}와 {{gold}} gold를 획득했습니다.',
         gainedXp: '＜획득 경험치＞',
         xpLine: 'Exp +{{xp}} {{name}} ({{xp}} x {{multiplier}}배)',
+        levelUpLine: '레벨 업! Lv{{oldLevel}} -> Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
       },
       log: {

--- a/goblin_native/src/shared/types/Battle.ts
+++ b/goblin_native/src/shared/types/Battle.ts
@@ -40,6 +40,10 @@ export interface BattleLogMeta {
     level: number
     xpEach: number
     expMultiplier: number
+    levelUp?: {
+      oldLevel: number
+      newLevel: number
+    }
   }>
 }
 


### PR DESCRIPTION
## Summary
- 戦闘勝利時のレベルアップをバトルログに表示する機能を追加
- 経験値を生存メンバーのみに分配するよう修正（戦闘不能メンバーはXP 0）
- プレイバック中の経験値・レベル状態をリアルタイム追跡

## Test plan
- [ ] 遠征プレイバックでレベルアップが発生した際にオレンジ色のテキストが表示されること
- [ ] 戦闘不能メンバーに経験値が配分されないこと
- [ ] TreasureDrop テストが通ること (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)