### PR TITLE
fix(ui): 負傷ゴブリンアバターのtintColorを削除し自然な見た目に修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -563,7 +563,6 @@ const styles = StyleSheet.create({
   },
   memberAvatarInjured: {
     opacity: 0.45,
-    tintColor: '#9CA3AF',
   },
   memberHp: {
     fontSize: 10,

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -755,7 +755,6 @@ const styles = StyleSheet.create({
   },
   memberAvatarInjured: {
     opacity: 0.45,
-    tintColor: '#9CA3AF',
   },
   memberHp: {
     fontSize: 10,


### PR DESCRIPTION
## Summary
- 編成・準備画面の負傷ゴブリンアバターから `tintColor: '#9CA3AF'` を削除
- opacityのみで負傷状態を表現し、グレー化による不自然な見た目を解消

## Test plan
- [ ] 編成画面で負傷ゴブリンのアバターが半透明で表示されること（グレーにならないこと）
- [ ] 準備画面でも同様に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)