### PR TITLE
feat(skills): [才能]アイテム装備可能数の追加とアンデッドゴブリンへの適用

### DIFF
--- a/goblin_native/src/core/services/EquipmentService.ts
+++ b/goblin_native/src/core/services/EquipmentService.ts
@@ -3,7 +3,7 @@ import type { CharacterSkill } from '../../shared/types/CharacterSkill'
 import type { EquipmentInstance, EquipmentStatBonus } from '../../shared/types/Equipment'
 import { calculateSlotCount } from '../../shared/data/equipmentConfig'
 import { getEquipmentTemplate } from '../../shared/data/equipmentPoolLoader'
-import { cloneCharacterSkill } from '../../shared/data/characterSkills'
+import { cloneCharacterSkill, hasItemSlotsBonusSkill } from '../../shared/data/characterSkills'
 import { EquipmentTitleService } from './EquipmentTitleService'
 
 /**
@@ -56,7 +56,8 @@ export class EquipmentService {
    * ゴブリンが利用可能なスロット数を取得
    */
   static getAvailableSlots(goblin: Goblin): number {
-    return calculateSlotCount(goblin.level)
+    const hasBonus = hasItemSlotsBonusSkill(goblin.skills ?? [])
+    return calculateSlotCount(goblin.level, hasBonus)
   }
 
   /**

--- a/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
+++ b/goblin_native/src/shared/data/__tests__/equipmentConfig.test.ts
@@ -1,4 +1,4 @@
-import { EQUIPMENT_SLOT_LEVELS, calculateSlotCount } from '../equipmentConfig'
+import { EQUIPMENT_SLOT_LEVELS, TALENT_EQUIPMENT_SLOT_LEVELS, calculateSlotCount } from '../equipmentConfig'
 
 describe('equipmentConfig', () => {
   it('装備枠の解放レベル表を正しく持つ', () => {
@@ -22,5 +22,34 @@ describe('equipmentConfig', () => {
 
   it('不正なレベル値でもNaNを返さない', () => {
     expect(calculateSlotCount(Number.NaN)).toBe(1)
+  })
+
+  it('[才能]アイテム装備可能数の解放レベル表を正しく持つ', () => {
+    expect(TALENT_EQUIPMENT_SLOT_LEVELS).toEqual([
+      1, 2, 5, 7, 10, 13, 16, 20, 24, 29, 34, 40, 46, 53,
+      60, 67, 75, 83, 91, 99, 108, 117, 126, 135, 145, 158, 172, 187,
+    ])
+  })
+
+  it('[才能]アイテム装備可能数付きでレベル閾値どおりに装備枠数を返す', () => {
+    expect(calculateSlotCount(1, true)).toBe(1)
+    expect(calculateSlotCount(2, true)).toBe(2)
+    expect(calculateSlotCount(4, true)).toBe(2)
+    expect(calculateSlotCount(5, true)).toBe(3)
+    expect(calculateSlotCount(7, true)).toBe(4)
+    expect(calculateSlotCount(10, true)).toBe(5)
+    expect(calculateSlotCount(13, true)).toBe(6)
+    expect(calculateSlotCount(16, true)).toBe(7)
+    expect(calculateSlotCount(20, true)).toBe(8)
+    expect(calculateSlotCount(24, true)).toBe(9)
+    expect(calculateSlotCount(29, true)).toBe(10)
+    expect(calculateSlotCount(99, true)).toBe(20)
+    expect(calculateSlotCount(187, true)).toBe(28)
+    expect(calculateSlotCount(200, true)).toBe(28)
+  })
+
+  it('[才能]なしの場合は従来どおり', () => {
+    expect(calculateSlotCount(2, false)).toBe(1)
+    expect(calculateSlotCount(3, false)).toBe(2)
   })
 })

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -121,6 +121,10 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
     return i18n.t('battle.hpRegen', { value: skill.hpRegenPercent })
   }
 
+  if (skill.itemSlotsBonus) {
+    return i18n.t('battle.itemSlotsBonus')
+  }
+
   if (skill.protectRearAllyNormalAttackMultiplier !== undefined) {
     const reducedRate = Math.round((1 - skill.protectRearAllyNormalAttackMultiplier) * 100)
     return i18n.t('battle.rearProtection', { value: reducedRate })
@@ -316,6 +320,10 @@ export function getGoldBonusPercentFromSkills(skills: CharacterSkill[]): number 
 
 export function hasUndeadSkill(skills: CharacterSkill[]): boolean {
   return getUniqueSkillsById(skills).some((skill) => skill.undead)
+}
+
+export function hasItemSlotsBonusSkill(skills: CharacterSkill[]): boolean {
+  return getUniqueSkillsById(skills).some((skill) => skill.itemSlotsBonus)
 }
 
 export function getHpRegenPercentFromSkills(skills: CharacterSkill[]): number {

--- a/goblin_native/src/shared/data/equipmentConfig.ts
+++ b/goblin_native/src/shared/data/equipmentConfig.ts
@@ -23,6 +23,15 @@ export const EQUIPMENT_SLOT_LEVELS = [
 ] as const
 
 /**
+ * [才能]アイテム装備可能数を持つ場合の装備枠解放レベル表
+ * 通常より早く多くの枠が開放される（最大28枠）
+ */
+export const TALENT_EQUIPMENT_SLOT_LEVELS = [
+  1, 2, 5, 7, 10, 13, 16, 20, 24, 29, 34, 40, 46, 53,
+  60, 67, 75, 83, 91, 99, 108, 117, 126, 135, 145, 158, 172, 187,
+] as const
+
+/**
  * 血統別の攻撃回数補正
  * 攻撃回数は敏捷ベースで算出し、血統差分のみ最終補正として加算する
  */
@@ -51,13 +60,14 @@ function normalizeEquipmentLevel(level: unknown): number {
 
 /**
  * ゴブリンのレベルからスロット数を計算
+ * @param hasItemSlotsBonus [才能]アイテム装備可能数を持つ場合 true
  */
-export function calculateSlotCount(level: number): number
-export function calculateSlotCount(level: number): number {
+export function calculateSlotCount(level: number, hasItemSlotsBonus?: boolean): number {
   const normalizedLevel = normalizeEquipmentLevel(level)
+  const table = hasItemSlotsBonus ? TALENT_EQUIPMENT_SLOT_LEVELS : EQUIPMENT_SLOT_LEVELS
   let unlockedSlots = 0
 
-  for (const unlockLevel of EQUIPMENT_SLOT_LEVELS) {
+  for (const unlockLevel of table) {
     if (normalizedLevel < unlockLevel) break
     unlockedSlots++
   }

--- a/goblin_native/src/shared/data/goblinVariants.ts
+++ b/goblin_native/src/shared/data/goblinVariants.ts
@@ -137,7 +137,9 @@ export const goblinVariantDefinitions: Record<string, GoblinVariantDefinition> =
       { type: 'stat_bonus', target: 'hp', value: 40 },
       { type: 'stat_bonus', target: 'atk', value: 10 },
     ],
+    baseAttributes: { power: 11, wisdom: 8, spirit: 10, vitality: 15, agility: 7, luck: 9 },
     defaultSkillIds: [
+      'talent_itemSlots',
       'undead_trait',
       'hp_regen_20',
     ],

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -124,6 +124,11 @@ export const CHARACTER_SKILL_CATALOG = {
     equipmentCategoryMultiplier: { armor: 1.5 },
   },
 
+  talent_itemSlots: {
+    id: 'talent_itemSlots',
+    itemSlotsBonus: true,
+  } as CharacterSkill,
+
   talent_hp_150: createTalentSkill('hp'),
   talent_atk_150: createTalentSkill('atk'),
   talent_def_150: createTalentSkill('def'),

--- a/goblin_native/src/shared/i18n/entityLocalization.ts
+++ b/goblin_native/src/shared/i18n/entityLocalization.ts
@@ -96,6 +96,10 @@ export function getSkillLabel(skill: CharacterSkill): string {
     return i18n.t('battle.additionalDamage', { value: skill.additionalDamage })
   }
 
+  if (skill.itemSlotsBonus) {
+    return i18n.t('battle.itemSlotsBonus')
+  }
+
   return skill.id
 }
 

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -510,6 +510,7 @@ const en = {
       talent_evasion_150: { name: '[Talent] Evasion' },
       talent_accuracy_150: { name: '[Talent] Accuracy' },
       talent_criticalRate_150: { name: '[Talent] Critical Rate' },
+      talent_itemSlots: { name: '[Talent] Item Slots' },
       cover_low_hp_ally: { name: 'Cover' },
       equipment_accuracy_200: { name: '[2.0x] Accuracy' },
       evasion_150: { name: 'Evasion Aptitude' },

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -510,6 +510,7 @@ const ja = {
       talent_evasion_150: { name: '[才能]回避' },
       talent_accuracy_150: { name: '[才能]命中精度' },
       talent_criticalRate_150: { name: '[才能]必殺率' },
+      talent_itemSlots: { name: '[才能]アイテム装備可能数' },
       cover_low_hp_ally: { name: 'かばう' },
       equipment_accuracy_200: { name: '[2.0倍]命中精度' },
       evasion_150: { name: '回避適正' },
@@ -587,6 +588,7 @@ const ja = {
     undead: '遠征終了時にHP0でも治療不要で全回復する',
     hpRegen: '[{{value}}%]毎ターン終了時に最大HPの{{value}}%を回復',
     hpRegenAction: '回復能力',
+    itemSlotsBonus: 'アイテム装備可能数が増加する',
   },
   dungeonTier: {
     normal: '通常',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -510,6 +510,7 @@ const ko = {
       talent_evasion_150: { name: '[재능] 회피' },
       talent_accuracy_150: { name: '[재능] 명중' },
       talent_criticalRate_150: { name: '[재능] 치명률' },
+      talent_itemSlots: { name: '[재능] 아이템 장비 가능 수' },
       cover_low_hp_ally: { name: '커버' },
       equipment_accuracy_200: { name: '[2.0배] 명중' },
       evasion_150: { name: '회피 적성' },

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -32,4 +32,5 @@ export interface CharacterSkill {
   goldBonusPercent?: number
   undead?: boolean
   hpRegenPercent?: number
+  itemSlotsBonus?: boolean
 }


### PR DESCRIPTION
## Summary
- 才能スキル「[才能]アイテム装備可能数」を新規追加（`talent_itemSlots`）
- 保有時は専用の装備枠解放テーブルが適用され、通常より早く多くの枠が開放（最大28枠）
- アンデッドゴブリンに本才能と基本能力値（力11/体力15/敏捷7/運9）を設定

## Test plan
- [x] `equipmentConfig.test.ts` に才能付きテーブルのテストを追加・全パス
- [x] `npx tsc --noEmit` 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)