### PR TITLE
feat(stats): 基礎能力値のレベル成長システムを追加

### DIFF
--- a/goblin_native/app/goblin/detail.tsx
+++ b/goblin_native/app/goblin/detail.tsx
@@ -15,7 +15,7 @@ import { getExpForNextLevel, getExpProgress } from '@/core/services/ExperienceSy
 import { getModTemplate } from '@/shared/data/modPoolLoader'
 import { describeCharacterSkill, getUniqueSkillsById } from '@/shared/data/characterSkills'
 import { getGoblinJobDefinition } from '@/shared/data/goblinJobs'
-import { getGoblinBaseAttributes } from '@/shared/utils/goblinHp'
+import { getGoblinBaseAttributesAtLevel } from '@/shared/utils/goblinHp'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getFactorName, getRaceLabel, getSkillLabel, getStatLabel } from '@/shared/i18n/entityLocalization'
 
@@ -72,7 +72,7 @@ export default function GoblinDetailScreen() {
   const expProgress = goblin ? getExpProgress(goblin.level, goblin.experience) : 0
   const characterSkills = useMemo(() => getUniqueSkillsById(goblin?.skills ?? []), [goblin])
   const baseAttributes = useMemo(
-    () => goblin ? getGoblinBaseAttributes(goblin) : null,
+    () => goblin ? getGoblinBaseAttributesAtLevel(goblin, goblin.level) : null,
     [goblin]
   )
   const assignedParty = useMemo(() => (

--- a/goblin_native/src/core/domain/GoblinEntity.ts
+++ b/goblin_native/src/core/domain/GoblinEntity.ts
@@ -10,6 +10,7 @@ import {
   calculateGoblinBaseHp,
   calculateGoblinBaseMagicHeal,
   getGoblinBaseAttributes,
+  getGoblinBaseAttributesAtLevel,
 } from '../../shared/utils/goblinHp'
 
 export class GoblinEntity {
@@ -66,7 +67,7 @@ export class GoblinEntity {
    */
   public calculateCombatPower(): number {
     const stats = this.effectiveStats
-    const agility = this.base.baseAttributes?.agility ?? getGoblinBaseAttributes(this.base).agility
+    const agility = getGoblinBaseAttributesAtLevel(this.base, this.level).agility
     const rawPower = stats.atk * 1.5 + stats.def * 1.2 + agility + stats.hp / 10
     return Math.round(rawPower)
   }

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -17,7 +17,7 @@ import type { SpellDef } from '../../shared/types/Spell'
 import { CombatantManager } from './CombatantManager'
 import { DamageCalculator } from './DamageCalculator'
 import { ModStatCalculator } from './ModStatCalculator'
-import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
+import { getGoblinBaseAttributesAtLevel } from '../../shared/utils/goblinHp'
 import { getEffectiveStats } from '../../shared/utils/goblinStats'
 import i18n from '../../shared/i18n'
 import { getSpellLabel } from '../../shared/i18n/entityLocalization'
@@ -759,7 +759,7 @@ export class BattleSystem {
       currentHP: hp,
       maxHP: effectiveStats.hp,
       initialHP: hp,
-      agility: actionOrderAgility ?? getGoblinBaseAttributes(goblin).agility,
+      agility: actionOrderAgility ?? getGoblinBaseAttributesAtLevel(goblin, goblin.level).agility,
       attackCount: effectiveStats.attackCount,
       accuracy: effectiveStats.accuracy,
       evasion: effectiveStats.evasion,

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -22,7 +22,7 @@ import { ModStatCalculator } from './ModStatCalculator'
 import { EquipmentTitleService } from './EquipmentTitleService'
 import { normalizePartyRewardMultipliers, DUNGEON_TIER_SCALING, getDungeonTierAreaLevel } from '../../shared/types'
 import { getGoldBonusPercentFromSkills } from '../../shared/data/characterSkills'
-import { getGoblinBaseAttributes } from '../../shared/utils/goblinHp'
+import { getGoblinBaseAttributesAtLevel } from '../../shared/utils/goblinHp'
 import { getEffectiveStats } from '../../shared/utils/goblinStats'
 
 /** 全エリア共通の宝箱ドロップ確率（敵1体ごと） */
@@ -367,7 +367,7 @@ export class ExpeditionEngine {
         baseHP: goblin.stats.hp,
         atk: goblin.stats.atk,
         def: goblin.stats.def,
-        agility: getGoblinBaseAttributes(goblin).agility,
+        agility: getGoblinBaseAttributesAtLevel(goblin, goblin.level).agility,
         attackCount: goblin.stats.attackCount,
         accuracy: goblin.stats.accuracy,
         evasion: goblin.stats.evasion,

--- a/goblin_native/src/shared/utils/goblinHp.ts
+++ b/goblin_native/src/shared/utils/goblinHp.ts
@@ -32,6 +32,31 @@ export function getGoblinBaseAttributes(goblin: GoblinRaceContext): GoblinBaseAt
   return { ...(getGoblinVariantByRace(resolveRaceId(goblin))?.baseAttributes ?? DEFAULT_BASE_ATTRIBUTES) }
 }
 
+/**
+ * レベルによる基礎能力値ボーナスを返す
+ * 4レベルごとに+1、Lv40で+10が上限
+ */
+export function getBaseAttributeLevelBonus(level: number): number {
+  return Math.min(10, Math.floor(level / 4))
+}
+
+/**
+ * レベルを考慮した基礎能力値を返す
+ * 初期値からLv40で全ステータス+10になるよう成長する
+ */
+export function getGoblinBaseAttributesAtLevel(goblin: GoblinRaceContext, level: number): GoblinBaseAttributes {
+  const base = getGoblinBaseAttributes(goblin)
+  const bonus = getBaseAttributeLevelBonus(level)
+  return {
+    power: base.power + bonus,
+    wisdom: base.wisdom + bonus,
+    spirit: base.spirit + bonus,
+    vitality: base.vitality + bonus,
+    agility: base.agility + bonus,
+    luck: base.luck + bonus,
+  }
+}
+
 export function getGoblinHpCoefficient(goblin: Pick<Goblin, 'race' | 'job'> & { raceId?: Goblin['raceId'] }): number {
   const raceId = resolveRaceId(goblin)
   if (raceId === 'goblin' && goblin.job) {
@@ -92,7 +117,7 @@ export function calculateGoblinBaseHp(
     return goblin.stats.hp
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const multiplier = getBaseStatMultiplier(goblin, 'hp')
@@ -104,7 +129,7 @@ export function calculateGoblinBaseAtk(level: number, goblin: GoblinStatContext)
     return goblin.stats.atk
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const multiplier = getBaseStatMultiplier(goblin, 'atk')
@@ -116,7 +141,7 @@ export function calculateGoblinBaseDef(level: number, goblin: GoblinStatContext)
     return goblin.stats.def
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const multiplier = getBaseStatMultiplier(goblin, 'def')
@@ -128,7 +153,7 @@ export function calculateGoblinBaseMagicDef(level: number, goblin: GoblinStatCon
     return goblin.stats.magicDef
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const multiplier = getBaseStatMultiplier(goblin, 'magicDef')
@@ -140,7 +165,7 @@ export function calculateGoblinBaseAccuracy(level: number, goblin: GoblinStatCon
     return goblin.stats.accuracy
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const attributeAverage = (attributes.power + attributes.agility) / 2
@@ -153,7 +178,7 @@ export function calculateGoblinBaseEvasion(level: number, goblin: GoblinStatCont
     return goblin.stats.evasion
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const attributeAverage = (attributes.agility + attributes.luck) / 2
@@ -166,7 +191,7 @@ export function calculateGoblinBaseAttackCount(level: number, goblin: GoblinStat
     return goblin.stats.attackCount
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const bloodlineAttackCountBonus = getBloodlineAttackCountBonus(goblin.raceId ?? goblin.race)
@@ -184,7 +209,7 @@ export function calculateGoblinBaseMagicAtk(level: number, goblin: GoblinStatCon
     return goblin.stats.magicAtk
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const multiplier = getBaseStatMultiplier(goblin, 'magicAtk')
@@ -196,7 +221,7 @@ export function calculateGoblinBaseMagicHeal(level: number, goblin: GoblinStatCo
     return goblin.stats.magicHeal
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   return Math.round(attributes.spirit * (1 + levelScale * 2 * coefficient))
@@ -207,7 +232,7 @@ export function calculateGoblinBaseCriticalRate(level: number, goblin: GoblinSta
     return goblin.stats.criticalRate
   }
 
-  const attributes = getGoblinBaseAttributes(goblin)
+  const attributes = getGoblinBaseAttributesAtLevel(goblin, level)
   const levelScale = getGoblinStatLevelScale(level, goblin.raceId ?? goblin.race)
   const coefficient = getGoblinStatCoefficient(goblin)
   const rawBase = attributes.agility * 1 + attributes.luck * 2 - 45


### PR DESCRIPTION
## Summary
- 基礎能力値（力・知恵・精神・体力・敏捷・運）が4レベルごとに+1ずつ成長し、Lv40で初期値+10に到達する仕組みを追加
- `getBaseAttributeLevelBonus` / `getGoblinBaseAttributesAtLevel` を新設し、全ステータス計算関数・戦闘・遠征・表示で適用
- 保存値（`baseAttributes`）は種族初期値のまま維持し、レベルボーナスは計算時に都度適用する設計

## Test plan
- [x] TypeScript型チェック通過
- [x] 全222テスト通過
- [ ] Lv1ゴブリンの基本能力値が初期値のままであること
- [ ] Lv40ゴブリンの基本能力値が初期値+10であること
- [ ] Lv40以降は+10で頭打ちになること
- [ ] 各亜種で初期値が異なる場合も正しく+10されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)