### PR TITLE
fix(expedition): 遠征クリア時のゴブリン追加が遅延計算時にスキップされる不具合を修正

### DIFF
--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -346,7 +346,7 @@ export const useExpeditionFlow = ({
           }
         }
 
-        await handleDungeonClear(record)
+        await handleDungeonClear({ ...record, replay: result.enrichedReplay })
         // UseCaseがDB上のbase_state.goldや制圧済み拠点を直接更新するため、ストアを同期
         await useBaseStore.getState().refresh()
         // UseCaseがDB上のparty.statusを'idle'に直接更新するため、ストアを同期


### PR DESCRIPTION
## Summary
- `completeDueExpeditions`でreplayを遅延計算した場合、元の`record`オブジェクトの`replay`が`undefined`のまま`handleDungeonClear`に渡されていたため、ゴブリン追加処理が早期リターンでスキップされていた
- `result.enrichedReplay`を明示的にrecordに含めて渡すよう修正
- 一括出撃・個別出撃後の遠征クリア時にもゴブリンが正常に追加されるようになる

## 再現条件
- 編成画面で一括出撃後、遠征がクリアされた場合 → ゴブリンが追加されない
- 冒険準備画面で個別出撃後、編成画面に戻ってクリアされた場合 → ゴブリンが追加されない
- ログ再生画面経由の場合のみ正常動作していた（playback側でreplayが事前に計算済みのため）

## Test plan
- [ ] 一括出撃で遠征クリア後、ゴブリンが追加されることを確認
- [ ] 個別出撃→編成画面復帰→遠征クリア後、ゴブリンが追加されることを確認
- [ ] ログ再生画面経由の既存フローが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)