### PR TITLE
fix(enemy): 敵のレベル・経験値・魔法防御力のバランス調整

### DIFF
--- a/goblin_native/src/shared/data/enemy/dwarf_mine_1.json
+++ b/goblin_native/src/shared/data/enemy/dwarf_mine_1.json
@@ -16,7 +16,7 @@
       "exp": 38,
       "gold": 32,
       "agility": 3,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "DWF002",
@@ -34,7 +34,7 @@
       "exp": 44,
       "gold": 38,
       "agility": 4,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "DWF003",
@@ -52,7 +52,7 @@
       "exp": 48,
       "gold": 42,
       "agility": 5,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "DWF004",
@@ -70,7 +70,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "DWF005",
@@ -88,7 +88,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 4,
-      "magicDef": 9
+      "magicDef": 14
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/dwarf_mine_2.json
+++ b/goblin_native/src/shared/data/enemy/dwarf_mine_2.json
@@ -16,7 +16,7 @@
       "exp": 38,
       "gold": 32,
       "agility": 3,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "DWF002",
@@ -34,7 +34,7 @@
       "exp": 44,
       "gold": 38,
       "agility": 4,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "DWF003",
@@ -52,7 +52,7 @@
       "exp": 48,
       "gold": 42,
       "agility": 5,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "DWF004",
@@ -70,7 +70,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "DWF005",
@@ -88,7 +88,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 4,
-      "magicDef": 9
+      "magicDef": 14
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/dwarf_mine_3.json
+++ b/goblin_native/src/shared/data/enemy/dwarf_mine_3.json
@@ -16,7 +16,7 @@
       "exp": 38,
       "gold": 32,
       "agility": 3,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "DWF002",
@@ -34,7 +34,7 @@
       "exp": 44,
       "gold": 38,
       "agility": 4,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "DWF003",
@@ -52,7 +52,7 @@
       "exp": 48,
       "gold": 42,
       "agility": 5,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "DWF004",
@@ -70,7 +70,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "DWF005",
@@ -88,7 +88,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 4,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "B_FORGEKING",
@@ -112,7 +112,7 @@
         }
       ],
       "agility": 5,
-      "magicDef": 25
+      "magicDef": 38
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/elf_forest_1.json
+++ b/goblin_native/src/shared/data/enemy/elf_forest_1.json
@@ -16,7 +16,7 @@
       "exp": 45,
       "gold": 40,
       "agility": 12,
-      "magicDef": 6
+      "magicDef": 10
     },
     {
       "id": "ELF002",
@@ -34,7 +34,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 11,
-      "magicDef": 5
+      "magicDef": 8
     },
     {
       "id": "ELF003",
@@ -52,7 +52,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 9,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "ELF004",
@@ -70,7 +70,7 @@
       "exp": 52,
       "gold": 46,
       "agility": 10,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "ELF005",
@@ -89,7 +89,7 @@
       "exp": 58,
       "gold": 50,
       "agility": 6,
-      "magicDef": 16
+      "magicDef": 24
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/elf_forest_2.json
+++ b/goblin_native/src/shared/data/enemy/elf_forest_2.json
@@ -16,7 +16,7 @@
       "exp": 45,
       "gold": 40,
       "agility": 12,
-      "magicDef": 6
+      "magicDef": 10
     },
     {
       "id": "ELF002",
@@ -34,7 +34,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 11,
-      "magicDef": 5
+      "magicDef": 8
     },
     {
       "id": "ELF003",
@@ -52,7 +52,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 9,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "ELF004",
@@ -70,7 +70,7 @@
       "exp": 52,
       "gold": 46,
       "agility": 10,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "ELF005",
@@ -89,7 +89,7 @@
       "exp": 58,
       "gold": 50,
       "agility": 6,
-      "magicDef": 16
+      "magicDef": 24
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/elf_forest_3.json
+++ b/goblin_native/src/shared/data/enemy/elf_forest_3.json
@@ -16,7 +16,7 @@
       "exp": 45,
       "gold": 40,
       "agility": 12,
-      "magicDef": 6
+      "magicDef": 10
     },
     {
       "id": "ELF002",
@@ -34,7 +34,7 @@
       "exp": 50,
       "gold": 44,
       "agility": 11,
-      "magicDef": 5
+      "magicDef": 8
     },
     {
       "id": "ELF003",
@@ -52,7 +52,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 9,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "ELF004",
@@ -70,7 +70,7 @@
       "exp": 52,
       "gold": 46,
       "agility": 10,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "ELF005",
@@ -89,7 +89,7 @@
       "exp": 58,
       "gold": 50,
       "agility": 6,
-      "magicDef": 16
+      "magicDef": 24
     },
     {
       "id": "B_FORESTGUARD",
@@ -113,7 +113,7 @@
         }
       ],
       "agility": 12,
-      "magicDef": 22
+      "magicDef": 34
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/forest_outskirts.json
+++ b/goblin_native/src/shared/data/enemy/forest_outskirts.json
@@ -6,15 +6,15 @@
       "raceTags": [
         "beast"
       ],
-      "level": 1,
+      "level": 2,
       "hp": 10,
       "atk": 4,
       "def": 2,
       "attackCount": 1,
       "accuracy": 170,
       "evasion": 9,
-      "exp": 4,
-      "gold": 5,
+      "exp": 2,
+      "gold": 2,
       "agility": 2,
       "magicDef": 1
     },
@@ -24,15 +24,15 @@
       "raceTags": [
         "beast"
       ],
-      "level": 2,
+      "level": 3,
       "hp": 10,
       "atk": 7,
       "def": 2,
       "attackCount": 1,
       "accuracy": 190,
       "evasion": 10,
-      "exp": 6,
-      "gold": 6,
+      "exp": 3,
+      "gold": 3,
       "agility": 8,
       "magicDef": 1
     },
@@ -42,17 +42,17 @@
       "raceTags": [
         "beast"
       ],
-      "level": 3,
+      "level": 4,
       "hp": 20,
       "atk": 9,
       "def": 4,
       "attackCount": 1,
       "accuracy": 210,
       "evasion": 11,
-      "exp": 10,
-      "gold": 9,
+      "exp": 5,
+      "gold": 5,
       "agility": 8,
-      "magicDef": 3
+      "magicDef": 5
     },
     {
       "id": "E004",
@@ -60,17 +60,17 @@
       "raceTags": [
         "beast"
       ],
-      "level": 4,
+      "level": 5,
       "hp": 20,
       "atk": 11,
       "def": 6,
       "attackCount": 1,
       "accuracy": 225,
       "evasion": 12,
-      "exp": 12,
-      "gold": 10,
+      "exp": 7,
+      "gold": 6,
       "agility": 8,
-      "magicDef": 4
+      "magicDef": 7
     },
     {
       "id": "B001",
@@ -85,8 +85,8 @@
       "attackCount": 2,
       "accuracy": 270,
       "evasion": 16,
-      "exp": 50,
-      "gold": 50,
+      "exp": 25,
+      "gold": 22,
       "factorDrops": [
         {
           "factorId": "wolf",
@@ -94,7 +94,7 @@
         }
       ],
       "agility": 15,
-      "magicDef": 8
+      "magicDef": 12
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/goblin_village_1.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_1.json
@@ -16,7 +16,7 @@
       "evasion": 11,
       "exp": 8,
       "gold": 6,
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB002",
@@ -52,7 +52,7 @@
       "evasion": 13,
       "exp": 15,
       "gold": 12,
-      "magicDef": 4
+      "magicDef": 7
     },
     {
       "id": "GOB004",
@@ -78,7 +78,7 @@
           "grantsSpellId": "fireball"
         }
       ],
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB005",
@@ -96,7 +96,7 @@
       "evasion": 14,
       "exp": 20,
       "gold": 18,
-      "magicDef": 24
+      "magicDef": 36
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/goblin_village_2.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_2.json
@@ -16,7 +16,7 @@
       "evasion": 11,
       "exp": 8,
       "gold": 6,
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB002",
@@ -52,7 +52,7 @@
       "evasion": 13,
       "exp": 15,
       "gold": 12,
-      "magicDef": 4
+      "magicDef": 7
     },
     {
       "id": "GOB004",
@@ -78,7 +78,7 @@
           "grantsSpellId": "fireball"
         }
       ],
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB005",
@@ -96,7 +96,7 @@
       "evasion": 14,
       "exp": 20,
       "gold": 18,
-      "magicDef": 24
+      "magicDef": 36
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/goblin_village_3.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_3.json
@@ -16,7 +16,7 @@
       "evasion": 11,
       "exp": 8,
       "gold": 6,
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB002",
@@ -52,7 +52,7 @@
       "evasion": 13,
       "exp": 15,
       "gold": 12,
-      "magicDef": 4
+      "magicDef": 7
     },
     {
       "id": "GOB004",
@@ -78,7 +78,7 @@
           "grantsSpellId": "fireball"
         }
       ],
-      "magicDef": 2
+      "magicDef": 4
     },
     {
       "id": "GOB005",
@@ -96,7 +96,7 @@
       "evasion": 14,
       "exp": 20,
       "gold": 18,
-      "magicDef": 24
+      "magicDef": 36
     },
     {
       "id": "B_HOB",
@@ -133,7 +133,7 @@
           "probability": 1
         }
       ],
-      "magicDef": 11
+      "magicDef": 17
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/human_fortress_1.json
+++ b/goblin_native/src/shared/data/enemy/human_fortress_1.json
@@ -16,7 +16,7 @@
       "exp": 80,
       "gold": 72,
       "agility": 7,
-      "magicDef": 20
+      "magicDef": 39
     },
     {
       "id": "FRT002",
@@ -34,7 +34,7 @@
       "exp": 88,
       "gold": 78,
       "agility": 9,
-      "magicDef": 11
+      "magicDef": 21
     },
     {
       "id": "FRT003",
@@ -52,7 +52,7 @@
       "exp": 92,
       "gold": 82,
       "agility": 4,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "FRT004",
@@ -70,7 +70,7 @@
       "exp": 85,
       "gold": 76,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "FRT005",
@@ -88,7 +88,7 @@
       "exp": 100,
       "gold": 90,
       "agility": 8,
-      "magicDef": 24
+      "magicDef": 45
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/human_fortress_2.json
+++ b/goblin_native/src/shared/data/enemy/human_fortress_2.json
@@ -16,7 +16,7 @@
       "exp": 80,
       "gold": 72,
       "agility": 7,
-      "magicDef": 20
+      "magicDef": 39
     },
     {
       "id": "FRT002",
@@ -34,7 +34,7 @@
       "exp": 88,
       "gold": 78,
       "agility": 9,
-      "magicDef": 11
+      "magicDef": 21
     },
     {
       "id": "FRT003",
@@ -52,7 +52,7 @@
       "exp": 92,
       "gold": 82,
       "agility": 4,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "FRT004",
@@ -70,7 +70,7 @@
       "exp": 85,
       "gold": 76,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "FRT005",
@@ -88,7 +88,7 @@
       "exp": 100,
       "gold": 90,
       "agility": 8,
-      "magicDef": 24
+      "magicDef": 45
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/human_fortress_3.json
+++ b/goblin_native/src/shared/data/enemy/human_fortress_3.json
@@ -16,7 +16,7 @@
       "exp": 80,
       "gold": 72,
       "agility": 7,
-      "magicDef": 20
+      "magicDef": 39
     },
     {
       "id": "FRT002",
@@ -34,7 +34,7 @@
       "exp": 88,
       "gold": 78,
       "agility": 9,
-      "magicDef": 11
+      "magicDef": 21
     },
     {
       "id": "FRT003",
@@ -52,7 +52,7 @@
       "exp": 92,
       "gold": 82,
       "agility": 4,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "FRT004",
@@ -70,7 +70,7 @@
       "exp": 85,
       "gold": 76,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "FRT005",
@@ -88,7 +88,7 @@
       "exp": 100,
       "gold": 90,
       "agility": 8,
-      "magicDef": 24
+      "magicDef": 45
     },
     {
       "id": "B_COMMANDER",
@@ -106,7 +106,7 @@
       "exp": 480,
       "gold": 420,
       "agility": 10,
-      "magicDef": 32
+      "magicDef": 60
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/human_village.json
+++ b/goblin_native/src/shared/data/enemy/human_village.json
@@ -3,60 +3,75 @@
     {
       "id": "VIL001",
       "name": "民兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 21,
       "hp": 180,
       "atk": 40,
       "def": 16,
-      "magicDef": 10,
+      "magicDef": 24,
       "agility": 12,
       "attackCount": 1,
       "accuracy": 340,
       "evasion": 20,
-      "exp": 42,
-      "gold": 32
+      "exp": 68,
+      "gold": 60
     },
     {
       "id": "VIL002",
       "name": "村守備兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 23,
       "hp": 250,
       "atk": 35,
       "def": 26,
-      "magicDef": 16,
+      "magicDef": 39,
       "agility": 10,
       "attackCount": 1,
       "accuracy": 330,
       "evasion": 18,
-      "exp": 50,
-      "gold": 38
+      "exp": 78,
+      "gold": 68
     },
     {
       "id": "VIL003",
       "name": "猟師",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 23,
       "hp": 150,
       "atk": 70,
       "def": 16,
-      "magicDef": 10,
+      "magicDef": 24,
       "agility": 16,
-      "attackCount": 3,
+      "attackCount": 5,
       "accuracy": 420,
       "evasion": 26,
-      "exp": 55,
-      "gold": 36
+      "exp": 82,
+      "gold": 72,
+      "skills": [
+        {
+          "id": "preemptive_strike",
+          "name": "先制攻撃",
+          "actionOrderMultiplier": 2
+        }
+      ]
     },
     {
       "id": "B_CANNON",
       "name": "防衛砲台",
-      "raceTags": ["construct"],
+      "raceTags": [
+        "construct"
+      ],
       "level": 25,
       "hp": 400,
       "atk": 250,
       "def": 20,
-      "magicDef": 14,
+      "magicDef": 30,
       "agility": 2,
       "attackCount": 1,
       "accuracy": 160,
@@ -74,233 +89,530 @@
   "patterns": [
     {
       "id": "HV_001",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_002",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["VIL001", "VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_003",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["VIL001", "VIL001"],
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_004",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_005",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_006",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["VIL001", "VIL002"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_007",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["VIL002", "VIL001"],
-        ["VIL001", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_008",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["VIL001", "VIL001"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_009",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["VIL002", "VIL001"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL002"],
-        ["VIL003"]
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_010",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["VIL001", "VIL002"],
-        ["VIL001", "VIL001"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL001",
+          "VIL002"
+        ],
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_011",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL002"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_012",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["VIL002", "VIL001"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_013",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL001", "VIL001"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL001",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_014",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["VIL002", "VIL001"],
-        ["VIL002", "VIL001"],
-        ["VIL001"],
-        ["VIL002"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_015",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL001"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_016",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL002"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_017",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL001", "VIL002"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL001",
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_018",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL002"],
-        ["VIL001", "VIL002"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001",
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_019",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002", "VIL001"],
-        ["VIL002"],
-        ["VIL002"],
-        ["VIL001"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL001"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "HV_020",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL002", "VIL001"],
-        ["VIL002"],
-        ["VIL002"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL002",
+          "VIL001"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ]
     },
     {
       "id": "BOSS",
-      "floors": [4],
+      "floors": [
+        4
+      ],
       "enemies": [
-        ["VIL002", "VIL002"],
-        ["VIL001", "VIL002"],
-        ["VIL002"],
-        ["B_CANNON"],
-        ["VIL003", "VIL003"]
+        [
+          "VIL002",
+          "VIL002"
+        ],
+        [
+          "VIL001",
+          "VIL002"
+        ],
+        [
+          "VIL002"
+        ],
+        [
+          "B_CANNON"
+        ],
+        [
+          "VIL003",
+          "VIL003"
+        ]
       ],
       "isBoss": true
     }

--- a/goblin_native/src/shared/data/enemy/lizardman_swamp_1.json
+++ b/goblin_native/src/shared/data/enemy/lizardman_swamp_1.json
@@ -16,7 +16,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 7,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "LIZ002",
@@ -34,7 +34,7 @@
       "exp": 60,
       "gold": 52,
       "agility": 9,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "LIZ003",
@@ -52,7 +52,7 @@
       "exp": 65,
       "gold": 56,
       "agility": 8,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "LIZ004",
@@ -70,7 +70,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 4,
-      "magicDef": 20
+      "magicDef": 31
     },
     {
       "id": "LIZ005",
@@ -88,7 +88,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 13,
-      "magicDef": 8
+      "magicDef": 12
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/lizardman_swamp_2.json
+++ b/goblin_native/src/shared/data/enemy/lizardman_swamp_2.json
@@ -16,7 +16,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 7,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "LIZ002",
@@ -34,7 +34,7 @@
       "exp": 60,
       "gold": 52,
       "agility": 9,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "LIZ003",
@@ -52,7 +52,7 @@
       "exp": 65,
       "gold": 56,
       "agility": 8,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "LIZ004",
@@ -70,7 +70,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 4,
-      "magicDef": 20
+      "magicDef": 31
     },
     {
       "id": "LIZ005",
@@ -88,7 +88,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 13,
-      "magicDef": 8
+      "magicDef": 12
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/lizardman_swamp_3.json
+++ b/goblin_native/src/shared/data/enemy/lizardman_swamp_3.json
@@ -16,7 +16,7 @@
       "exp": 55,
       "gold": 48,
       "agility": 7,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "LIZ002",
@@ -34,7 +34,7 @@
       "exp": 60,
       "gold": 52,
       "agility": 9,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "LIZ003",
@@ -52,7 +52,7 @@
       "exp": 65,
       "gold": 56,
       "agility": 8,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "LIZ004",
@@ -70,7 +70,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 4,
-      "magicDef": 20
+      "magicDef": 31
     },
     {
       "id": "LIZ005",
@@ -88,7 +88,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 13,
-      "magicDef": 8
+      "magicDef": 12
     },
     {
       "id": "B_SWAMPKING",
@@ -112,7 +112,7 @@
         }
       ],
       "agility": 9,
-      "magicDef": 24
+      "magicDef": 36
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/orc_camp_1.json
+++ b/goblin_native/src/shared/data/enemy/orc_camp_1.json
@@ -6,17 +6,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 6,
+      "level": 14,
       "hp": 300,
       "atk": 70,
       "def": 10,
-      "agility": 8,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 215,
       "evasion": 12,
-      "exp": 24,
-      "gold": 18,
-      "magicDef": 8
+      "exp": 46,
+      "gold": 40,
+      "magicDef": 12
     },
     {
       "id": "ORC005",
@@ -24,17 +24,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 8,
+      "level": 17,
       "hp": 550,
       "atk": 100,
       "def": 16,
-      "agility": 7,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 205,
       "evasion": 13,
-      "exp": 36,
-      "gold": 28,
-      "magicDef": 12
+      "exp": 62,
+      "gold": 54,
+      "magicDef": 19
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/orc_camp_2.json
+++ b/goblin_native/src/shared/data/enemy/orc_camp_2.json
@@ -6,17 +6,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 6,
+      "level": 14,
       "hp": 300,
       "atk": 70,
       "def": 10,
-      "agility": 8,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 215,
       "evasion": 12,
-      "exp": 24,
-      "gold": 18,
-      "magicDef": 8
+      "exp": 46,
+      "gold": 40,
+      "magicDef": 12
     },
     {
       "id": "ORC005",
@@ -24,17 +24,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 8,
+      "level": 17,
       "hp": 550,
       "atk": 100,
       "def": 16,
-      "agility": 7,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 205,
       "evasion": 13,
-      "exp": 36,
-      "gold": 28,
-      "magicDef": 12
+      "exp": 62,
+      "gold": 54,
+      "magicDef": 19
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/orc_camp_3.json
+++ b/goblin_native/src/shared/data/enemy/orc_camp_3.json
@@ -6,17 +6,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 6,
+      "level": 14,
       "hp": 300,
       "atk": 70,
       "def": 10,
-      "agility": 8,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 215,
       "evasion": 12,
-      "exp": 24,
-      "gold": 18,
-      "magicDef": 8
+      "exp": 46,
+      "gold": 40,
+      "magicDef": 12
     },
     {
       "id": "ORC005",
@@ -24,17 +24,17 @@
       "raceTags": [
         "orc"
       ],
-      "level": 8,
+      "level": 17,
       "hp": 550,
       "atk": 100,
       "def": 16,
-      "agility": 7,
+      "agility": 10,
       "attackCount": 1,
       "accuracy": 205,
       "evasion": 13,
-      "exp": 36,
-      "gold": 28,
-      "magicDef": 12
+      "exp": 62,
+      "gold": 54,
+      "magicDef": 19
     },
     {
       "id": "B_ORC",
@@ -42,7 +42,7 @@
       "raceTags": [
         "orc"
       ],
-      "level": 12,
+      "level": 20,
       "hp": 450,
       "atk": 120,
       "def": 18,
@@ -50,15 +50,15 @@
       "attackCount": 1,
       "accuracy": 225,
       "evasion": 14,
-      "exp": 120,
-      "gold": 100,
+      "exp": 160,
+      "gold": 140,
       "factorDrops": [
         {
           "factorId": "orc",
           "probability": 1
         }
       ],
-      "magicDef": 14
+      "magicDef": 22
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/orc_fortress_1.json
+++ b/goblin_native/src/shared/data/enemy/orc_fortress_1.json
@@ -16,7 +16,7 @@
       "evasion": 13,
       "exp": 58,
       "gold": 44,
-      "magicDef": 18
+      "magicDef": 29
     },
     {
       "id": "ORF002",
@@ -52,7 +52,7 @@
       "evasion": 10,
       "exp": 72,
       "gold": 56,
-      "magicDef": 22
+      "magicDef": 34
     },
     {
       "id": "B_ORC_FORTRESS",
@@ -76,7 +76,7 @@
           "probability": 1
         }
       ],
-      "magicDef": 28
+      "magicDef": 43
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/road_1.json
+++ b/goblin_native/src/shared/data/enemy/road_1.json
@@ -16,7 +16,7 @@
       "evasion": 18,
       "exp": 24,
       "gold": 16,
-      "magicDef": 4
+      "magicDef": 7
     },
     {
       "id": "RD002",
@@ -34,7 +34,7 @@
       "evasion": 18,
       "exp": 32,
       "gold": 22,
-      "magicDef": 6
+      "magicDef": 10
     },
     {
       "id": "RD003",
@@ -52,7 +52,7 @@
       "evasion": 17,
       "exp": 38,
       "gold": 26,
-      "magicDef": 12
+      "magicDef": 19
     },
     {
       "id": "B_TRAVELER",
@@ -70,7 +70,7 @@
       "evasion": 28,
       "exp": 120,
       "gold": 180,
-      "magicDef": 17
+      "magicDef": 33
     },
     {
       "id": "B_HUM_GUARD",
@@ -79,7 +79,7 @@
         "human"
       ],
       "level": 20,
-      "hp": 240,
+      "hp": 480,
       "atk": 34,
       "def": 36,
       "agility": 7,
@@ -95,7 +95,7 @@
           "coverLowHpAlly": true
         }
       ],
-      "magicDef": 28
+      "magicDef": 54
     },
     {
       "id": "B_HUM_WARRIOR",
@@ -104,16 +104,16 @@
         "human"
       ],
       "level": 20,
-      "hp": 190,
+      "hp": 380,
       "atk": 90,
       "def": 22,
       "agility": 11,
-      "attackCount": 2,
+      "attackCount": 10,
       "accuracy": 395,
       "evasion": 28,
       "exp": 90,
       "gold": 72,
-      "magicDef": 17
+      "magicDef": 33
     },
     {
       "id": "B_HUM_MAGE",
@@ -122,7 +122,7 @@
         "human"
       ],
       "level": 19,
-      "hp": 120,
+      "hp": 240,
       "atk": 34,
       "magicAtk": 34,
       "def": 10,
@@ -144,7 +144,7 @@
           "grantsSpellId": "magic_arrow"
         }
       ],
-      "magicDef": 8
+      "magicDef": 15
     },
     {
       "id": "B_HUM_CLERIC",
@@ -153,7 +153,7 @@
         "human"
       ],
       "level": 19,
-      "hp": 150,
+      "hp": 300,
       "atk": 28,
       "def": 16,
       "magicHeal": 75,
@@ -169,7 +169,7 @@
           "recoveryMagicLevel": 7
         }
       ],
-      "magicDef": 12
+      "magicDef": 24
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/royal_capital_1.json
+++ b/goblin_native/src/shared/data/enemy/royal_capital_1.json
@@ -16,7 +16,7 @@
       "exp": 105,
       "gold": 95,
       "agility": 9,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "ROY002",
@@ -34,7 +34,7 @@
       "exp": 115,
       "gold": 105,
       "agility": 10,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "ROY003",
@@ -52,7 +52,7 @@
       "exp": 120,
       "gold": 110,
       "agility": 7,
-      "magicDef": 30
+      "magicDef": 57
     },
     {
       "id": "ROY004",
@@ -70,7 +70,7 @@
       "exp": 130,
       "gold": 120,
       "agility": 8,
-      "magicDef": 28
+      "magicDef": 54
     },
     {
       "id": "ROY005",
@@ -88,7 +88,7 @@
       "exp": 150,
       "gold": 140,
       "agility": 12,
-      "magicDef": 27
+      "magicDef": 51
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/royal_capital_2.json
+++ b/goblin_native/src/shared/data/enemy/royal_capital_2.json
@@ -16,7 +16,7 @@
       "exp": 105,
       "gold": 95,
       "agility": 9,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "ROY002",
@@ -34,7 +34,7 @@
       "exp": 115,
       "gold": 105,
       "agility": 10,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "ROY003",
@@ -52,7 +52,7 @@
       "exp": 120,
       "gold": 110,
       "agility": 7,
-      "magicDef": 30
+      "magicDef": 57
     },
     {
       "id": "ROY004",
@@ -70,7 +70,7 @@
       "exp": 130,
       "gold": 120,
       "agility": 8,
-      "magicDef": 28
+      "magicDef": 54
     },
     {
       "id": "ROY005",
@@ -88,7 +88,7 @@
       "exp": 150,
       "gold": 140,
       "agility": 12,
-      "magicDef": 27
+      "magicDef": 51
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/royal_capital_3.json
+++ b/goblin_native/src/shared/data/enemy/royal_capital_3.json
@@ -16,7 +16,7 @@
       "exp": 105,
       "gold": 95,
       "agility": 9,
-      "magicDef": 25
+      "magicDef": 48
     },
     {
       "id": "ROY002",
@@ -34,7 +34,7 @@
       "exp": 115,
       "gold": 105,
       "agility": 10,
-      "magicDef": 14
+      "magicDef": 27
     },
     {
       "id": "ROY003",
@@ -52,7 +52,7 @@
       "exp": 120,
       "gold": 110,
       "agility": 7,
-      "magicDef": 30
+      "magicDef": 57
     },
     {
       "id": "ROY004",
@@ -70,7 +70,7 @@
       "exp": 130,
       "gold": 120,
       "agility": 8,
-      "magicDef": 28
+      "magicDef": 54
     },
     {
       "id": "ROY005",
@@ -88,7 +88,7 @@
       "exp": 150,
       "gold": 140,
       "agility": 12,
-      "magicDef": 27
+      "magicDef": 51
     },
     {
       "id": "B_KING",
@@ -106,7 +106,7 @@
       "exp": 600,
       "gold": 500,
       "agility": 11,
-      "magicDef": 38
+      "magicDef": 72
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/subjugation_force_1.json
+++ b/goblin_native/src/shared/data/enemy/subjugation_force_1.json
@@ -3,12 +3,14 @@
     {
       "id": "HUM001",
       "name": "辺境城正規兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 400,
       "atk": 85,
       "def": 18,
-      "magicDef": 12,
+      "magicDef": 27,
       "agility": 6,
       "attackCount": 1,
       "accuracy": 320,
@@ -19,7 +21,9 @@
     {
       "id": "HUM002",
       "name": "辺境城魔術師",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 250,
       "atk": 110,
@@ -47,12 +51,14 @@
     {
       "id": "HUM003",
       "name": "辺境城弓兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 280,
       "atk": 95,
       "def": 10,
-      "magicDef": 8,
+      "magicDef": 15,
       "agility": 10,
       "attackCount": 1,
       "accuracy": 340,
@@ -63,12 +69,14 @@
     {
       "id": "HUM004",
       "name": "辺境城クレリック",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 350,
       "atk": 70,
       "def": 16,
-      "magicDef": 22,
+      "magicDef": 24,
       "magicHeal": 100,
       "agility": 5,
       "attackCount": 1,
@@ -86,12 +94,14 @@
     {
       "id": "HUM005",
       "name": "辺境城騎士",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 550,
       "atk": 100,
       "def": 24,
-      "magicDef": 16,
+      "magicDef": 36,
       "agility": 4,
       "attackCount": 1,
       "accuracy": 300,
@@ -103,142 +113,296 @@
   "patterns": [
     {
       "id": "SF1_001",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM001"],
-        ["HUM003"]
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF1_002",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM001", "HUM001"],
-        ["HUM003"]
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF1_003",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003"]
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF1_004",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM001", "HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF1_005",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF1_006",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003"]
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF1_007",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM001", "HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF1_008",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF1_009",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF1_010",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF1_011",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF1_012",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF1_013",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF1_014",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF1_015",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     }
   ]

--- a/goblin_native/src/shared/data/enemy/subjugation_force_2.json
+++ b/goblin_native/src/shared/data/enemy/subjugation_force_2.json
@@ -3,12 +3,14 @@
     {
       "id": "HUM001",
       "name": "辺境城正規兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 400,
       "atk": 85,
       "def": 18,
-      "magicDef": 12,
+      "magicDef": 27,
       "agility": 6,
       "attackCount": 1,
       "accuracy": 320,
@@ -19,7 +21,9 @@
     {
       "id": "HUM002",
       "name": "辺境城魔術師",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 250,
       "atk": 110,
@@ -47,12 +51,14 @@
     {
       "id": "HUM003",
       "name": "辺境城弓兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 280,
       "atk": 95,
       "def": 10,
-      "magicDef": 8,
+      "magicDef": 15,
       "agility": 10,
       "attackCount": 1,
       "accuracy": 340,
@@ -63,12 +69,14 @@
     {
       "id": "HUM004",
       "name": "辺境城クレリック",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 350,
       "atk": 70,
       "def": 16,
-      "magicDef": 22,
+      "magicDef": 24,
       "magicHeal": 100,
       "agility": 5,
       "attackCount": 1,
@@ -86,12 +94,14 @@
     {
       "id": "HUM005",
       "name": "辺境城騎士",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 550,
       "atk": 100,
       "def": 24,
-      "magicDef": 16,
+      "magicDef": 36,
       "agility": 4,
       "attackCount": 1,
       "accuracy": 300,
@@ -103,177 +113,420 @@
   "patterns": [
     {
       "id": "SF2_001",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF2_002",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_003",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_004",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_005",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_006",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF2_007",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_008",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_009",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004", "HUM003"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004",
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF2_010",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_011",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_012",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_013",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_014",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF2_015",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     }
   ]

--- a/goblin_native/src/shared/data/enemy/subjugation_force_3.json
+++ b/goblin_native/src/shared/data/enemy/subjugation_force_3.json
@@ -3,12 +3,14 @@
     {
       "id": "HUM001",
       "name": "辺境城正規兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 440,
       "atk": 95,
       "def": 20,
-      "magicDef": 14,
+      "magicDef": 30,
       "agility": 7,
       "attackCount": 1,
       "accuracy": 330,
@@ -19,7 +21,9 @@
     {
       "id": "HUM002",
       "name": "辺境城魔術師",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 280,
       "atk": 120,
@@ -47,12 +51,14 @@
     {
       "id": "HUM003",
       "name": "辺境城弓兵",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 310,
       "atk": 105,
       "def": 12,
-      "magicDef": 10,
+      "magicDef": 18,
       "agility": 11,
       "attackCount": 1,
       "accuracy": 350,
@@ -63,12 +69,14 @@
     {
       "id": "HUM004",
       "name": "辺境城クレリック",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 390,
       "atk": 80,
       "def": 18,
-      "magicDef": 24,
+      "magicDef": 27,
       "magicHeal": 110,
       "agility": 6,
       "attackCount": 1,
@@ -86,12 +94,14 @@
     {
       "id": "HUM005",
       "name": "辺境城騎士",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 30,
       "hp": 600,
       "atk": 110,
       "def": 28,
-      "magicDef": 18,
+      "magicDef": 42,
       "agility": 5,
       "attackCount": 1,
       "accuracy": 310,
@@ -102,12 +112,14 @@
     {
       "id": "B_CAPTAIN",
       "name": "辺境城騎士団長",
-      "raceTags": ["human"],
+      "raceTags": [
+        "human"
+      ],
       "level": 40,
       "hp": 1600,
       "atk": 150,
       "def": 30,
-      "magicDef": 22,
+      "magicDef": 45,
       "agility": 9,
       "attackCount": 10,
       "accuracy": 380,
@@ -120,189 +132,450 @@
   "patterns": [
     {
       "id": "SF3_001",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF3_002",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_003",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_004",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_005",
-      "floors": [1],
+      "floors": [
+        1
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_006",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ]
       ]
     },
     {
       "id": "SF3_007",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_008",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_009",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004", "HUM003"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004",
+          "HUM003"
+        ]
       ]
     },
     {
       "id": "SF3_010",
-      "floors": [2],
+      "floors": [
+        2
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_011",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_012",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_013",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM002"],
-        ["HUM003", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM002"
+        ],
+        [
+          "HUM003",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_014",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "SF3_015",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM005"],
-        ["HUM001", "HUM001"],
-        ["HUM001"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ]
     },
     {
       "id": "BOSS",
-      "floors": [3],
+      "floors": [
+        3
+      ],
       "enemies": [
-        ["HUM005", "HUM005"],
-        ["HUM001", "HUM001"],
-        ["B_CAPTAIN"],
-        ["HUM001"],
-        ["HUM003", "HUM003"],
-        ["HUM002", "HUM004"]
+        [
+          "HUM005",
+          "HUM005"
+        ],
+        [
+          "HUM001",
+          "HUM001"
+        ],
+        [
+          "B_CAPTAIN"
+        ],
+        [
+          "HUM001"
+        ],
+        [
+          "HUM003",
+          "HUM003"
+        ],
+        [
+          "HUM002",
+          "HUM004"
+        ]
       ],
       "isBoss": true
     }

--- a/goblin_native/src/shared/data/enemy/troll_canyon_1.json
+++ b/goblin_native/src/shared/data/enemy/troll_canyon_1.json
@@ -16,7 +16,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 4,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "TRL002",
@@ -34,7 +34,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "TRL003",
@@ -52,7 +52,7 @@
       "exp": 72,
       "gold": 64,
       "agility": 5,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "TRL004",
@@ -70,7 +70,7 @@
       "exp": 78,
       "gold": 68,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "TRL005",
@@ -88,7 +88,7 @@
       "exp": 70,
       "gold": 62,
       "agility": 7,
-      "magicDef": 11
+      "magicDef": 17
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/troll_canyon_2.json
+++ b/goblin_native/src/shared/data/enemy/troll_canyon_2.json
@@ -16,7 +16,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 4,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "TRL002",
@@ -34,7 +34,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "TRL003",
@@ -52,7 +52,7 @@
       "exp": 72,
       "gold": 64,
       "agility": 5,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "TRL004",
@@ -70,7 +70,7 @@
       "exp": 78,
       "gold": 68,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "TRL005",
@@ -88,7 +88,7 @@
       "exp": 70,
       "gold": 62,
       "agility": 7,
-      "magicDef": 11
+      "magicDef": 17
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/troll_canyon_3.json
+++ b/goblin_native/src/shared/data/enemy/troll_canyon_3.json
@@ -16,7 +16,7 @@
       "exp": 62,
       "gold": 54,
       "agility": 4,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "TRL002",
@@ -34,7 +34,7 @@
       "exp": 68,
       "gold": 60,
       "agility": 3,
-      "magicDef": 14
+      "magicDef": 22
     },
     {
       "id": "TRL003",
@@ -52,7 +52,7 @@
       "exp": 72,
       "gold": 64,
       "agility": 5,
-      "magicDef": 9
+      "magicDef": 14
     },
     {
       "id": "TRL004",
@@ -70,7 +70,7 @@
       "exp": 78,
       "gold": 68,
       "agility": 3,
-      "magicDef": 17
+      "magicDef": 26
     },
     {
       "id": "TRL005",
@@ -88,7 +88,7 @@
       "exp": 70,
       "gold": 62,
       "agility": 7,
-      "magicDef": 11
+      "magicDef": 17
     },
     {
       "id": "B_TYRANT",
@@ -112,7 +112,7 @@
         }
       ],
       "agility": 6,
-      "magicDef": 27
+      "magicDef": 41
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/undead_ruins_1.json
+++ b/goblin_native/src/shared/data/enemy/undead_ruins_1.json
@@ -6,7 +6,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 5,
+      "level": 9,
       "hp": 120,
       "atk": 20,
       "def": 6,
@@ -14,9 +14,9 @@
       "attackCount": 2,
       "accuracy": 230,
       "evasion": 13,
-      "exp": 16,
-      "gold": 12,
-      "magicDef": 4
+      "exp": 24,
+      "gold": 21,
+      "magicDef": 5
     },
     {
       "id": "UND002",
@@ -24,7 +24,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 9,
       "hp": 100,
       "atk": 12,
       "def": 4,
@@ -32,9 +32,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 14,
-      "exp": 18,
-      "gold": 14,
-      "magicDef": 3
+      "exp": 22,
+      "gold": 19,
+      "magicDef": 4
     },
     {
       "id": "UND003",
@@ -42,7 +42,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 10,
       "hp": 100,
       "atk": 14,
       "def": 2,
@@ -50,9 +50,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 16,
-      "exp": 20,
-      "gold": 16,
-      "magicDef": 1
+      "exp": 28,
+      "gold": 24,
+      "magicDef": 2
     },
     {
       "id": "UND004",
@@ -60,7 +60,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 7,
+      "level": 10,
       "hp": 60,
       "atk": 15,
       "def": 5,
@@ -68,9 +68,9 @@
       "attackCount": 1,
       "accuracy": 255,
       "evasion": 15,
-      "exp": 22,
-      "gold": 18,
-      "magicDef": 4
+      "exp": 30,
+      "gold": 26,
+      "magicDef": 5
     },
     {
       "id": "UND005",
@@ -78,7 +78,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 8,
+      "level": 12,
       "hp": 55,
       "atk": 50,
       "def": 10,
@@ -86,9 +86,9 @@
       "attackCount": 1,
       "accuracy": 180,
       "evasion": 16,
-      "exp": 28,
-      "gold": 22,
-      "magicDef": 8
+      "exp": 36,
+      "gold": 32,
+      "magicDef": 9
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/undead_ruins_2.json
+++ b/goblin_native/src/shared/data/enemy/undead_ruins_2.json
@@ -6,7 +6,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 5,
+      "level": 9,
       "hp": 120,
       "atk": 20,
       "def": 6,
@@ -14,9 +14,9 @@
       "attackCount": 2,
       "accuracy": 230,
       "evasion": 13,
-      "exp": 16,
-      "gold": 12,
-      "magicDef": 4
+      "exp": 24,
+      "gold": 21,
+      "magicDef": 5
     },
     {
       "id": "UND002",
@@ -24,7 +24,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 9,
       "hp": 100,
       "atk": 12,
       "def": 4,
@@ -32,9 +32,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 14,
-      "exp": 18,
-      "gold": 14,
-      "magicDef": 3
+      "exp": 22,
+      "gold": 19,
+      "magicDef": 4
     },
     {
       "id": "UND003",
@@ -42,7 +42,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 10,
       "hp": 100,
       "atk": 14,
       "def": 2,
@@ -50,9 +50,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 16,
-      "exp": 20,
-      "gold": 16,
-      "magicDef": 1
+      "exp": 28,
+      "gold": 24,
+      "magicDef": 2
     },
     {
       "id": "UND004",
@@ -60,7 +60,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 7,
+      "level": 10,
       "hp": 60,
       "atk": 15,
       "def": 5,
@@ -68,9 +68,9 @@
       "attackCount": 1,
       "accuracy": 255,
       "evasion": 15,
-      "exp": 22,
-      "gold": 18,
-      "magicDef": 4
+      "exp": 30,
+      "gold": 26,
+      "magicDef": 5
     },
     {
       "id": "UND005",
@@ -78,7 +78,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 8,
+      "level": 12,
       "hp": 55,
       "atk": 50,
       "def": 10,
@@ -86,9 +86,9 @@
       "attackCount": 1,
       "accuracy": 180,
       "evasion": 16,
-      "exp": 28,
-      "gold": 22,
-      "magicDef": 8
+      "exp": 36,
+      "gold": 32,
+      "magicDef": 9
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/undead_ruins_3.json
+++ b/goblin_native/src/shared/data/enemy/undead_ruins_3.json
@@ -6,7 +6,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 5,
+      "level": 9,
       "hp": 120,
       "atk": 20,
       "def": 6,
@@ -14,9 +14,9 @@
       "attackCount": 2,
       "accuracy": 230,
       "evasion": 13,
-      "exp": 16,
-      "gold": 12,
-      "magicDef": 4
+      "exp": 24,
+      "gold": 21,
+      "magicDef": 5
     },
     {
       "id": "UND002",
@@ -24,7 +24,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 9,
       "hp": 100,
       "atk": 12,
       "def": 4,
@@ -32,9 +32,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 14,
-      "exp": 18,
-      "gold": 14,
-      "magicDef": 3
+      "exp": 22,
+      "gold": 19,
+      "magicDef": 4
     },
     {
       "id": "UND003",
@@ -42,7 +42,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 6,
+      "level": 10,
       "hp": 100,
       "atk": 14,
       "def": 2,
@@ -50,9 +50,9 @@
       "attackCount": 1,
       "accuracy": 240,
       "evasion": 16,
-      "exp": 20,
-      "gold": 16,
-      "magicDef": 1
+      "exp": 28,
+      "gold": 24,
+      "magicDef": 2
     },
     {
       "id": "UND004",
@@ -60,7 +60,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 7,
+      "level": 10,
       "hp": 60,
       "atk": 15,
       "def": 5,
@@ -68,9 +68,9 @@
       "attackCount": 1,
       "accuracy": 255,
       "evasion": 15,
-      "exp": 22,
-      "gold": 18,
-      "magicDef": 4
+      "exp": 30,
+      "gold": 26,
+      "magicDef": 5
     },
     {
       "id": "UND005",
@@ -78,7 +78,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 8,
+      "level": 12,
       "hp": 55,
       "atk": 50,
       "def": 10,
@@ -86,9 +86,9 @@
       "attackCount": 1,
       "accuracy": 180,
       "evasion": 16,
-      "exp": 28,
-      "gold": 22,
-      "magicDef": 8
+      "exp": 36,
+      "gold": 32,
+      "magicDef": 9
     },
     {
       "id": "B_LICH",
@@ -96,7 +96,7 @@
       "raceTags": [
         "undead"
       ],
-      "level": 11,
+      "level": 14,
       "hp": 200,
       "atk": 28,
       "magicAtk": 28,
@@ -105,8 +105,8 @@
       "attackCount": 2,
       "accuracy": 330,
       "evasion": 19,
-      "exp": 90,
-      "gold": 80,
+      "exp": 105,
+      "gold": 92,
       "skills": [
         {
           "id": "fireball",
@@ -126,7 +126,7 @@
           "probability": 1
         }
       ],
-      "magicDef": 9
+      "magicDef": 11
     }
   ],
   "patterns": [


### PR DESCRIPTION
## Summary
- 周辺の森〜オーク野営地の敵レベルをステータス相応に引き上げ、EXP曲線を滑らかに調整
- 街道ボス護衛パーティ強化（HP2倍、ウォリアー10回攻撃）
- 辺境の村の猟師に先制攻撃スキル・5回攻撃を付与、EXP引き上げ
- magicDefを種族別ルールで一括調整（モンスター:DEF×1.2、人間系:DEF×1.5、アンデッド:DEF×0.9、特殊種族:据え置き）

## 変更対象（34ファイル）
- `forest_outskirts` / `goblin_village_*` / `undead_ruins_*` / `road_1`
- `orc_camp_*` / `orc_fortress_1` / `human_village`
- `elf_forest_*` / `dwarf_mine_*` / `lizardman_swamp_*` / `troll_canyon_*`
- `human_fortress_*` / `royal_capital_*` / `subjugation_force_*` / `vampire_castle_1`

## Test plan
- [ ] 周辺の森〜ゴブリン集落のEXP獲得量が滑らかに推移することを確認
- [ ] オーク野営地・アンデッド遺跡の敵レベル表示が適切か確認
- [ ] 街道ボス戦（護衛パーティ）の難易度が適切か確認
- [ ] 辺境の村の猟師が先制で5回攻撃してくることを確認
- [ ] 魔法攻撃に対する各種族の被ダメージバランスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)