### PR TITLE
feat(expedition): 課金による探索時間短縮倍率を遠征時間計算に適用

### DIFF
--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -18,6 +18,7 @@ import { useBaseStore, getBaseStateRepository } from '../stores/useBaseStore'
 import { useDungeonStore } from '../stores/useDungeonStore'
 import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQLiteEquipmentRepository'
 import { useDebugSettingsStore } from '../stores/useDebugSettingsStore'
+import { getSpeedMultiplier } from '../stores/usePurchaseStore'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
 import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
 import i18n from '../../shared/i18n'
@@ -155,7 +156,8 @@ export const useExpeditionFlow = ({
       last_one: 0.9,
     }
     const multiplier = multiplierMap[returnPolicy] ?? 1.0
-    return Math.floor(baseTime * multiplier)
+    const speedMultiplier = getSpeedMultiplier()
+    return Math.floor(baseTime * multiplier * speedMultiplier)
   }, [instantDungeonExploration])
 
   const formatTime = useCallback((date: Date) => {


### PR DESCRIPTION
## Summary
- 探索時間1/2・2/3の買い切り商品を購入した際に、遠征の探索時間が短縮されるよう `getSpeedMultiplier()` を `estimateExplorationTime` に適用

## Test plan
- [ ] 探索時間1/2購入状態で遠征開始し、探索時間が半分になることを確認
- [ ] 探索時間2/3購入状態で遠征開始し、探索時間が2/3になることを確認
- [ ] 両方購入状態で遠征開始し、探索時間が約1/3になることを確認
- [ ] 未購入状態で探索時間が通常通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)