### PR TITLE
fix(formation): ダンジョン選択時のデフォルトティアをクリア済み最高に修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -225,11 +225,11 @@ export default function ExpeditionPreparationScreen() {
     return Math.min(maxCleared, 5) as DungeonTier
   }, [selectedDungeon])
 
-  // ダンジョン変更時にティアをデフォルト選択
+  // ダンジョン変更時にティアをデフォルト選択（クリア済みの最高ティア）
   const autoSelectTier = useCallback((dungeon: Dungeon) => {
     const maxCleared = dungeon.maxClearedTier ?? 0
-    // 魔性以上が解放されている場合は最高解放ティアをデフォルト選択
-    const defaultTier = Math.min(maxCleared, 5) as DungeonTier
+    // maxClearedTier は「次に解放されるティア番号」なので、クリア済み最高は -1
+    const defaultTier = Math.min(Math.max(maxCleared - 1, 0), 5) as DungeonTier
     setSelectedTier(defaultTier)
     if (partyId) {
       void setDungeonTier(parseInt(partyId, 10), defaultTier)


### PR DESCRIPTION
## Summary
- ダンジョン選択時のデフォルトティアが未クリアのティア（解放済み最高）になっていた問題を修正
- `maxClearedTier` は「次に解放されるティア番号」のため、クリア済み最高ティアは `maxClearedTier - 1` で算出するよう変更

## Test plan
- [ ] ダンジョン選択時、クリア済みの最高ティアがデフォルト選択されることを確認
- [ ] 未クリアのダンジョンでは通常（tier 0）がデフォルト選択されることを確認
- [ ] 手動でティアを変更した場合は正常に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)