### PR TITLE
feat(expedition): 遠征中の途中帰還機能を実装

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -62,6 +62,7 @@ interface PartyCardProps {
   party: Party
   goblins: Goblin[]
   onPress: () => void
+  onAbort: () => void
   historyDisplays: ExpeditionHistoryDisplay[]
   onHistoryPress: (record: ExpeditionRecord, ongoing: boolean) => void
   onLogPress: (record: ExpeditionRecord) => void
@@ -73,6 +74,7 @@ const PartyCard = memo(function PartyCard({
   party,
   goblins,
   onPress,
+  onAbort,
   historyDisplays,
   onHistoryPress,
   onLogPress,
@@ -111,9 +113,16 @@ const PartyCard = memo(function PartyCard({
         <View style={styles.partyHeader}>
           <Text style={styles.partyName}>{party.name}</Text>
           {status === 'expedition' && (
-            <View style={styles.expeditionBadge}>
-              <Text style={styles.expeditionBadgeText}>{t('ui.formation.index.expeditionStatus')}</Text>
-            </View>
+            <TouchableOpacity
+              style={styles.expeditionBadge}
+              onPress={(e) => {
+                e.stopPropagation()
+                onAbort()
+              }}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.expeditionBadgeText}>{t('ui.formation.index.abortButton')}</Text>
+            </TouchableOpacity>
           )}
         </View>
 
@@ -173,6 +182,7 @@ export default function FormationScreen() {
     partyHistoryDisplays,
     startExpedition,
     startBulkExpedition,
+    abortExpedition,
   } = useExpeditionFlow({ parties, enableAutoCompletion: true, currentTime })
   const [isBulkLaunching, setIsBulkLaunching] = useState(false)
   const { slotSize, avatarSize } = useMemo(() => {
@@ -237,6 +247,24 @@ export default function FormationScreen() {
       })
     }
   }, [createParty, partyHistories, t])
+
+  const handleAbort = useCallback((party: Party) => {
+    const latestHistory = partyHistories[party.id]?.[0]
+    if (!latestHistory || latestHistory.status !== 'ongoing') return
+
+    Alert.alert(
+      t('ui.formation.index.abortConfirmTitle'),
+      t('ui.formation.index.abortConfirmBody'),
+      [
+        { text: t('ui.common.cancel'), style: 'cancel' },
+        {
+          text: t('ui.formation.index.abortConfirmOk'),
+          style: 'destructive',
+          onPress: () => void abortExpedition(latestHistory),
+        },
+      ],
+    )
+  }, [abortExpedition, partyHistories, t])
 
   const handleHistoryPress = useCallback((record: ExpeditionRecord, ongoing: boolean) => {
     if (ongoing) {
@@ -358,6 +386,7 @@ export default function FormationScreen() {
           party={item}
           goblins={goblins}
           onPress={() => handlePartyPress(item, index)}
+          onAbort={() => handleAbort(item)}
           historyDisplays={partyHistoryDisplays[item.id] ?? []}
           onHistoryPress={handleHistoryPress}
           onLogPress={handleLogPress}
@@ -383,7 +412,7 @@ export default function FormationScreen() {
         </View>
       </TouchableOpacity>
     )
-  }, [avatarSize, goblins, handleHistoryPress, handleLogPress, handlePartyPress, partyHistoryDisplays, slotSize])
+  }, [avatarSize, goblins, handleAbort, handleHistoryPress, handleLogPress, handlePartyPress, partyHistoryDisplays, slotSize])
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -39,8 +39,10 @@ export class CompleteExpeditionUseCase {
 
   public async execute(
     partyId: number,
-    replay: ExpeditionReplay
+    replay: ExpeditionReplay,
+    options?: { isAbort?: boolean }
   ): Promise<ExpeditionCompletionResult> {
+    const isAbort = options?.isAbort ?? false
     const party = await this.partyRepository.getParty(partyId)
     if (!party) {
       throw new Error('パーティが見つかりません')
@@ -131,7 +133,7 @@ export class CompleteExpeditionUseCase {
       (e): e is Extract<TimelineEvent, { type: 'boss' }> => e.type === 'boss'
     )
 
-    if (bossEvent && bossEvent.combat.outcome === 'win') {
+    if (!isAbort && bossEvent && bossEvent.combat.outcome === 'win') {
       const enemyDatabase = getEnemyDatabase(replay.meta.areaId)
 
       if (enemyDatabase) {
@@ -195,7 +197,7 @@ export class CompleteExpeditionUseCase {
     }
 
     const treasureDrops = replay.summary.treasureDrops ?? []
-    if (treasureDrops.length > 0 && this.equipmentRepository) {
+    if (!isAbort && treasureDrops.length > 0 && this.equipmentRepository) {
       for (const drop of treasureDrops) {
         const equipmentId = `eq_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
         await this.equipmentRepository.save({
@@ -209,25 +211,27 @@ export class CompleteExpeditionUseCase {
     }
 
     let newDungeonCaptured: string | undefined
-    const goldGained = replay.summary.goldGained || 0
+    const goldGained = isAbort ? 0 : (replay.summary.goldGained || 0)
 
-    const currentBaseState = await this.baseStateRepository.getBaseState()
-    if (currentBaseState) {
-      let updatedBaseState = {
-        ...currentBaseState,
-        gold: currentBaseState.gold + goldGained,
-      }
-
-      if (replay.summary.success) {
-        const wasCaptured = currentBaseState.capturedDungeons.includes(replay.meta.areaId)
-        updatedBaseState = captureDungeon(replay.meta.areaId, updatedBaseState)
-
-        if (!wasCaptured) {
-          newDungeonCaptured = replay.meta.areaId
+    if (!isAbort) {
+      const currentBaseState = await this.baseStateRepository.getBaseState()
+      if (currentBaseState) {
+        let updatedBaseState = {
+          ...currentBaseState,
+          gold: currentBaseState.gold + goldGained,
         }
-      }
 
-      await this.baseStateRepository.saveBaseState(updatedBaseState)
+        if (replay.summary.success) {
+          const wasCaptured = currentBaseState.capturedDungeons.includes(replay.meta.areaId)
+          updatedBaseState = captureDungeon(replay.meta.areaId, updatedBaseState)
+
+          if (!wasCaptured) {
+            newDungeonCaptured = replay.meta.areaId
+          }
+        }
+
+        await this.baseStateRepository.saveBaseState(updatedBaseState)
+      }
     }
 
     await this.partyRepository.updatePartyStatus(partyId, 'idle')

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -329,6 +329,98 @@ export const useExpeditionFlow = ({
 
   const updateExpeditionReplay = useExpeditionStore((state) => state.updateExpeditionReplay)
 
+  const abortExpedition = useCallback(async (record: ExpeditionRecord): Promise<void> => {
+    setIsProcessing(true)
+    try {
+      // replay が未計算の場合は遅延計算を実行
+      let replay = record.replay
+      if (!replay && record.expeditionMeta) {
+        replay = await computeExpeditionReplay(record.expeditionMeta)
+        await updateExpeditionReplay(record.id, replay)
+      }
+      if (!replay) return
+
+      // 経過時間の割合でリプレイを途中で切断
+      const now = new Date()
+      const startMs = record.startTime.getTime()
+      const returnMs = record.returnTime ? record.returnTime.getTime() : startMs
+      const totalMs = returnMs - startMs
+      const elapsedRatio = totalMs > 0
+        ? Math.min(1, Math.max(0, (now.getTime() - startMs) / totalMs))
+        : 0
+      const cutoffSec = elapsedRatio * replay.durationSec
+
+      // cutoffSec 以前のイベントのみ残し、元の return イベントを除外
+      const truncatedEvents = replay.events.filter(
+        e => e.type !== 'return' && e.at <= cutoffSec
+      )
+      // abort の return イベントを追加
+      truncatedEvents.push({ type: 'return', at: cutoffSec, reason: 'abort' as const })
+
+      // 切断されたイベントから summary を再計算
+      let xpGained = 0
+      let goldGained = 0
+      let maxFloorReached = 1
+      const truncatedTreasureDrops: typeof replay.summary.treasureDrops = []
+      const casualtyIds: string[] = []
+
+      // HP追跡用
+      const hpState = replay.meta.party.map((id) => {
+        const snapshot = replay!.meta.partySnapshot?.find(g => g.id === Number.parseInt(id, 10))
+        return snapshot?.currentHp ?? 999
+      })
+
+      for (const event of truncatedEvents) {
+        if (event.type === 'battle' || event.type === 'boss') {
+          if (event.combat.outcome === 'win') xpGained += event.xp
+          goldGained += event.enemy.gold
+          maxFloorReached = Math.max(maxFloorReached, event.floor)
+          event.combat.allyHPDelta.forEach((delta, i) => {
+            if (i < hpState.length) hpState[i] = Math.max(0, hpState[i] + delta)
+          })
+        } else if (event.type === 'floor_up') {
+          maxFloorReached = Math.max(maxFloorReached, event.to)
+        } else if (event.type === 'treasure') {
+          truncatedTreasureDrops.push(...event.items)
+        }
+      }
+
+      // HP0のメンバーを casualties に追加
+      replay.meta.party.forEach((id, i) => {
+        if (hpState[i] <= 0) casualtyIds.push(id)
+      })
+
+      const truncatedReplay: typeof replay = {
+        ...replay,
+        durationSec: cutoffSec,
+        events: truncatedEvents,
+        summary: {
+          success: false,
+          maxFloorReached,
+          xpGained,
+          goldGained,
+          casualties: casualtyIds,
+          treasureDrops: truncatedTreasureDrops.length > 0 ? truncatedTreasureDrops : undefined,
+        },
+      }
+
+      // abort モードで完了処理（Gold・アイテム・因子・制圧をスキップ）
+      const result = await completeExpeditionUseCase.execute(record.partyId, truncatedReplay, { isAbort: true })
+
+      // スケジュール済み通知をキャンセル
+      await cancelExpeditionNotification(record.id)
+
+      // DBをアトミックに更新
+      await completeExpeditionRecord(record.id, result.enrichedReplay)
+
+      // ストアを同期
+      await usePartyStore.getState().refresh()
+      await useGoblinStore.getState().refresh()
+    } finally {
+      setIsProcessing(false)
+    }
+  }, [completeExpeditionUseCase, completeExpeditionRecord, updateExpeditionReplay, cancelExpeditionNotification])
+
   const completeDueExpeditions = useCallback(async (): Promise<void> => {
     const now = new Date()
     const dueExpeditions = expeditionRecords.filter(record =>
@@ -475,6 +567,7 @@ export const useExpeditionFlow = ({
     isProcessing,
     startExpedition,
     startBulkExpedition,
+    abortExpedition,
     estimateExplorationTime,
     completeDueExpeditions,
     currentTime,

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -260,6 +260,10 @@ const en = {
         pendingOverflowBody: 'Not enough pending slots. If {{count}} parties are dispatched, newly added goblins after successful expeditions may be discarded. Dispatch anyway?',
         partyDefaultName: 'PT{{index}}',
         rewardText: 'G{{gold}}x Rare{{rare}}x Prefix{{title}}x',
+        abortButton: 'Return',
+        abortConfirmTitle: 'Confirm Return',
+        abortConfirmBody: 'End the expedition early.\nGold and items will be lost.\nExperience and HP status will be kept.',
+        abortConfirmOk: 'Return',
       },
       preparation: {
         title: 'Expedition Prep',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -260,6 +260,10 @@ const ja = {
         pendingOverflowBody: '待機枠が不足しています。{{count}}PT出撃すると、遠征成功時に追加されるゴブリンを受け取れず破棄する可能性があります。出撃しますか？',
         partyDefaultName: 'PT{{index}}',
         rewardText: 'G{{gold}}倍 レア{{rare}}倍 称号{{title}}倍',
+        abortButton: '帰還',
+        abortConfirmTitle: '帰還確認',
+        abortConfirmBody: '遠征を途中で終了します。\nGold・アイテムは持ち帰れません。\n経験値とHP状態は維持されます。',
+        abortConfirmOk: '帰還する',
       },
       preparation: {
         title: '冒険準備',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -260,6 +260,10 @@ const ko = {
         pendingOverflowBody: '대기 슬롯이 부족합니다. {{count}}개 PT가 출격하면 원정 성공 시 추가되는 고블린을 받지 못하고 폐기할 수 있습니다. 출격할까요?',
         partyDefaultName: 'PT{{index}}',
         rewardText: 'G{{gold}}배 레어{{rare}}배 칭호{{title}}배',
+        abortButton: '귀환',
+        abortConfirmTitle: '귀환 확인',
+        abortConfirmBody: '원정을 중도 종료합니다.\n골드와 아이템은 가져올 수 없습니다.\n경험치와 HP 상태는 유지됩니다.',
+        abortConfirmOk: '귀환하기',
       },
       preparation: {
         title: '원정 준비',


### PR DESCRIPTION
## Summary
- 編成画面のPTカード「遠征中」タグを「帰還」ボタンに変更し、遠征途中での帰還を可能にした
- 帰還時はGold・アイテムを破棄し、経験値とHP・生存状態のみ維持
- 経過時間の割合でリプレイを途中で切断し、ログ閲覧時にも正しく途中までの内容を表示

## 変更内容
- `CompleteExpeditionUseCase`: `isAbort`オプション追加（Gold・宝箱・因子・制圧スキップ）
- `useExpeditionFlow`: `abortExpedition`関数追加（リプレイ切断・summary再計算）
- `formation/index.tsx`: 遠征中バッジを帰還ボタン（確認ダイアログ付き）に変更
- i18n: 3言語（ja/en/ko）にテキスト追加

## Test plan
- [ ] 遠征中のPTカードに「帰還」ボタンが表示されること
- [ ] ボタンタップで確認ダイアログが表示されること
- [ ] 帰還後にGold・アイテムが増えていないこと
- [ ] 帰還後に経験値・HP状態が正しく反映されていること
- [ ] 帰還後のログ閲覧で途中までのイベントのみ表示されること
- [ ] 通常の遠征完了フローに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)