### PR TITLE
fix(formation): 遠征ログの開始時フロア表示を0Fから1Fに修正

### DIFF
--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -511,7 +511,7 @@ export const useExpeditionFlow = ({
       const items = history.map(record => {
         const dungeon = areasData.find(area => area.id === record.dungeonId)
         const ongoing = isExpeditionOngoing(record, currentTime)
-        const floorReached = record.replay?.summary.maxFloorReached ?? 0
+        const floorReached = record.replay?.summary.maxFloorReached ?? 1
         const remainingMinutes = ongoing && record.returnTime
           ? getRemainingMinutes(record.returnTime, currentTime)
           : 0


### PR DESCRIPTION
## Summary
- 遠征開始直後のPTカード履歴ログで `[0F]` と表示されていたバグを修正
- `replay` 未計算時の `maxFloorReached` フォールバック値を `0` → `1` に変更

## Test plan
- [ ] 遠征を開始し、編成画面のPTカード下部の遠征ログが `[1F]` と表示されることを確認
- [ ] 遠征完了後のログ表示が正しいフロア数で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)