### PR TITLE
feat(battle-log): 戦闘ログにLv表示と味方キャラクター画像を追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useEffect } from 'react'
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
-import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
+import type { BattleLogEntry, BattleLogMeta, Goblin } from '@/shared/types'
 import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
+import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 
 export default function BattleLogScreen() {
   const { t } = useTranslation()
@@ -19,6 +20,15 @@ export default function BattleLogScreen() {
 
   const battleLog = stored?.log ?? null
   const meta = stored?.meta ?? null
+  const partySnapshot = stored?.partySnapshot ?? []
+
+  const goblinMap = useMemo(() => {
+    const map = new Map<string, Goblin>()
+    for (const goblin of partySnapshot) {
+      map.set(String(goblin.id), goblin)
+    }
+    return map
+  }, [partySnapshot])
 
   useEffect(() => {
     const raw = Array.isArray(logId) ? logId[0] : logId
@@ -83,13 +93,19 @@ export default function BattleLogScreen() {
             const isHealingAction = entry.targets?.some(target => target.totalDamage < 0) ?? false
             const isBarrierAction = entry.actionEffect === 'barrier' || entry.action === t('entities.spell.shield_barrier')
 
+            const allyGoblin = entry.isAlly ? goblinMap.get(entry.actorId) : undefined
+            const actorImage = allyGoblin ? getGoblinDisplayImage(allyGoblin) : undefined
+
             if (entry.actionEffect === 'regen') {
               const healed = Math.abs(entry.targets?.[0]?.totalDamage ?? 0)
               return (
                 <View key={`log-${index}`} style={styles.logCard}>
-                  <Text style={styles.logText}>
-                    {t('ui.formation.battleLog.regenSummary', { actor: entry.actorName, heal: healed })}
-                  </Text>
+                  <View style={styles.logHeader}>
+                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
+                    <Text style={[styles.logText, styles.logHeaderText]}>
+                      {t('ui.formation.battleLog.regenSummary', { actor: entry.actorName, heal: healed })}
+                    </Text>
+                  </View>
                 </View>
               )
             }
@@ -97,36 +113,46 @@ export default function BattleLogScreen() {
             if (isBarrierAction) {
               return (
                 <View key={`log-${index}`} style={styles.logCard}>
-                  <Text style={styles.logTitle}>
-                    {t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
-                  </Text>
-                  <Text style={styles.logText}>
-                    {t('ui.formation.battleLog.shieldBarrierSummary')}
-                  </Text>
+                  <View style={styles.logHeader}>
+                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
+                    <View style={styles.logHeaderText}>
+                      <Text style={styles.logTitle}>
+                        {t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
+                      </Text>
+                      <Text style={styles.logText}>
+                        {t('ui.formation.battleLog.shieldBarrierSummary')}
+                      </Text>
+                    </View>
+                  </View>
                 </View>
               )
             }
 
             return (
               <View key={`log-${index}`} style={styles.logCard}>
-                <Text style={styles.logTitle}>
-                  {isSpell
-                    ? t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })
-                    : t('ui.formation.battleLog.attackTitle', { actor: entry.actorName, count: entry.attackCount, hp: entry.actorHP, maxHp: entry.actorMaxHP })
-                  }
-                </Text>
-                <Text style={styles.logText}>
-                  {isHealingAction
-                    ? t('ui.formation.battleLog.healSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
-                    : isSpell
-                    ? t('ui.formation.battleLog.spellSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
-                    : entry.isCritical
-                    ? t('ui.formation.battleLog.attackCriticalSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
-                    : t('ui.formation.battleLog.attackSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
-                  }
-                </Text>
+                <View style={styles.logHeader}>
+                  {actorImage && <Image source={actorImage} style={styles.actorImage} />}
+                  <View style={styles.logHeaderText}>
+                    <Text style={styles.logTitle}>
+                      {isSpell
+                        ? t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })
+                        : t('ui.formation.battleLog.attackTitle', { actor: entry.actorName, count: entry.attackCount, hp: entry.actorHP, maxHp: entry.actorMaxHP })
+                      }
+                    </Text>
+                    <Text style={styles.logText}>
+                      {isHealingAction
+                        ? t('ui.formation.battleLog.healSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
+                        : isSpell
+                        ? t('ui.formation.battleLog.spellSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
+                        : entry.isCritical
+                        ? t('ui.formation.battleLog.attackCriticalSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
+                        : t('ui.formation.battleLog.attackSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
+                      }
+                    </Text>
+                  </View>
+                </View>
                 {entry.targets?.map((target, targetIndex) => (
-                  <Text key={`target-${targetIndex}`} style={styles.logText}>
+                  <Text key={`target-${targetIndex}`} style={[styles.logText, actorImage ? styles.logTargetIndented : undefined]}>
                     {target.totalDamage < 0
                       ? t('ui.formation.battleLog.targetHealed', { row: target.targetRow, name: target.targetName, heal: Math.abs(target.totalDamage) })
                       : target.defeated
@@ -261,6 +287,23 @@ const styles = StyleSheet.create({
     padding: 12,
     borderWidth: 1,
     borderColor: '#E5E7EB',
+  },
+  logHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  actorImage: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    marginTop: 2,
+  },
+  logHeaderText: {
+    flex: 1,
+  },
+  logTargetIndented: {
+    marginLeft: 36,
   },
   logTitle: {
     fontSize: 13,

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -126,9 +126,9 @@ export default function ExpeditionPlaybackScreen() {
   }, [])
 
   const openBattleLog = useCallback((detail: BattleLogEntry[], meta?: BattleLogMeta) => {
-    const logId = storeBattleLog(detail, meta)
+    const logId = storeBattleLog(detail, meta, partyGoblins)
     router.push(`/formation/battle-log?logId=${encodeURIComponent(logId)}` as Href)
-  }, [])
+  }, [partyGoblins])
 
   const getReturnReasonText = useCallback((reason: ExpeditionEndReason) => {
     if (reason === 'completed') return t('ui.formation.playback.completed')

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -1001,7 +1001,8 @@ export class BattleSystem {
   }
 
   private getLogName(unit: BattleUnit): string {
-    return unit.logName ?? unit.combatant.name
+    const name = unit.logName ?? unit.combatant.name
+    return `Lv${unit.level} ${name}`
   }
 
   private assignEnemyLogNames(enemyUnits: BattleUnit[]): void {

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1407,8 +1407,8 @@ describe('spell charges', () => {
     const turnStartLog = result.detailedLog.find(log => log.action === 'turn_start')
     const attackLog = result.detailedLog.find(log => log.actorId === '1' && log.action === '通常攻撃')
 
-    expect(turnStartLog?.turnState?.enemies.map(enemy => enemy.name)).toEqual(['オーク兵A', 'オーク兵B'])
-    expect(attackLog?.targets[0]?.targetName).toBe('オーク兵A')
+    expect(turnStartLog?.turnState?.enemies.map(enemy => enemy.name)).toEqual(['Lv1 オーク兵A', 'Lv1 オーク兵B'])
+    expect(attackLog?.targets[0]?.targetName).toBe('Lv1 オーク兵A')
   })
 
   it('ファイヤーボール2回は1戦闘で2回使える', () => {
@@ -1825,7 +1825,7 @@ describe('BattleSystem — 隊列統合テスト', () => {
 
   it('前列の敵が後列より多くダメージを受ける（統計的検証）', () => {
     // 3列の敵に攻撃して、ダメージの分布を確認
-    const damageByName: Record<string, number> = { '前列': 0, '中列': 0, '後列': 0 }
+    const damageByName: Record<string, number> = { 'Lv1 前列': 0, 'Lv1 中列': 0, 'Lv1 後列': 0 }
 
     for (let seed = 0; seed < 100; seed++) {
       const allies = [createTestGoblin({
@@ -1851,7 +1851,7 @@ describe('BattleSystem — 隊列統合テスト', () => {
     }
 
     // 3列: 1/2, 1/4, 1/4 → 前列が最もダメージを受ける
-    expect(damageByName['前列']).toBeGreaterThan(damageByName['中列'])
-    expect(damageByName['前列']).toBeGreaterThan(damageByName['後列'])
+    expect(damageByName['Lv1 前列']).toBeGreaterThan(damageByName['Lv1 中列'])
+    expect(damageByName['Lv1 前列']).toBeGreaterThan(damageByName['Lv1 後列'])
   })
 })

--- a/goblin_native/src/presentation/contexts/battleLogStore.ts
+++ b/goblin_native/src/presentation/contexts/battleLogStore.ts
@@ -1,17 +1,18 @@
-import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
+import type { BattleLogEntry, BattleLogMeta, Goblin } from '@/shared/types'
 
 interface StoredBattleLog {
   log: BattleLogEntry[]
   meta?: BattleLogMeta
+  partySnapshot?: Goblin[]
 }
 
 const battleLogStore = new Map<string, StoredBattleLog>()
 let logCounter = 0
 
-export const storeBattleLog = (log: BattleLogEntry[], meta?: BattleLogMeta): string => {
+export const storeBattleLog = (log: BattleLogEntry[], meta?: BattleLogMeta, partySnapshot?: Goblin[]): string => {
   logCounter += 1
   const id = `${Date.now()}-${logCounter}`
-  battleLogStore.set(id, { log, meta })
+  battleLogStore.set(id, { log, meta, partySnapshot })
   return id
 }
 


### PR DESCRIPTION
## Summary
- 戦闘ログで敵・味方の名前の前に `Lv{レベル}` を表示するようにした
- 味方キャラクターの行動ログ（攻撃/呪文/バリア/リジェン）にキャラクター画像（28x28）を表示するようにした
- `battleLogStore` に `partySnapshot` を保存し、戦闘ログ画面で `actorId` からゴブリン画像を解決できるようにした

## Test plan
- [x] 既存テスト全222件パス
- [x] 型チェック（`tsc --noEmit`）パス
- [ ] 遠征後の戦闘ログ画面で味方の行動ログにキャラクター画像が表示されることを確認
- [ ] 敵の行動ログには画像が表示されないことを確認
- [ ] 味方・敵ともに名前の前にLvが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)