### PR TITLE
feat(reward): PT Gold倍率表示にスキル補正を反映

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -11,6 +11,7 @@ import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import { getGoldBonusPercentFromSkills } from '@/shared/data/characterSkills'
 import { normalizePartyRewardMultipliers } from '@/shared/types'
 import type { Party, Goblin, Dungeon, DungeonTier, ExpeditionRequest, ExpeditionRecord } from '@/shared/types'
 
@@ -90,12 +91,18 @@ const PartyCard = memo(function PartyCard({
 
   const partyRewardText = useMemo(() => {
     const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
+    // スキル由来のGoldボーナスは PT 内で1つのみ有効（最大値）
+    const maxGoldBonusPercent = members.reduce(
+      (max, member) => Math.max(max, getGoldBonusPercentFromSkills(member.skills)),
+      0,
+    )
+    const goldMultiplier = multipliers.gold * (1 + maxGoldBonusPercent / 100)
     return t('ui.formation.index.rewardText', {
-      gold: formatMultiplier(multipliers.gold),
+      gold: formatMultiplier(goldMultiplier),
       rare: formatMultiplier(multipliers.rare),
       title: formatMultiplier(multipliers.title),
     })
-  }, [party.rewardMultipliers, t])
+  }, [party.rewardMultipliers, members, t])
 
   // 6スロット分の配列を作成
   const slots = useMemo(() => {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -9,6 +9,7 @@ import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import { getGoldBonusPercentFromSkills } from '@/shared/data/characterSkills'
 import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '@/shared/types'
 import type { ExpeditionRequest, Goblin, Dungeon, Party, DungeonTier } from '@/shared/types'
 import { getDungeonDescription, getDungeonName, getReturnPolicyLabel } from '@/shared/i18n/entityLocalization'
@@ -139,12 +140,18 @@ export default function ExpeditionPreparationScreen() {
   const partyRewardText = useMemo(() => {
     if (!party) return ''
     const multipliers = normalizePartyRewardMultipliers(party.rewardMultipliers)
+    // スキル由来のGoldボーナスは PT 内で1つのみ有効（最大値）
+    const maxGoldBonusPercent = partyMembers.reduce(
+      (max, member) => Math.max(max, getGoldBonusPercentFromSkills(member.skills)),
+      0,
+    )
+    const goldMultiplier = multipliers.gold * (1 + maxGoldBonusPercent / 100)
     return t('ui.formation.preparation.rewardText', {
-      gold: formatMultiplier(multipliers.gold),
+      gold: formatMultiplier(goldMultiplier),
       rare: formatMultiplier(multipliers.rare),
       title: formatMultiplier(multipliers.title),
     })
-  }, [party, t])
+  }, [party, partyMembers, t])
 
   // 6スロット分の配列を作成
   const slots = useMemo(() => {

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -127,6 +127,7 @@ export default function ExpeditionResultScreen() {
   const isSuccess = replay?.summary.success ?? false
   const expGained = replay?.summary.xpGained ?? 0
   const goldGained = replay?.summary.goldGained ?? 0
+  const goldMultiplier = replay?.summary.goldMultiplier ?? 1
   const treasureDrops = replay?.summary.treasureDrops ?? []
 
   useEffect(() => {
@@ -250,7 +251,14 @@ export default function ExpeditionResultScreen() {
 
         <View style={styles.section}>
           <Text style={styles.summaryText}>{t('ui.result.gainedXp', { value: expGained.toLocaleString() })}</Text>
-          <Text style={styles.summaryText}>{t('ui.result.gainedGold', { value: goldGained.toLocaleString() })}</Text>
+          <Text style={styles.summaryText}>
+            {goldMultiplier > 1
+              ? t('ui.result.gainedGoldWithMultiplier', {
+                  value: goldGained.toLocaleString(),
+                  multiplier: goldMultiplier.toFixed(1),
+                })
+              : t('ui.result.gainedGold', { value: goldGained.toLocaleString() })}
+          </Text>
         </View>
 
         {treasureDrops.length > 0 && (

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -732,12 +732,14 @@ export class ExpeditionEngine {
     )
 
     const goldGained = Math.floor(baseGoldGained * goldMultiplier * skillGoldMultiplier)
+    const totalGoldMultiplier = goldMultiplier * skillGoldMultiplier
 
     return {
       success,
       maxFloorReached,
       xpGained,
       goldGained,
+      goldMultiplier: totalGoldMultiplier,
       casualties,
       treasureDrops: treasureDrops.length > 0 ? treasureDrops : undefined,
     }

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -95,6 +95,7 @@ const en = {
       partyDefeated: 'The party was wiped out.',
       gainedXp: 'Gained {{value}} XP',
       gainedGold: 'Gained {{value}} Gold',
+      gainedGoldWithMultiplier: 'Gained {{value}} Gold (×{{multiplier}})',
       items: 'Items Obtained',
       unlockedArea: 'Unlocked next area: "{{name}}"',
       storyUnlocked: 'A new story has been unlocked',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -95,6 +95,7 @@ const ja = {
       partyDefeated: 'パーティは全滅しました。',
       gainedXp: '経験値 {{value}} XP',
       gainedGold: '{{value}} Gold を獲得',
+      gainedGoldWithMultiplier: '{{value}} Gold を獲得 (×{{multiplier}})',
       items: '獲得アイテム',
       unlockedArea: '次のエリア「{{name}}」が解放されました',
       storyUnlocked: '新しい物語が解放されました',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -95,6 +95,7 @@ const ko = {
       partyDefeated: '파티가 전멸했습니다.',
       gainedXp: '경험치 {{value}} XP 획득',
       gainedGold: '{{value}} Gold 획득',
+      gainedGoldWithMultiplier: '{{value}} Gold 획득 (×{{multiplier}})',
       items: '획득 아이템',
       unlockedArea: '다음 지역 "{{name}}"이 해금되었습니다',
       storyUnlocked: '새로운 이야기가 해금되었습니다',

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -100,6 +100,7 @@ export interface RewardSummary {
   maxFloorReached: number
   xpGained: number
   goldGained: number
+  goldMultiplier?: number  // PT倍率×スキル補正の合成値（Goldログ表示用）
   casualties: string[]
   treasureDrops?: TreasureDrop[]  // 宝箱から獲得した装備
   memberLevelUps?: MemberLevelUp[]  // 遠征完了時に確定したレベルアップ情報


### PR DESCRIPTION
## Summary
- ゴブリンシーフの「取得Gold +50%」スキル補正を編成画面のPTカードと遠征準備画面のゴールド倍率表示に反映（G1.0倍 → G1.5倍 など）
- 遠征結果画面のGold獲得ログに倍率が1超のときのみ「(×1.5)」を併記
- `RewardSummary.goldMultiplier` を追加し、PT倍率×スキル補正の合成値を保存

## Background
Gold倍率の計算自体は既に `ExpeditionEngine.calculateRewardSummary` で正しく適用されていましたが、UI側ではPTが保持する `rewardMultipliers.gold` のみを表示していたため、シーフを編成しても `G1.0倍` のまま変化しませんでした。

## Test plan
- [ ] 編成画面のPTカードでシーフを編成した際に `G1.5倍` と表示されること
- [ ] 遠征準備画面でも同様に倍率が反映されること
- [ ] 遠征結果画面でシーフがいる場合に `○○ Gold を獲得 (×1.5)` と表示されること
- [ ] シーフ未編成時は従来通り `G1.0倍` / `○○ Gold を獲得` のみが表示されること
- [x] `npx tsc --noEmit` 通過
- [x] `npm test` 通過 (222 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)