### PR TITLE
fix(battle): 遠征戦闘で戦闘行動率設定が反映されない不具合を修正

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -122,9 +122,6 @@ export default function BattleLogScreen() {
                       <Text style={styles.logTitle}>
                         {t('ui.formation.battleLog.defendTitle', { actor: entry.actorName, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
                       </Text>
-                      <Text style={styles.logText}>
-                        {t('ui.formation.battleLog.defendSummary', { row: entry.actorRow, actor: entry.actorName })}
-                      </Text>
                     </View>
                   </View>
                 </View>

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -380,6 +380,7 @@ export class ExpeditionEngine {
         factors: goblin.factors || [],
         variantFactorId: goblin.variantFactorId,
         spells: goblin.spells,
+        battleActionPolicy: goblin.battleActionPolicy,
         level: goblin.level,
         avatar: goblin.avatar,
       }
@@ -558,6 +559,7 @@ export class ExpeditionEngine {
       factors: member.factors,
       variantFactorId: member.variantFactorId,
       spells: member.spells,
+      battleActionPolicy: member.battleActionPolicy,
     } as Goblin))
 
     // 各メンバーの現在HPを配列で渡す

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1683,6 +1683,46 @@ describe('spell charges', () => {
     expect(result.detailedLog.some(log => log.actorId === '1' && log.action === '通常攻撃')).toBe(false)
   })
 
+  it('遠征戦闘でも攻撃行動率0のユニットは防御する', () => {
+    const partyState = [{
+      id: '1',
+      name: '防御役',
+      race: 'ゴブリン',
+      currentHP: 300,
+      maxHP: 300,
+      baseHP: 300,
+      atk: 80,
+      magicAtk: 0,
+      def: 10,
+      magicDef: 0,
+      agility: 100,
+      attackCount: 1,
+      accuracy: 999,
+      evasion: 0,
+      magicHeal: 0,
+      isKO: false,
+      isDead: false,
+      mods: [],
+      skills: [],
+      factors: [],
+      spells: [],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 100, mageMagicRate: 100 },
+      level: 1,
+      avatar: '/test.png',
+    }]
+    const enemy = createTestEnemy({
+      hp: 300,
+      atk: 1,
+      def: 1,
+      agility: 1,
+      attackCount: 0,
+    })
+    const combat = (new ExpeditionEngine(1) as any).resolveCombat(partyState, [[enemy]], { areaLevel: 1 }, false)
+
+    expect(combat.detailedLog.some((log: any) => log.actorId === '1' && log.action === '防御')).toBe(true)
+    expect(combat.detailedLog.some((log: any) => log.actorId === '1' && log.action === '通常攻撃')).toBe(false)
+  })
+
   it('防御後に受ける通常攻撃ダメージは半減する', () => {
     const defender = createTestGoblin({
       id: 1,

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -365,7 +365,6 @@ const en = {
         attackTitle: '{{actor}} attacked {{count}} times ({{hp}}/{{maxHp}} HP)',
         shieldBarrierSummary: 'Attack and breath damage taken by party members is halved',
         defendTitle: '{{actor}} defended ({{hp}}/{{maxHp}} HP)',
-        defendSummary: '[Row {{row}}] {{actor}} halves damage taken later this turn',
         spellSummary: '[Row {{row}}] {{actor}} used {{action}}! Hit {{count}} targets!',
         regenSummary: '{{actor}} regenerated {{heal}} HP!',
         healSummary: '[Row {{row}}] {{actor}} used {{action}}! Healed {{count}} targets!',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -365,7 +365,6 @@ const ja = {
         attackTitle: '{{actor}}の{{count}}回攻撃（{{hp}}/{{maxHp}}HP）',
         shieldBarrierSummary: 'パーティメンバーが受ける攻撃ダメージとブレスダメージが半減',
         defendTitle: '{{actor}}は防御した（{{hp}}/{{maxHp}}HP）',
-        defendSummary: '[列{{row}}] {{actor}}はこのターン中、以後に受けるダメージを半減する',
         spellSummary: '[列{{row}}] {{actor}}の{{action}}！{{count}}体にヒット！',
         regenSummary: '{{actor}}の回復能力！HPが{{heal}}回復した',
         healSummary: '[列{{row}}] {{actor}}の{{action}}！{{count}}体を回復！',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -365,7 +365,6 @@ const ko = {
         attackTitle: '{{actor}}의 {{count}}회 공격 ({{hp}}/{{maxHp}}HP)',
         shieldBarrierSummary: '파티원이 받는 공격 피해와 브레스 피해가 절반으로 감소',
         defendTitle: '{{actor}} 방어 ({{hp}}/{{maxHp}}HP)',
-        defendSummary: '[열{{row}}] {{actor}}은(는) 이번 턴 이후 받는 피해를 절반으로 줄인다',
         spellSummary: '[열{{row}}] {{actor}}의 {{action}}! {{count}}체에 히트!',
         regenSummary: '{{actor}}의 회복 능력! HP가 {{heal}} 회복되었다',
         healSummary: '[열{{row}}] {{actor}}의 {{action}}! {{count}}체를 회복!',

--- a/goblin_native/src/shared/types/Party.ts
+++ b/goblin_native/src/shared/types/Party.ts
@@ -3,6 +3,7 @@ import type { DungeonTier } from "./DungeonTier"
 import type { CharacterSkill } from "./CharacterSkill"
 import type { ModInstance } from "./Mod"
 import type { LearnedSpell } from "./Spell"
+import type { BattleActionPolicy } from "./Battle"
 
 export type PartyStatus = "idle" | "expedition"
 
@@ -72,6 +73,7 @@ export interface PartyState {
   factors: string[]   // 因子ID配列（ModStatCalculatorでボーナス計算に使用）
   variantFactorId?: string  // 亜種の元となった因子ID（追加効果適用に使用）
   spells?: LearnedSpell[]
+  battleActionPolicy?: BattleActionPolicy
   level: number
   avatar: string
 }


### PR DESCRIPTION
## Summary
- `PartyState` に `battleActionPolicy` を追加し、遠征エンジン内でも伝播するよう修正
- 戦闘ログの防御表示で重複していたサマリー行を削除しタイトルのみに整理
- 遠征戦闘でも攻撃行動率0のユニットが防御することを検証するテストを追加

## Test plan
- [ ] `npm test` が通ること
- [ ] `npx tsc --noEmit` で型エラーが出ないこと
- [ ] 遠征戦闘で戦闘行動率を調整したゴブリンの挙動を確認
- [ ] 戦闘ログの防御表示が1行のみになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)