### PR TITLE
feat(notification): 遠征帰還通知でアプリアイコンのバッジを表示

### DIFF
--- a/goblin_native/app/_layout.tsx
+++ b/goblin_native/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { View, ActivityIndicator, Text, StyleSheet, Pressable, Platform } from 'react-native'
+import { View, ActivityIndicator, Text, StyleSheet, Pressable, Platform, AppState } from 'react-native'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -42,13 +42,34 @@ export default function RootLayout() {
       if (Platform.OS !== 'web') {
         const { status } = await Notifications.getPermissionsAsync()
         if (status !== 'granted') {
-          await Notifications.requestPermissionsAsync()
+          await Notifications.requestPermissionsAsync({
+            ios: { allowAlert: true, allowBadge: true, allowSound: true },
+          })
+        }
+        // 起動時点でユーザーは既にアプリを見ているので、アプリアイコンのバッジはクリア
+        try {
+          await Notifications.setBadgeCountAsync(0)
+        } catch {
+          // バッジクリア失敗は致命ではない
         }
       }
       setStoresReady(true)
     }
     void init()
   }, [ready])
+
+  // フォアグラウンド復帰時にアプリアイコンのバッジをクリア
+  useEffect(() => {
+    if (Platform.OS === 'web') return
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        Notifications.setBadgeCountAsync(0).catch(() => {
+          // バッジクリア失敗は致命ではない
+        })
+      }
+    })
+    return () => subscription.remove()
+  }, [])
 
   if (error) {
     return (

--- a/goblin_native/src/presentation/hooks/useExpeditionNotification.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionNotification.ts
@@ -3,8 +3,9 @@ import { Platform } from 'react-native'
 import * as Notifications from 'expo-notifications'
 import type { ExpeditionRecord } from '../../shared/types'
 import i18n from '../../shared/i18n'
+import { useExpeditionStore } from '../stores/useExpeditionStore'
 
-// フォアグラウンド時は通知バナーを表示しない（アプリ内で結果が見えるため）
+// フォアグラウンド時は通知バナー・バッジを表示しない（アプリ内で結果が見えるため）
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: false,
@@ -17,6 +18,20 @@ Notifications.setNotificationHandler({
 
 function notificationId(expeditionId: string): string {
   return `expedition_${expeditionId}`
+}
+
+// 対象の帰還予定時刻までに帰還する予定のongoing遠征件数（対象自身含む）を算出
+function calcBadgeCountForReturnAt(returnTime: Date, selfId: string): number {
+  const records = useExpeditionStore.getState().expeditionRecords
+  const targetMs = returnTime.getTime()
+  let count = 1 // 自分自身
+  for (const rec of records) {
+    if (rec.id === selfId) continue
+    if (rec.status !== 'ongoing') continue
+    if (!rec.returnTime) continue
+    if (rec.returnTime.getTime() <= targetMs) count += 1
+  }
+  return count
 }
 
 export function useExpeditionNotification() {
@@ -42,12 +57,15 @@ export function useExpeditionNotification() {
         Math.floor((record.returnTime.getTime() - Date.now()) / 1000),
       )
 
+      const badge = calcBadgeCountForReturnAt(record.returnTime, record.id)
+
       await Notifications.scheduleNotificationAsync({
         identifier: notificationId(record.id),
         content: {
           title: i18n.t('ui.notification.expeditionTitle'),
           body: i18n.t('ui.notification.expeditionReturn', { partyName: record.partyName }),
           sound: true,
+          badge,
         },
         trigger: Platform.OS === 'web'
           ? null
@@ -59,9 +77,17 @@ export function useExpeditionNotification() {
 
   /**
    * フォアグラウンドで遠征完了を処理した場合、スケジュール済み通知をキャンセルする
+   * アプリ内で処理した以上バッジに残す意味はないので合わせて0にする
    */
   const cancelExpeditionNotification = useCallback(async (expeditionId: string) => {
     await Notifications.cancelScheduledNotificationAsync(notificationId(expeditionId))
+    if (Platform.OS !== 'web') {
+      try {
+        await Notifications.setBadgeCountAsync(0)
+      } catch {
+        // バッジクリア失敗は致命ではない
+      }
+    }
   }, [])
 
   return {


### PR DESCRIPTION
## Summary
- 遠征帰還のローカル通知がiOSホーム画面のアプリバッジに反映されない不具合を修正
- 通知 payload に \`badge\` を付与し、iOSパーミッション要求に \`allowBadge\` を明示
- 起動時 / フォアグラウンド復帰時 / アプリ内で結果を消化した時にバッジを 0 にクリア

## 実装メモ
- \`badge\` 値は「その遠征の帰還時刻までに帰還予定の ongoing 遠征件数（対象自身含む）」として算出
- \`AppState\` の active 遷移を監視してバッジクリアを実行

## Test plan
- [ ] 実機でアプリを閉じた状態で遠征を出して、帰還時刻にアイコンバッジが出ることを確認
- [ ] 複数遠征を並行して出した場合、順次バッジの数字が増えていくことを確認
- [ ] アプリをフォアグラウンドに戻すとバッジが消えることを確認
- [ ] アプリ内で遠征結果を消化するとバッジがクリアされることを確認
- [ ] iOS 設定 → 通知 → gobkin の「バッジ」トグルが有効になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)