### PR TITLE
feat(studio): ゴブリンキングダムのデータ編集/シミュレーション用Webツール

### DIFF
--- a/goblin_native/src/shared/data/expeditionArea/dragon_volcano_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/dragon_volcano_1.json
@@ -1,7 +1,7 @@
 {
   "id": "dragon_volcano_1",
   "name": "ドラゴンの火山巣",
-  "areaLevel": 8,
+  "areaLevel": 48,
   "floors": 3,
   "baseDurationSec": 15600,
   "description": "王城地下から通じる火山巣。王国が最後に解き放ったドラゴンを越えなければ玉座には届かない。",

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_1",
   "name": "ドワーフ坑道・入口",
-  "areaLevel": 5,
+  "areaLevel": 25,
   "floors": 2,
   "baseDurationSec": 6000,
   "description": "坑道の入口。ドワーフ坑夫たちが工具を武器に抵抗してくる。",

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_2",
   "name": "ドワーフ坑道・深層",
-  "areaLevel": 5,
+  "areaLevel": 27,
   "floors": 2,
   "baseDurationSec": 6120,
   "description": "坑道深部。戦士やルーン鍛冶師が待ち構える。",

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_3",
   "name": "ドワーフ坑道・最深部",
-  "areaLevel": 5,
+  "areaLevel": 29,
   "floors": 2,
   "baseDurationSec": 6300,
   "description": "坑道の最深部。坑道守護者と擲弾兵に守られた鍛冶王が待ち受ける。鍛冶能力をゴブリン国家に取り込め。",

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_1.json
@@ -1,7 +1,7 @@
 {
   "id": "elf_forest_1",
   "name": "エルフの隠れ里・外縁",
-  "areaLevel": 5,
+  "areaLevel": 45,
   "floors": 2,
   "baseDurationSec": 6900,
   "description": "隠れ里の外縁。森の斥候と射手が素早い攻撃を仕掛けてくる。",

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_2.json
@@ -1,7 +1,7 @@
 {
   "id": "elf_forest_2",
   "name": "エルフの隠れ里・内部",
-  "areaLevel": 5,
+  "areaLevel": 45,
   "floors": 2,
   "baseDurationSec": 7020,
   "description": "里の内部。精霊使いや月の衛士が守りを固めている。",

--- a/goblin_native/src/shared/data/expeditionArea/elf_forest_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/elf_forest_3.json
@@ -1,7 +1,7 @@
 {
   "id": "elf_forest_3",
   "name": "エルフの隠れ里・中枢",
-  "areaLevel": 5,
+  "areaLevel": 45,
   "floors": 2,
   "baseDurationSec": 7200,
   "description": "里の中枢。古樹の戦士に守られた森の番人が最後の壁として立ちはだかる。魔法の力を手に入れろ。",

--- a/goblin_native/src/shared/data/expeditionArea/harpy_cliff_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/harpy_cliff_1.json
@@ -1,7 +1,7 @@
 {
   "id": "harpy_cliff_1",
   "name": "ハーピィの崖巣",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 7200,
   "description": "沼地を抜けた断崖。空から急襲するハーピィたちが峡谷への道を塞いでいる。",

--- a/goblin_native/src/shared/data/expeditionArea/hobbit_hills_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/hobbit_hills_1.json
@@ -1,7 +1,7 @@
 {
   "id": "hobbit_hills_1",
   "name": "ホビットの丘陵村",
-  "areaLevel": 4,
+  "areaLevel": 25,
   "floors": 2,
   "baseDurationSec": 5700,
   "description": "辺境の村の先に広がる丘陵地。身軽なホビットの斥候と投石手が補給路を守っている。",

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_1.json
@@ -1,7 +1,7 @@
 {
   "id": "human_fortress_1",
   "name": "人間の城塞・外壁",
-  "areaLevel": 7,
+  "areaLevel": 47,
   "floors": 2,
   "baseDurationSec": 9900,
   "description": "城塞の外壁。騎士と宮廷魔術師が城壁から迎え撃つ。",

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_2.json
@@ -1,7 +1,7 @@
 {
   "id": "human_fortress_2",
   "name": "人間の城塞・城内",
-  "areaLevel": 7,
+  "areaLevel": 47,
   "floors": 2,
   "baseDurationSec": 10200,
   "description": "城内へ侵入。重装騎兵と攻城兵器操手が待ち構える。",

--- a/goblin_native/src/shared/data/expeditionArea/human_fortress_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_fortress_3.json
@@ -1,7 +1,7 @@
 {
   "id": "human_fortress_3",
   "name": "人間の城塞・本丸",
-  "areaLevel": 7,
+  "areaLevel": 47,
   "floors": 2,
   "baseDurationSec": 10500,
   "description": "城塞の本丸。精鋭近衛兵に守られた城塞司令官との最終決戦。異種族の力を総動員して突破せよ。",

--- a/goblin_native/src/shared/data/expeditionArea/human_village.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_village.json
@@ -1,7 +1,7 @@
 {
   "id": "human_village",
   "name": "辺境の村",
-  "areaLevel": 18,
+  "areaLevel": 24,
   "floors": 4,
   "baseDurationSec": 5400,
   "description": "村の中心部。自警団長が最後の砦として立ちはだかる。制圧してゴブリン国家の礎を築け。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_1",
   "name": "リザードマンの沼砦・浅瀬",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 6300,
   "description": "沼砦の浅瀬。沼の戦士と毒牙兵が水際で襲いかかる。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_2",
   "name": "リザードマンの沼砦・深沼",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 6420,
   "description": "砦の深部。呪術師や暗殺者が潜む危険な沼地。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_3",
   "name": "リザードマンの沼砦・本拠",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 6600,
   "description": "砦の本拠。鱗の重装兵に守られた沼王が待ち受ける。水棲戦力を手に入れろ。",

--- a/goblin_native/src/shared/data/expeditionArea/minotaur_labyrinth_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/minotaur_labyrinth_1.json
@@ -1,7 +1,7 @@
 {
   "id": "minotaur_labyrinth_1",
   "name": "ミノタウロス迷宮",
-  "areaLevel": 7,
+  "areaLevel": 47,
   "floors": 2,
   "baseDurationSec": 8700,
   "description": "城塞へ続く古い迷宮。重い斧を振るうミノタウロスの戦士たちが侵入者を迷路へ誘い込む。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_1",
   "name": "オークの野営地・前哨",
-  "areaLevel": 12,
+  "areaLevel": 20,
   "floors": 2,
   "baseDurationSec": 2160,
   "description": "オーク野営地の前哨。前線のブルートと、その後方に控える兵たちが見張りに立っている。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_2",
   "name": "オークの野営地・陣営",
-  "areaLevel": 13,
+  "areaLevel": 21,
   "floors": 2,
   "baseDurationSec": 2340,
   "description": "野営地の陣営部。前に出るブルートを壁に、兵たちが厚く控える。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_3",
   "name": "オークの野営地・本陣",
-  "areaLevel": 14,
+  "areaLevel": 22,
   "floors": 2,
   "baseDurationSec": 2700,
   "description": "野営地の本陣。ブルートが陣を固め、奥にはオーク遠征隊長が控える。攻略すれば拠点として利用可能。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_fortress_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_fortress_1.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_fortress_1",
   "name": "オークの砦",
-  "areaLevel": 15,
+  "areaLevel": 75,
   "floors": 3,
   "baseDurationSec": 10800,
   "description": "野営地の奥に築かれた石造りの砦。解放直後の戦力ではまず歯が立たない。オークの重装兵に加え、傭兵として雇われたトロルが門を守っている。",

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_1.json
@@ -1,7 +1,7 @@
 {
   "id": "royal_capital_1",
   "name": "王都決戦・城門",
-  "areaLevel": 8,
+  "areaLevel": 160,
   "floors": 2,
   "baseDurationSec": 13200,
   "description": "王都の城門を突破する。近衛騎士と大魔導師が立ちはだかる。",

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_2.json
@@ -1,7 +1,7 @@
 {
   "id": "royal_capital_2",
   "name": "王都決戦・王城内部",
-  "areaLevel": 8,
+  "areaLevel": 170,
   "floors": 2,
   "baseDurationSec": 13500,
   "description": "王城内部へ侵攻。聖騎士や王国禁衛隊が最後の防衛線を張る。",

--- a/goblin_native/src/shared/data/expeditionArea/royal_capital_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/royal_capital_3.json
@@ -1,7 +1,7 @@
 {
   "id": "royal_capital_3",
   "name": "王都決戦・玉座の間",
-  "areaLevel": 8,
+  "areaLevel": 180,
   "floors": 2,
   "baseDurationSec": 18000,
   "description": "最終決戦。勇者と人間王が最後の壁として立ちはだかる。ゴブリンキングダムの完成をかけた決戦。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_1",
   "name": "vs討伐隊防衛戦・先遣隊",
-  "areaLevel": 3,
+  "areaLevel": 40,
   "floors": 3,
   "baseDurationSec": 5700,
   "description": "辺境城から先遣隊が接近。正規兵と弓兵を中心とした少数部隊を迎撃せよ。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_2",
   "name": "vs討伐隊防衛戦・本隊",
-  "areaLevel": 3,
+  "areaLevel": 42,
   "floors": 3,
   "baseDurationSec": 5820,
   "description": "討伐隊の本隊が到着。騎士・魔術師・クレリックを含む正規編成で攻勢が激化する。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_3",
   "name": "vs討伐隊防衛戦・決戦",
-  "areaLevel": 3,
+  "areaLevel": 44,
   "floors": 3,
   "baseDurationSec": 6000,
   "description": "辺境城騎士団長が自ら前線に立つ。精鋭部隊との最終決戦。撃退せよ。",

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_1.json
@@ -1,7 +1,7 @@
 {
   "id": "troll_canyon_1",
   "name": "トロルの峡谷・入口",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 7800,
   "description": "峡谷の入口。トロルが単体で徘徊している。一体でも油断ならない巨躯。",

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_2.json
@@ -1,7 +1,7 @@
 {
   "id": "troll_canyon_2",
   "name": "トロルの峡谷・深部",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 7920,
   "description": "峡谷の深部。洞窟トロルや投石トロルが群れをなす。",

--- a/goblin_native/src/shared/data/expeditionArea/troll_canyon_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/troll_canyon_3.json
@@ -1,7 +1,7 @@
 {
   "id": "troll_canyon_3",
   "name": "トロルの峡谷・暴君の間",
-  "areaLevel": 6,
+  "areaLevel": 46,
   "floors": 2,
   "baseDurationSec": 8100,
   "description": "峡谷の最奥。巨大トロルの群れの先に、峡谷の暴君が待ち受ける。再生能力を手に入れろ。",

--- a/goblin_native/src/shared/data/expeditionArea/vampire_castle_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/vampire_castle_1.json
@@ -1,7 +1,7 @@
 {
   "id": "vampire_castle_1",
   "name": "ヴァンパイアの古城",
-  "areaLevel": 8,
+  "areaLevel": 55,
   "floors": 2,
   "baseDurationSec": 11700,
   "description": "王都へ向かう街道を見下ろす古城。夜の眷属を率いるヴァンパイアが影から進軍を阻む。",

--- a/tools/studio/.gitignore
+++ b/tools/studio/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.vite
+*.tsbuildinfo
+
+# ローカルで保存するPTプリセット等。チームで共有したければこの行を外してください
+data/

--- a/tools/studio/README.md
+++ b/tools/studio/README.md
@@ -1,0 +1,29 @@
+# Goblin Studio
+
+ゴブリンキングダムのダンジョン/敵データを閲覧・編集し、シミュレーションを実行するローカル開発ツール。
+
+## 前提
+- Node.js 22 系（リポジトリ直下の `.node-version` に合わせる）
+- `../../goblin_native/src/` を TypeScript / Vite から直接参照するため、同リポジトリに配置されている必要がある
+
+## セットアップ
+```bash
+cd tools/studio
+npm install
+npm run dev
+```
+
+デフォルトで http://localhost:5180 で起動する。
+
+## データ保存について
+- ダンジョン/敵データ: `/api/dungeons` 経由で `../../goblin_native/src/shared/data/expeditionArea/*.json` と `../../goblin_native/src/shared/data/enemy/*.json` を直接読み書きする。変更は即 JSON に書き戻され、`git diff` で確認・コミット可能
+- PTプリセット: `/api/party-presets` 経由で `tools/studio/data/party-presets.json` に保存される。デフォルトで `.gitignore` 済み（個人作業用）。チームで共有したい場合は `.gitignore` から `data/` を外してコミット
+- セーブデータ（SQLite / バックアップJSON）には一切書き込まない。バックアップは読み取り専用でメモリ上のみ保持
+
+## 実装ロードマップ
+- [x] Step 1: scaffolding（一覧/詳細・読み取り確認）
+- [x] Step 2: 閲覧 UI 強化（敵一覧・パターン表示）
+- [x] Step 3: 編集＋保存（エリア設定・敵ステータス・パターン）
+- [x] Step 4: エンカウントテーブル編集 UI 強化（ドラッグ配置・敵パレット）
+- [x] Step 5: PT 編成（バックアップ JSON 読み込み対応）
+- [x] Step 6: ダンジョン別シミュレーション（ExpeditionEngine 直接実行）

--- a/tools/studio/index.html
+++ b/tools/studio/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Goblin Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tools/studio/package-lock.json
+++ b/tools/studio/package-lock.json
@@ -1,0 +1,1906 @@
+{
+  "name": "goblin-studio",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goblin-studio",
+      "version": "0.0.1",
+      "dependencies": {
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.1.1",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.3",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/studio/package.json
+++ b/tools/studio/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "goblin-studio",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.1.1",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.7"
+  }
+}

--- a/tools/studio/src/App.tsx
+++ b/tools/studio/src/App.tsx
@@ -1,0 +1,34 @@
+import { Link, Route, Routes } from 'react-router-dom'
+
+import { DungeonList } from './pages/DungeonList'
+import { DungeonDetail } from './pages/DungeonDetail'
+import { PartyPage } from './pages/PartyPage'
+import { SimulatePage } from './pages/SimulatePage'
+import { PartyStoreProvider } from './stores/partyStore'
+
+export function App() {
+  return (
+    <PartyStoreProvider>
+      <div className="app">
+        <header className="app-header">
+          <h1>
+            <Link to="/">Goblin Studio</Link>
+          </h1>
+          <nav>
+            <Link to="/">ダンジョン</Link>
+            <Link to="/party">PT編成</Link>
+            <Link to="/simulate">シミュレーション</Link>
+          </nav>
+        </header>
+        <main className="app-main">
+          <Routes>
+            <Route path="/" element={<DungeonList />} />
+            <Route path="/dungeons/:areaId" element={<DungeonDetail />} />
+            <Route path="/party" element={<PartyPage />} />
+            <Route path="/simulate" element={<SimulatePage />} />
+          </Routes>
+        </main>
+      </div>
+    </PartyStoreProvider>
+  )
+}

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Plugin } from 'vite'
+
+interface Options {
+  appSrc: string
+  dataDir: string
+}
+
+interface DungeonSummary {
+  areaId: string
+  name: string
+  areaLevel: number
+  floors: number
+  baseDurationSec: number
+  enemyCount: number
+  patternCount: number
+}
+
+export function dataApiPlugin(options: Options): Plugin {
+  const areaDir = path.join(options.appSrc, 'shared', 'data', 'expeditionArea')
+  const enemyDir = path.join(options.appSrc, 'shared', 'data', 'enemy')
+  const presetsFile = path.join(options.dataDir, 'party-presets.json')
+
+  return {
+    name: 'studio-data-api',
+    configureServer(server) {
+      server.middlewares.use('/api/dungeons', async (req, res) => {
+        try {
+          const url = new URL(req.url ?? '/', 'http://localhost')
+          const segments = url.pathname.split('/').filter(Boolean)
+
+          if (segments.length === 0) {
+            if (req.method === 'GET') {
+              return json(res, 200, await listDungeons(areaDir, enemyDir))
+            }
+            return json(res, 405, { error: 'Method not allowed' })
+          }
+
+          const areaId = segments[0]
+          if (!isSafeId(areaId)) {
+            return json(res, 400, { error: 'Invalid areaId' })
+          }
+
+          if (req.method === 'GET') {
+            return json(res, 200, await readDungeon(areaDir, enemyDir, areaId))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            return json(res, 200, await writeDungeon(areaDir, enemyDir, areaId, body))
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          const status = message.startsWith('NOT_FOUND') ? 404 : 500
+          return json(res, status, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/party-presets', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            return json(res, 200, await readPresets(presetsFile))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            await writePresets(presetsFile, body)
+            return json(res, 200, { ok: true })
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          return json(res, 500, { error: message })
+        }
+      })
+    },
+  }
+}
+
+async function readPresets(filePath: string): Promise<unknown[]> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) return parsed
+    if (parsed && Array.isArray((parsed as { presets?: unknown[] }).presets)) {
+      return (parsed as { presets: unknown[] }).presets
+    }
+    return []
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw err
+  }
+}
+
+async function writePresets(filePath: string, body: unknown): Promise<void> {
+  if (!Array.isArray(body)) {
+    throw new Error('Body must be an array of presets')
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const formatted = `${JSON.stringify(body, null, 2)}\n`
+  await fs.writeFile(filePath, formatted, 'utf8')
+}
+
+async function listDungeons(areaDir: string, enemyDir: string): Promise<DungeonSummary[]> {
+  const files = (await fs.readdir(areaDir)).filter((f) => f.endsWith('.json'))
+  const summaries = await Promise.all(
+    files.map(async (file) => {
+      const areaId = file.replace(/\.json$/, '')
+      const area = await readJson(path.join(areaDir, file))
+      if (!isAreaConfigShape(area)) return null
+      const enemyPath = path.join(enemyDir, file)
+      let enemyCount = 0
+      let patternCount = 0
+      try {
+        const enemy = await readJson(enemyPath)
+        enemyCount = Array.isArray(enemy.enemies) ? enemy.enemies.length : 0
+        patternCount = Array.isArray(enemy.patterns) ? enemy.patterns.length : 0
+      } catch {
+        // 敵DBが無いエリアは無視
+      }
+      return {
+        areaId,
+        name: String(area.name ?? areaId),
+        areaLevel: Number(area.areaLevel ?? 0),
+        floors: Number(area.floors ?? 0),
+        baseDurationSec: Number(area.baseDurationSec ?? 0),
+        enemyCount,
+        patternCount,
+      } satisfies DungeonSummary
+    }),
+  )
+  const filtered = summaries.filter((s): s is DungeonSummary => s !== null)
+  filtered.sort((a, b) => a.areaLevel - b.areaLevel || a.areaId.localeCompare(b.areaId))
+  return filtered
+}
+
+function isAreaConfigShape(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return typeof record.id === 'string' && typeof record.encounter === 'object'
+}
+
+async function readDungeon(areaDir: string, enemyDir: string, areaId: string) {
+  const areaPath = path.join(areaDir, `${areaId}.json`)
+  const enemyPath = path.join(enemyDir, `${areaId}.json`)
+  const [area, enemy] = await Promise.all([
+    readJson(areaPath).catch(() => {
+      throw new Error(`NOT_FOUND: area ${areaId}`)
+    }),
+    readJson(enemyPath).catch(() => null),
+  ])
+  return { areaId, area, enemy }
+}
+
+async function writeDungeon(
+  areaDir: string,
+  enemyDir: string,
+  areaId: string,
+  body: unknown,
+) {
+  if (!body || typeof body !== 'object') {
+    throw new Error('Invalid body')
+  }
+  const { area, enemy } = body as { area?: unknown; enemy?: unknown }
+  const writes: Promise<void>[] = []
+  if (area !== undefined) {
+    writes.push(writeJson(path.join(areaDir, `${areaId}.json`), area))
+  }
+  if (enemy !== undefined && enemy !== null) {
+    writes.push(writeJson(path.join(enemyDir, `${areaId}.json`), enemy))
+  }
+  await Promise.all(writes)
+  return { ok: true }
+}
+
+async function readJson(filePath: string): Promise<any> {
+  const raw = await fs.readFile(filePath, 'utf8')
+  return JSON.parse(raw)
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  const formatted = `${JSON.stringify(value, null, 2)}\n`
+  await fs.writeFile(filePath, formatted, 'utf8')
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer)
+  }
+  const raw = Buffer.concat(chunks).toString('utf8')
+  return raw.length === 0 ? undefined : JSON.parse(raw)
+}
+
+function json(res: ServerResponse, status: number, body: unknown) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  res.end(JSON.stringify(body))
+}
+
+function isSafeId(id: string): boolean {
+  return /^[a-z0-9_]+$/.test(id)
+}

--- a/tools/studio/src/components/AreaSettingsEditor.tsx
+++ b/tools/studio/src/components/AreaSettingsEditor.tsx
@@ -1,0 +1,249 @@
+import type { AreaConfig } from '../lib/schema'
+import type { FieldSize } from './fields'
+import {
+  FieldRow,
+  NumberField,
+  OptionalNumberField,
+  OptionalTextField,
+  TextField,
+} from './fields'
+
+type EventKey = 'battle' | 'exploring' | 'trap' | 'npc'
+
+export function AreaSettingsEditor({
+  area,
+  onChange,
+}: {
+  area: AreaConfig
+  onChange: (updater: (prev: AreaConfig) => AreaConfig) => void
+}) {
+  const w = area.encounter.eventWeights
+  const totalWeight =
+    (w.battle ?? 0) + (w.exploring ?? 0) + (w.trap ?? 0) + (w.npc ?? 0)
+
+  const setTopField = <K extends keyof AreaConfig>(key: K, value: AreaConfig[K]) => {
+    onChange((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const setEncounterField = <K extends keyof AreaConfig['encounter']>(
+    key: K,
+    value: AreaConfig['encounter'][K],
+  ) => {
+    onChange((prev) => ({
+      ...prev,
+      encounter: { ...prev.encounter, [key]: value },
+    }))
+  }
+
+  const setWeight = (key: EventKey, value: number | undefined) => {
+    onChange((prev) => {
+      const nextWeights = { ...prev.encounter.eventWeights }
+      if (value === undefined) {
+        if (key === 'battle' || key === 'exploring') {
+          nextWeights[key] = 0
+        } else {
+          delete nextWeights[key]
+        }
+      } else {
+        nextWeights[key] = value
+      }
+      return {
+        ...prev,
+        encounter: { ...prev.encounter, eventWeights: nextWeights },
+      }
+    })
+  }
+
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <h3>基本情報</h3>
+        <FieldRow>
+          <TextField
+            size="md"
+            label="id"
+            value={area.id}
+            onChange={(v) => setTopField('id', v)}
+          />
+          <TextField
+            size="lg"
+            label="name"
+            value={area.name}
+            onChange={(v) => setTopField('name', v)}
+          />
+          <NumberField
+            size="xs"
+            label="areaLevel"
+            value={area.areaLevel}
+            min={0}
+            onChange={(v) => setTopField('areaLevel', v)}
+          />
+          <NumberField
+            size="xs"
+            label="floors"
+            value={area.floors}
+            min={1}
+            onChange={(v) => setTopField('floors', v)}
+          />
+          <NumberField
+            size="sm"
+            label="baseDurationSec"
+            value={area.baseDurationSec}
+            min={1}
+            suffix="秒"
+            onChange={(v) => setTopField('baseDurationSec', v)}
+          />
+          <OptionalNumberField
+            size="sm"
+            label="moveSpeedScale"
+            value={area.moveSpeedScale}
+            min={0}
+            step={0.1}
+            onChange={(v) => setTopField('moveSpeedScale', v)}
+          />
+          <OptionalTextField
+            size="md"
+            label="unlockNext"
+            value={area.unlockNext}
+            onChange={(v) => setTopField('unlockNext', v)}
+          />
+          <OptionalTextField
+            size="lg"
+            label="description"
+            value={area.description}
+            onChange={(v) => setTopField('description', v)}
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <h3>エンカウント設定</h3>
+        <FieldRow>
+          <NumberField
+            size="sm"
+            label="perFloorEvents"
+            value={area.encounter.perFloorEvents}
+            min={1}
+            onChange={(v) => setEncounterField('perFloorEvents', v)}
+          />
+          <OptionalNumberField
+            size="sm"
+            label="pityTimerSec"
+            value={area.encounter.pityTimerSec}
+            min={0}
+            suffix="秒"
+            onChange={(v) => setEncounterField('pityTimerSec', v)}
+          />
+        </FieldRow>
+        <h4>イベント重み（合計 {totalWeight}）</h4>
+        <FieldRow>
+          <WeightRow
+            size="sm"
+            label="battle"
+            value={w.battle}
+            total={totalWeight}
+            onChange={(v) => setWeight('battle', v)}
+            required
+          />
+          <WeightRow
+            size="sm"
+            label="exploring"
+            value={w.exploring}
+            total={totalWeight}
+            onChange={(v) => setWeight('exploring', v)}
+            required
+          />
+          <WeightRow
+            size="sm"
+            label="trap"
+            value={w.trap}
+            total={totalWeight}
+            onChange={(v) => setWeight('trap', v)}
+          />
+          <WeightRow
+            size="sm"
+            label="npc"
+            value={w.npc}
+            total={totalWeight}
+            onChange={(v) => setWeight('npc', v)}
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <h3>enemyTable（パターン未使用時のフォールバック）</h3>
+        {(area.enemyTable ?? []).length === 0 ? (
+          <p className="subtle">未設定（パターンベースのエンカウントを利用）</p>
+        ) : (
+          <pre className="json-view">
+            {JSON.stringify(area.enemyTable, null, 2)}
+          </pre>
+        )}
+      </section>
+
+      {area.boss && (
+        <section className="card">
+          <h3>ボス</h3>
+          <FieldRow>
+            <TextField
+              size="md"
+              label="id"
+              value={area.boss.id}
+              onChange={(v) => setTopField('boss', { ...area.boss!, id: v })}
+            />
+            <NumberField
+              size="xs"
+              label="lvl"
+              value={area.boss.lvl}
+              min={0}
+              onChange={(v) => setTopField('boss', { ...area.boss!, lvl: v })}
+            />
+          </FieldRow>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function WeightRow({
+  label,
+  value,
+  total,
+  onChange,
+  required,
+  size,
+}: {
+  label: string
+  value: number | undefined
+  total: number
+  onChange: (v: number | undefined) => void
+  required?: boolean
+  size?: FieldSize
+}) {
+  const pct = total > 0 && value !== undefined ? ((value / total) * 100).toFixed(1) : '-'
+  return (
+    <label className={size ? `field field-size-${size}` : 'field'}>
+      <span className="field-label">
+        {label}
+        {!required && <span className="subtle"> (任意)</span>}
+      </span>
+      <span className="field-input">
+        <input
+          type="number"
+          value={value ?? ''}
+          placeholder={required ? '0' : '(未使用)'}
+          min={0}
+          onChange={(e) => {
+            const raw = e.target.value
+            if (required) {
+              onChange(Number(raw) || 0)
+            } else {
+              onChange(raw === '' ? undefined : Number(raw))
+            }
+          }}
+        />
+        <span className="field-suffix">{pct}%</span>
+      </span>
+    </label>
+  )
+}

--- a/tools/studio/src/components/BackupDropzone.tsx
+++ b/tools/studio/src/components/BackupDropzone.tsx
@@ -1,0 +1,73 @@
+import { useRef, useState } from 'react'
+
+import { usePartyStore } from '../stores/partyStore'
+
+export function BackupDropzone({ compact = false }: { compact?: boolean }) {
+  const { loadBackup, backupLoading } = usePartyStore()
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  const handleFile = (file: File | undefined | null) => {
+    if (!file) return
+    void loadBackup(file)
+  }
+
+  if (compact) {
+    return (
+      <>
+        <button
+          className="btn ghost"
+          onClick={() => inputRef.current?.click()}
+          disabled={backupLoading}
+        >
+          別のバックアップを読み込む
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="application/json,.json"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            handleFile(e.target.files?.[0])
+            e.target.value = ''
+          }}
+        />
+      </>
+    )
+  }
+
+  return (
+    <div
+      className={`dropzone ${dragging ? 'drag-over' : ''}`}
+      onDragOver={(ev) => {
+        ev.preventDefault()
+        setDragging(true)
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(ev) => {
+        ev.preventDefault()
+        setDragging(false)
+        handleFile(ev.dataTransfer.files[0])
+      }}
+      onClick={() => inputRef.current?.click()}
+    >
+      <p>
+        <strong>クリック</strong>してファイル選択、または JSON をここにドラッグ&ドロップ
+      </p>
+      <p className="subtle">
+        対応形式: ゴブリンキングダムのバックアップ JSON（<code>meta.app = "goblin_kingdom"</code>）
+      </p>
+      {backupLoading && <p className="subtle">読み込み中…</p>}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/json,.json"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          handleFile(e.target.files?.[0])
+          e.target.value = ''
+        }}
+      />
+    </div>
+  )
+}

--- a/tools/studio/src/components/BackupPartyList.tsx
+++ b/tools/studio/src/components/BackupPartyList.tsx
@@ -1,0 +1,65 @@
+import { usePartyStore } from '../stores/partyStore'
+import type { BackupGoblin } from '../lib/goblinMapper'
+
+export function BackupPartyList() {
+  const { backup, loadBackupParty, importBackupPartyAsPreset } = usePartyStore()
+  if (!backup || backup.parties.length === 0) return null
+
+  const goblinById = new Map(backup.goblins.map((g) => [g.id, g]))
+
+  return (
+    <section className="card">
+      <h3>バックアップ内のPT ({backup.parties.length})</h3>
+      <p className="subtle" style={{ margin: '0 0 0.5rem' }}>
+        ゲーム本体で作成済みのPTをそのまま読み込めます。
+      </p>
+      <ul className="preset-list">
+        {backup.parties.map((p) => {
+          const members = p.memberIds
+            .map((id) => goblinById.get(id))
+            .filter((g): g is BackupGoblin => g !== undefined)
+          return (
+            <li key={p.id} className="preset-item">
+              <div className="preset-info">
+                <div className="preset-name">{p.name}</div>
+                <div className="subtle">
+                  {p.memberIds.length}体
+                  {p.dungeonId ? ` · 遠征先: ${p.dungeonId}` : ''}
+                  {p.status && p.status !== 'idle' ? ` · ${p.status}` : ''}
+                </div>
+                {members.length > 0 && (
+                  <div className="subtle" style={{ marginTop: '0.2rem' }}>
+                    {members
+                      .map((g) => `${g.name}(Lv${g.level})`)
+                      .join(' / ')}
+                  </div>
+                )}
+                {members.length < p.memberIds.length && (
+                  <div className="save-error" style={{ marginTop: '0.3rem', padding: '0.3rem 0.5rem' }}>
+                    {p.memberIds.length - members.length}体のゴブリンがバックアップ内に見つかりません
+                  </div>
+                )}
+              </div>
+              <div className="preset-actions">
+                <button
+                  className="btn ghost small"
+                  onClick={() => loadBackupParty(p.id)}
+                  title="現在の編成に読み込む"
+                >
+                  読込
+                </button>
+                <button
+                  className="btn ghost small"
+                  onClick={() => importBackupPartyAsPreset(p.id)}
+                  title="プリセットとして永続化"
+                >
+                  プリセット化
+                </button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/tools/studio/src/components/EnemyEditor.tsx
+++ b/tools/studio/src/components/EnemyEditor.tsx
@@ -1,0 +1,313 @@
+import { useMemo, useState } from 'react'
+
+import type { EnemyDatabase } from '../lib/schema'
+import {
+  FieldGroup,
+  NumberField,
+  OptionalNumberField,
+  TextField,
+} from './fields'
+
+type Enemy = EnemyDatabase['enemies'][number]
+
+export function EnemyEditor({
+  enemy,
+  onChange,
+}: {
+  enemy: EnemyDatabase
+  onChange: (updater: (prev: EnemyDatabase) => EnemyDatabase) => void
+}) {
+  const [query, setQuery] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(enemy.enemies[0]?.id ?? null)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (q === '') return enemy.enemies
+    return enemy.enemies.filter(
+      (e) =>
+        e.id.toLowerCase().includes(q) ||
+        e.name.toLowerCase().includes(q) ||
+        e.raceTags.some((tag) => tag.toLowerCase().includes(q)),
+    )
+  }, [enemy.enemies, query])
+
+  const selectedIndex = enemy.enemies.findIndex((e) => e.id === selectedId)
+  const selected = selectedIndex >= 0 ? enemy.enemies[selectedIndex] : null
+
+  const updateSelected = (updater: (prev: Enemy) => Enemy) => {
+    if (selectedIndex < 0) return
+    onChange((prev) => {
+      const next = prev.enemies.slice()
+      next[selectedIndex] = updater(next[selectedIndex])
+      return { ...prev, enemies: next }
+    })
+  }
+
+  return (
+    <div className="enemy-layout">
+      <div className="enemy-list">
+        <input
+          type="search"
+          placeholder="id / name / raceTag で絞り込み"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="search-input"
+        />
+        <table className="enemy-table">
+          <thead>
+            <tr>
+              <th>id</th>
+              <th>name</th>
+              <th className="num">Lv</th>
+              <th className="num">HP</th>
+              <th className="num">ATK</th>
+              <th className="num">DEF</th>
+              <th className="num">AGI</th>
+              <th className="num">EXP</th>
+              <th className="num">Gold</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((e) => (
+              <tr
+                key={e.id}
+                className={selectedId === e.id ? 'selected' : ''}
+                onClick={() => setSelectedId(e.id)}
+              >
+                <td><code>{e.id}</code></td>
+                <td>{e.name}</td>
+                <td className="num">{e.level}</td>
+                <td className="num">{e.hp}</td>
+                <td className="num">{e.atk}</td>
+                <td className="num">{e.def}</td>
+                <td className="num">{e.agility}</td>
+                <td className="num">{e.exp}</td>
+                <td className="num">{e.gold}</td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={9} className="subtle">該当する敵がいません</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {selected && <EnemyForm enemy={selected} onChange={updateSelected} />}
+    </div>
+  )
+}
+
+function EnemyForm({
+  enemy,
+  onChange,
+}: {
+  enemy: Enemy
+  onChange: (updater: (prev: Enemy) => Enemy) => void
+}) {
+  const set = <K extends keyof Enemy>(key: K, value: Enemy[K]) =>
+    onChange((prev) => ({ ...prev, [key]: value }))
+
+  return (
+    <aside className="card enemy-detail">
+      <h3>
+        {enemy.name} <span className="subtle">/ <code>{enemy.id}</code></span>
+      </h3>
+      <FieldGroup columns={1}>
+        <TextField
+          label="id"
+          value={enemy.id}
+          onChange={(v) => set('id', v)}
+        />
+        <TextField
+          label="name"
+          value={enemy.name}
+          onChange={(v) => set('name', v)}
+        />
+        <TextField
+          label="raceTags (カンマ区切り)"
+          value={enemy.raceTags.join(', ')}
+          onChange={(v) =>
+            set(
+              'raceTags',
+              v
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean),
+            )
+          }
+        />
+      </FieldGroup>
+
+      <h4>ステータス</h4>
+      <FieldGroup columns={2}>
+        <NumberField label="level" value={enemy.level} min={0} onChange={(v) => set('level', v)} />
+        <NumberField label="hp" value={enemy.hp} min={0} onChange={(v) => set('hp', v)} />
+        <NumberField label="atk" value={enemy.atk} min={0} onChange={(v) => set('atk', v)} />
+        <NumberField label="def" value={enemy.def} min={0} onChange={(v) => set('def', v)} />
+        <NumberField
+          label="agility"
+          value={enemy.agility}
+          min={0}
+          onChange={(v) => set('agility', v)}
+        />
+        <NumberField
+          label="attackCount"
+          value={enemy.attackCount}
+          min={1}
+          onChange={(v) => set('attackCount', v)}
+        />
+        <NumberField
+          label="accuracy"
+          value={enemy.accuracy}
+          min={0}
+          onChange={(v) => set('accuracy', v)}
+        />
+        <NumberField
+          label="evasion"
+          value={enemy.evasion}
+          min={0}
+          onChange={(v) => set('evasion', v)}
+        />
+        <NumberField label="exp" value={enemy.exp} min={0} onChange={(v) => set('exp', v)} />
+        <NumberField label="gold" value={enemy.gold} min={0} onChange={(v) => set('gold', v)} />
+      </FieldGroup>
+
+      <h4>オプション</h4>
+      <FieldGroup columns={2}>
+        <OptionalNumberField
+          label="vitality"
+          value={enemy.vitality}
+          min={0}
+          onChange={(v) => set('vitality', v)}
+        />
+        <OptionalNumberField
+          label="magicAtk"
+          value={enemy.magicAtk}
+          min={0}
+          onChange={(v) => set('magicAtk', v)}
+        />
+        <OptionalNumberField
+          label="magicDef"
+          value={enemy.magicDef}
+          min={0}
+          onChange={(v) => set('magicDef', v)}
+        />
+        <OptionalNumberField
+          label="magicHeal"
+          value={enemy.magicHeal}
+          min={0}
+          onChange={(v) => set('magicHeal', v)}
+        />
+        <OptionalNumberField
+          label="criticalRate"
+          value={enemy.criticalRate}
+          min={0}
+          onChange={(v) => set('criticalRate', v)}
+        />
+      </FieldGroup>
+
+      <h4>耐性 (%)</h4>
+      <FieldGroup columns={2}>
+        <OptionalNumberField
+          label="physical"
+          value={enemy.physicalResistancePercent}
+          onChange={(v) => set('physicalResistancePercent', v)}
+        />
+        <OptionalNumberField
+          label="penetration"
+          value={enemy.penetrationResistancePercent}
+          onChange={(v) => set('penetrationResistancePercent', v)}
+        />
+        <OptionalNumberField
+          label="critical"
+          value={enemy.criticalResistancePercent}
+          onChange={(v) => set('criticalResistancePercent', v)}
+        />
+        <OptionalNumberField
+          label="magic"
+          value={enemy.magicResistancePercent}
+          onChange={(v) => set('magicResistancePercent', v)}
+        />
+      </FieldGroup>
+
+      <ExtraJsonSection
+        label="skills"
+        value={(enemy as any).skills}
+        onChange={(v) => onChange((prev) => ({ ...prev, skills: v }) as Enemy)}
+      />
+      <ExtraJsonSection
+        label="spells"
+        value={(enemy as any).spells}
+        onChange={(v) => onChange((prev) => ({ ...prev, spells: v }) as Enemy)}
+      />
+      <ExtraJsonSection
+        label="factorDrops"
+        value={(enemy as any).factorDrops}
+        onChange={(v) => onChange((prev) => ({ ...prev, factorDrops: v }) as Enemy)}
+      />
+      <ExtraJsonSection
+        label="equipmentDrops"
+        value={(enemy as any).equipmentDrops}
+        onChange={(v) => onChange((prev) => ({ ...prev, equipmentDrops: v }) as Enemy)}
+      />
+    </aside>
+  )
+}
+
+function ExtraJsonSection({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: unknown
+  onChange: (v: unknown) => void
+}) {
+  const [text, setText] = useState(() =>
+    value === undefined ? '' : JSON.stringify(value, null, 2),
+  )
+  const [dirtyLocal, setDirtyLocal] = useState(false)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  return (
+    <details className="json-section">
+      <summary>{label}{Array.isArray(value) ? ` (${value.length})` : value !== undefined ? ' (設定あり)' : ' (未設定)'}</summary>
+      <textarea
+        className="json-editor"
+        value={text}
+        rows={Math.min(12, Math.max(3, text.split('\n').length))}
+        onChange={(e) => {
+          setText(e.target.value)
+          setDirtyLocal(true)
+          setParseError(null)
+        }}
+        placeholder="[] または未入力で削除"
+      />
+      {parseError && <p className="save-error">{parseError}</p>}
+      <div className="json-section-actions">
+        <button
+          className="btn ghost"
+          disabled={!dirtyLocal}
+          onClick={() => {
+            if (text.trim() === '') {
+              onChange(undefined)
+              setDirtyLocal(false)
+              setParseError(null)
+              return
+            }
+            try {
+              onChange(JSON.parse(text))
+              setDirtyLocal(false)
+              setParseError(null)
+            } catch (err) {
+              setParseError(err instanceof Error ? err.message : String(err))
+            }
+          }}
+        >
+          適用
+        </button>
+      </div>
+    </details>
+  )
+}

--- a/tools/studio/src/components/EnemyPalette.tsx
+++ b/tools/studio/src/components/EnemyPalette.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from 'react'
+
+import type { EnemyDatabase } from '../lib/schema'
+import { encodePayload } from './dragPayload'
+
+type Enemy = EnemyDatabase['enemies'][number]
+
+export function EnemyPalette({
+  enemies,
+  selectedEnemyId,
+  onSelect,
+}: {
+  enemies: Enemy[]
+  selectedEnemyId: string | null
+  onSelect: (id: string) => void
+}) {
+  const [query, setQuery] = useState('')
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (q === '') return enemies
+    return enemies.filter(
+      (e) =>
+        e.id.toLowerCase().includes(q) ||
+        e.name.toLowerCase().includes(q) ||
+        e.raceTags.some((tag) => tag.toLowerCase().includes(q)),
+    )
+  }, [enemies, query])
+
+  return (
+    <aside className="enemy-palette">
+      <h3>敵パレット</h3>
+      <p className="subtle">クリックで選択、ドラッグでスロットに配置</p>
+      <input
+        type="search"
+        className="search-input"
+        placeholder="絞り込み"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <div className="palette-list">
+        {filtered.map((e) => (
+          <div
+            key={e.id}
+            className={`palette-item ${selectedEnemyId === e.id ? 'selected' : ''}`}
+            draggable
+            onDragStart={(ev) => {
+              ev.dataTransfer.effectAllowed = 'copy'
+              ev.dataTransfer.setData(
+                'application/x-goblin-studio',
+                encodePayload({ kind: 'new', enemyId: e.id }),
+              )
+            }}
+            onClick={() => onSelect(e.id)}
+          >
+            <div className="palette-name">{e.name}</div>
+            <div className="palette-sub">
+              <code>{e.id}</code>
+              <span className="subtle">Lv{e.level}</span>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && <p className="subtle">該当する敵がいません</p>}
+      </div>
+    </aside>
+  )
+}

--- a/tools/studio/src/components/GoblinBrowser.tsx
+++ b/tools/studio/src/components/GoblinBrowser.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from 'react'
+
+import { usePartyStore } from '../stores/partyStore'
+import type { BackupGoblin } from '../lib/goblinMapper'
+
+type SortKey = 'id' | 'level' | 'name' | 'job' | 'race'
+
+export function GoblinBrowser() {
+  const { backup, draft, addMember } = usePartyStore()
+  const [query, setQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('level')
+  const [sortDesc, setSortDesc] = useState(true)
+
+  const partyMemberIds = useMemo(
+    () => new Set(draft.members.filter((m): m is number => m !== null)),
+    [draft.members],
+  )
+
+  const filtered = useMemo(() => {
+    if (!backup) return []
+    const q = query.trim().toLowerCase()
+    let list = backup.goblins
+    if (q !== '') {
+      list = list.filter(
+        (g) =>
+          g.name.toLowerCase().includes(q) ||
+          g.race.toLowerCase().includes(q) ||
+          g.job?.toLowerCase().includes(q) ||
+          String(g.id).includes(q),
+      )
+    }
+    const sorted = list.slice().sort((a, b) => compareByKey(a, b, sortKey))
+    if (sortDesc) sorted.reverse()
+    return sorted
+  }, [backup, query, sortKey, sortDesc])
+
+  if (!backup) return null
+  const equipmentByGoblin = backup.equipmentByGoblin
+
+  return (
+    <div>
+      <div className="goblin-toolbar">
+        <input
+          type="search"
+          className="search-input"
+          placeholder="id / name / race / job で絞り込み"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <span className="subtle">{filtered.length} / {backup.goblins.length} 体表示</span>
+      </div>
+      <table className="enemy-table">
+        <thead>
+          <tr>
+            <SortHeader label="id" k="id" sortKey={sortKey} sortDesc={sortDesc} onClick={setSort(setSortKey, setSortDesc, sortKey, sortDesc)} align="num" />
+            <SortHeader label="name" k="name" sortKey={sortKey} sortDesc={sortDesc} onClick={setSort(setSortKey, setSortDesc, sortKey, sortDesc)} />
+            <SortHeader label="race" k="race" sortKey={sortKey} sortDesc={sortDesc} onClick={setSort(setSortKey, setSortDesc, sortKey, sortDesc)} />
+            <SortHeader label="job" k="job" sortKey={sortKey} sortDesc={sortDesc} onClick={setSort(setSortKey, setSortDesc, sortKey, sortDesc)} />
+            <SortHeader label="Lv" k="level" sortKey={sortKey} sortDesc={sortDesc} onClick={setSort(setSortKey, setSortDesc, sortKey, sortDesc)} align="num" />
+            <th className="num">HP</th>
+            <th className="num">ATK</th>
+            <th className="num">DEF</th>
+            <th className="num">装備</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((g) => {
+            const inParty = partyMemberIds.has(g.id)
+            const equipCount = equipmentByGoblin.get(g.id)?.length ?? 0
+            const stats = g.effectiveStats ?? g.stats
+            return (
+              <tr key={g.id} className={inParty ? 'selected' : ''}>
+                <td className="num">{g.id}</td>
+                <td>{g.name}</td>
+                <td>{g.race}</td>
+                <td>{g.job ?? '-'}</td>
+                <td className="num">{g.level}</td>
+                <td className="num">{stats.hp}</td>
+                <td className="num">{stats.atk}</td>
+                <td className="num">{stats.def}</td>
+                <td className="num">{equipCount}</td>
+                <td>
+                  <button
+                    className="btn ghost small"
+                    disabled={inParty}
+                    onClick={() => addMember(g.id)}
+                  >
+                    {inParty ? '編成済' : '+ PT'}
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+          {filtered.length === 0 && (
+            <tr>
+              <td colSpan={10} className="subtle">該当するゴブリンがいません</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SortHeader({
+  label,
+  k,
+  sortKey,
+  sortDesc,
+  onClick,
+  align,
+}: {
+  label: string
+  k: SortKey
+  sortKey: SortKey
+  sortDesc: boolean
+  onClick: (k: SortKey) => void
+  align?: 'num'
+}) {
+  const active = sortKey === k
+  return (
+    <th className={align === 'num' ? 'num sortable' : 'sortable'} onClick={() => onClick(k)}>
+      {label}
+      {active ? (sortDesc ? ' ▼' : ' ▲') : ''}
+    </th>
+  )
+}
+
+function setSort(
+  setKey: (k: SortKey) => void,
+  setDesc: (d: boolean) => void,
+  currentKey: SortKey,
+  currentDesc: boolean,
+) {
+  return (k: SortKey) => {
+    if (k === currentKey) {
+      setDesc(!currentDesc)
+    } else {
+      setKey(k)
+      setDesc(true)
+    }
+  }
+}
+
+function compareByKey(a: BackupGoblin, b: BackupGoblin, key: SortKey): number {
+  switch (key) {
+    case 'id':
+      return a.id - b.id
+    case 'level':
+      return a.level - b.level
+    case 'name':
+      return a.name.localeCompare(b.name)
+    case 'job':
+      return (a.job ?? '').localeCompare(b.job ?? '')
+    case 'race':
+      return a.race.localeCompare(b.race)
+  }
+}

--- a/tools/studio/src/components/PartyEditor.tsx
+++ b/tools/studio/src/components/PartyEditor.tsx
@@ -1,0 +1,98 @@
+import { MAX_PARTY_MEMBERS, useGoblinById, usePartyStore } from '../stores/partyStore'
+
+export function PartyEditor() {
+  const { draft, setDraftName, removeMember, clearDraft, savePreset } = usePartyStore()
+  const filledCount = draft.members.filter((m) => m !== null).length
+
+  return (
+    <section className="card">
+      <header className="party-editor-head">
+        <input
+          type="text"
+          className="inline-input flex1"
+          value={draft.name}
+          onChange={(e) => setDraftName(e.target.value)}
+          placeholder="PT名"
+        />
+        <span className="subtle">{filledCount} / {MAX_PARTY_MEMBERS}</span>
+      </header>
+      <ol className="party-slots">
+        {draft.members.map((id, idx) => (
+          <PartySlot key={idx} index={idx} goblinId={id} onRemove={() => removeMember(idx)} />
+        ))}
+      </ol>
+      <div className="party-editor-actions">
+        <button
+          className="btn ghost"
+          onClick={clearDraft}
+          disabled={filledCount === 0 && draft.name === '新規PT'}
+        >
+          クリア
+        </button>
+        <button
+          className="btn primary"
+          onClick={savePreset}
+          disabled={filledCount === 0}
+        >
+          プリセット保存
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function PartySlot({
+  index,
+  goblinId,
+  onRemove,
+}: {
+  index: number
+  goblinId: number | null
+  onRemove: () => void
+}) {
+  const goblin = useGoblinById(goblinId)
+
+  if (goblinId === null) {
+    return (
+      <li className="party-slot empty">
+        <span className="slot-index">{index + 1}</span>
+        <span className="subtle">空きスロット</span>
+      </li>
+    )
+  }
+
+  if (goblin === null) {
+    return (
+      <li className="party-slot">
+        <span className="slot-index">{index + 1}</span>
+        <div className="slot-body">
+          <div className="slot-title">
+            <strong>ID: {goblinId}</strong>
+            <span className="subtle"> / バックアップ未ロード</span>
+          </div>
+        </div>
+        <button className="icon-btn danger" onClick={onRemove} title="外す">×</button>
+      </li>
+    )
+  }
+
+  const stats = goblin.effectiveStats ?? goblin.stats
+  return (
+    <li className="party-slot">
+      <span className="slot-index">{index + 1}</span>
+      <div className="slot-body">
+        <div className="slot-title">
+          <strong>{goblin.name}</strong>
+          <span className="subtle"> / Lv{goblin.level} {goblin.job ? `(${goblin.job})` : ''}</span>
+        </div>
+        <div className="slot-stats">
+          <span>HP {stats.hp}</span>
+          <span>ATK {stats.atk}</span>
+          <span>DEF {stats.def}</span>
+          {stats.magicAtk !== undefined && <span>M-ATK {stats.magicAtk}</span>}
+        </div>
+      </div>
+      <button className="icon-btn danger" onClick={onRemove} title="外す">×</button>
+    </li>
+  )
+}

--- a/tools/studio/src/components/PatternCardEditor.tsx
+++ b/tools/studio/src/components/PatternCardEditor.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react'
+
+import type { EnemyDatabase } from '../lib/schema'
+import { DRAG_MIME, decodePayload, encodePayload } from './dragPayload'
+
+type Pattern = EnemyDatabase['patterns'][number]
+
+interface Props {
+  pattern: Pattern
+  enemyNameMap: Map<string, string>
+  selectedEnemyId: string | null
+  onChange: (updater: (prev: Pattern) => Pattern) => void
+  onDuplicate: () => void
+  onDelete: () => void
+  onMoveUp: () => void
+  onMoveDown: () => void
+}
+
+export function PatternCardEditor({
+  pattern,
+  enemyNameMap,
+  selectedEnemyId,
+  onChange,
+  onDuplicate,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: Props) {
+  const [floorsText, setFloorsText] = useState(pattern.floors.join(','))
+
+  const setFloorsFromText = (raw: string) => {
+    const floors = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => Number.isFinite(n))
+    onChange((prev) => ({ ...prev, floors }))
+  }
+
+  const insertSlot = (row: number, targetSlot: number, enemyId: string) => {
+    onChange((prev) => {
+      const nextRows = prev.enemies.map((r) => r.slice())
+      while (nextRows.length <= row) nextRows.push([])
+      const clamped = Math.max(0, Math.min(targetSlot, nextRows[row].length))
+      nextRows[row].splice(clamped, 0, enemyId)
+      return { ...prev, enemies: nextRows }
+    })
+  }
+
+  const moveSlot = (
+    source: { row: number; slot: number },
+    target: { row: number; slot: number },
+  ) => {
+    onChange((prev) => {
+      const nextRows = prev.enemies.map((r) => r.slice())
+      if (source.row >= nextRows.length) return prev
+      const [picked] = nextRows[source.row].splice(source.slot, 1)
+      if (picked === undefined) return prev
+      while (nextRows.length <= target.row) nextRows.push([])
+      let targetSlot = target.slot
+      if (source.row === target.row && source.slot < target.slot) {
+        targetSlot = target.slot - 1
+      }
+      const clamped = Math.max(0, Math.min(targetSlot, nextRows[target.row].length))
+      nextRows[target.row].splice(clamped, 0, picked)
+      return { ...prev, enemies: nextRows }
+    })
+  }
+
+  const removeSlot = (row: number, slot: number) => {
+    onChange((prev) => {
+      const nextRows = prev.enemies.map((r) => r.slice())
+      if (row >= nextRows.length) return prev
+      nextRows[row].splice(slot, 1)
+      return { ...prev, enemies: nextRows }
+    })
+  }
+
+  const addRow = () => {
+    onChange((prev) => ({ ...prev, enemies: [...prev.enemies, []] }))
+  }
+
+  const removeRow = (row: number) => {
+    onChange((prev) => {
+      const nextRows = prev.enemies.slice()
+      nextRows.splice(row, 1)
+      return { ...prev, enemies: nextRows.length === 0 ? [[]] : nextRows }
+    })
+  }
+
+  const moveRow = (row: number, direction: -1 | 1) => {
+    onChange((prev) => {
+      const target = row + direction
+      if (target < 0 || target >= prev.enemies.length) return prev
+      const nextRows = prev.enemies.slice()
+      ;[nextRows[row], nextRows[target]] = [nextRows[target], nextRows[row]]
+      return { ...prev, enemies: nextRows }
+    })
+  }
+
+  const handleDropAt = (row: number, slot: number) => (ev: React.DragEvent) => {
+    ev.preventDefault()
+    const payload = decodePayload(ev.dataTransfer.getData(DRAG_MIME))
+    if (!payload) return
+    if (payload.kind === 'new') {
+      insertSlot(row, slot, payload.enemyId)
+    } else {
+      moveSlot(payload.source, { row, slot })
+    }
+  }
+
+  return (
+    <section className={pattern.isBoss ? 'card pattern-card boss' : 'card pattern-card'}>
+      <header className="pattern-header">
+        <input
+          type="text"
+          className="inline-input"
+          value={pattern.id}
+          onChange={(e) => onChange((prev) => ({ ...prev, id: e.target.value }))}
+        />
+        <label className="subtle">
+          階層:{' '}
+          <input
+            type="text"
+            className="inline-input narrow"
+            value={floorsText}
+            onChange={(e) => setFloorsText(e.target.value)}
+            onBlur={() => setFloorsFromText(floorsText)}
+          />
+        </label>
+        <label className="subtle">
+          <input
+            type="checkbox"
+            checked={!!pattern.isBoss}
+            onChange={(e) =>
+              onChange((prev) => ({ ...prev, isBoss: e.target.checked || undefined }))
+            }
+          />
+          boss
+        </label>
+        <div className="pattern-actions">
+          <button className="icon-btn" title="上へ" onClick={onMoveUp}>↑</button>
+          <button className="icon-btn" title="下へ" onClick={onMoveDown}>↓</button>
+          <button className="icon-btn" title="複製" onClick={onDuplicate}>⧉</button>
+          <button className="icon-btn danger" title="削除" onClick={onDelete}>×</button>
+        </div>
+      </header>
+
+      <div className="formation editable-formation">
+        {pattern.enemies.map((row, rowIndex) => (
+          <div key={rowIndex} className="formation-row-editable">
+            <div className="row-header">
+              <span className="row-label">{rowIndex + 1}列</span>
+              <div className="row-actions">
+                <button
+                  className="icon-btn small"
+                  title="上の列へ"
+                  onClick={() => moveRow(rowIndex, -1)}
+                  disabled={rowIndex === 0}
+                >
+                  ↑
+                </button>
+                <button
+                  className="icon-btn small"
+                  title="下の列へ"
+                  onClick={() => moveRow(rowIndex, 1)}
+                  disabled={rowIndex === pattern.enemies.length - 1}
+                >
+                  ↓
+                </button>
+                <button
+                  className="icon-btn small danger"
+                  title="列を削除"
+                  onClick={() => removeRow(rowIndex)}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <div
+              className="slot-lane"
+              onDragOver={(ev) => {
+                ev.preventDefault()
+                ev.dataTransfer.dropEffect = 'move'
+              }}
+              onDrop={handleDropAt(rowIndex, row.length)}
+            >
+              {row.map((enemyId, slotIndex) => (
+                <SlotTile
+                  key={`${rowIndex}-${slotIndex}`}
+                  row={rowIndex}
+                  slot={slotIndex}
+                  enemyId={enemyId}
+                  name={enemyNameMap.get(enemyId) ?? enemyId}
+                  onDropBefore={handleDropAt(rowIndex, slotIndex)}
+                  onRemove={() => removeSlot(rowIndex, slotIndex)}
+                />
+              ))}
+              <button
+                className="slot-add"
+                title={selectedEnemyId ? `+ ${enemyNameMap.get(selectedEnemyId) ?? selectedEnemyId}` : '+'}
+                disabled={!selectedEnemyId}
+                onClick={() => {
+                  if (selectedEnemyId) insertSlot(rowIndex, row.length, selectedEnemyId)
+                }}
+              >
+                + 追加
+              </button>
+            </div>
+          </div>
+        ))}
+        <button className="btn ghost small" onClick={addRow}>
+          + 列を追加
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function SlotTile({
+  row,
+  slot,
+  enemyId,
+  name,
+  onDropBefore,
+  onRemove,
+}: {
+  row: number
+  slot: number
+  enemyId: string
+  name: string
+  onDropBefore: (ev: React.DragEvent) => void
+  onRemove: () => void
+}) {
+  const [dragOver, setDragOver] = useState(false)
+  const known = name !== enemyId
+
+  return (
+    <div
+      className={`slot-tile ${dragOver ? 'drag-over' : ''} ${known ? '' : 'unknown'}`}
+      draggable
+      onDragStart={(ev) => {
+        ev.dataTransfer.effectAllowed = 'move'
+        ev.dataTransfer.setData(
+          DRAG_MIME,
+          encodePayload({ kind: 'move', enemyId, source: { row, slot } }),
+        )
+      }}
+      onDragOver={(ev) => {
+        ev.preventDefault()
+        ev.dataTransfer.dropEffect = 'move'
+        setDragOver(true)
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(ev) => {
+        setDragOver(false)
+        onDropBefore(ev)
+      }}
+      title={enemyId}
+    >
+      <span className="slot-name">{name}</span>
+      <button
+        className="slot-remove"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove()
+        }}
+        title="削除"
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/tools/studio/src/components/PatternEditor.tsx
+++ b/tools/studio/src/components/PatternEditor.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useState } from 'react'
+
+import type { EnemyDatabase } from '../lib/schema'
+import { EnemyPalette } from './EnemyPalette'
+import { PatternCardEditor } from './PatternCardEditor'
+
+type Pattern = EnemyDatabase['patterns'][number]
+
+export function PatternEditor({
+  enemy,
+  enemyNameMap,
+  onChange,
+}: {
+  enemy: EnemyDatabase
+  enemyNameMap: Map<string, string>
+  onChange: (updater: (prev: EnemyDatabase) => EnemyDatabase) => void
+}) {
+  const [floorFilter, setFloorFilter] = useState<number | 'all'>('all')
+  const [bossOnly, setBossOnly] = useState(false)
+  const [rawMode, setRawMode] = useState(false)
+  const [selectedEnemyId, setSelectedEnemyId] = useState<string | null>(
+    enemy.enemies[0]?.id ?? null,
+  )
+
+  const availableFloors = useMemo(() => {
+    const set = new Set<number>()
+    enemy.patterns.forEach((p) => p.floors.forEach((f) => set.add(f)))
+    return Array.from(set).sort((a, b) => a - b)
+  }, [enemy.patterns])
+
+  const visiblePatterns = useMemo(() => {
+    return enemy.patterns
+      .map((pattern, idx) => ({ pattern, idx }))
+      .filter(({ pattern }) => {
+        if (bossOnly && !pattern.isBoss) return false
+        if (floorFilter !== 'all' && !pattern.floors.includes(floorFilter)) return false
+        return true
+      })
+  }, [enemy.patterns, floorFilter, bossOnly])
+
+  const mutatePattern = (index: number, updater: (prev: Pattern) => Pattern) => {
+    onChange((prev) => {
+      const next = prev.patterns.slice()
+      next[index] = updater(next[index])
+      return { ...prev, patterns: next }
+    })
+  }
+
+  const duplicatePattern = (index: number) => {
+    onChange((prev) => {
+      const source = prev.patterns[index]
+      const clone: Pattern = {
+        ...source,
+        id: uniqueCopyId(source.id, prev.patterns),
+        floors: [...source.floors],
+        enemies: source.enemies.map((row) => [...row]),
+      }
+      const next = prev.patterns.slice()
+      next.splice(index + 1, 0, clone)
+      return { ...prev, patterns: next }
+    })
+  }
+
+  const deletePattern = (index: number) => {
+    onChange((prev) => {
+      const next = prev.patterns.slice()
+      next.splice(index, 1)
+      return { ...prev, patterns: next }
+    })
+  }
+
+  const movePattern = (index: number, direction: -1 | 1) => {
+    onChange((prev) => {
+      const target = index + direction
+      if (target < 0 || target >= prev.patterns.length) return prev
+      const next = prev.patterns.slice()
+      ;[next[index], next[target]] = [next[target], next[index]]
+      return { ...prev, patterns: next }
+    })
+  }
+
+  const addPattern = () => {
+    onChange((prev) => ({
+      ...prev,
+      patterns: [
+        ...prev.patterns,
+        {
+          id: uniqueCopyId('NEW', prev.patterns),
+          floors: floorFilter === 'all' ? [1] : [floorFilter],
+          enemies: [[]],
+        },
+      ],
+    }))
+  }
+
+  if (rawMode) {
+    return (
+      <div className="panel-stack">
+        <div className="filters">
+          <button className="btn ghost" onClick={() => setRawMode(false)}>
+            ← ビジュアル編集に戻る
+          </button>
+          <span className="subtle">JSON 直接編集モード（保存時に検証）</span>
+        </div>
+        <RawPatternEditor enemy={enemy} onChange={onChange} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="pattern-layout">
+      <div className="pattern-main">
+        <div className="filters">
+          <label>
+            階層:{' '}
+            <select
+              value={floorFilter === 'all' ? 'all' : String(floorFilter)}
+              onChange={(e) =>
+                setFloorFilter(e.target.value === 'all' ? 'all' : Number(e.target.value))
+              }
+            >
+              <option value="all">すべて</option>
+              {availableFloors.map((f) => (
+                <option key={f} value={String(f)}>
+                  {f}F
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={bossOnly}
+              onChange={(e) => setBossOnly(e.target.checked)}
+            />
+            ボスのみ
+          </label>
+          <span className="subtle">
+            {visiblePatterns.length} / {enemy.patterns.length} 件表示
+          </span>
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.4rem' }}>
+            <button className="btn primary" onClick={addPattern}>+ パターン追加</button>
+            <button className="btn ghost" onClick={() => setRawMode(true)}>JSON 直接編集</button>
+          </div>
+        </div>
+
+        <div className="pattern-grid">
+          {visiblePatterns.map(({ pattern, idx }) => (
+            <PatternCardEditor
+              key={`${pattern.id}-${idx}`}
+              pattern={pattern}
+              enemyNameMap={enemyNameMap}
+              selectedEnemyId={selectedEnemyId}
+              onChange={(updater) => mutatePattern(idx, updater)}
+              onDuplicate={() => duplicatePattern(idx)}
+              onDelete={() => deletePattern(idx)}
+              onMoveUp={() => movePattern(idx, -1)}
+              onMoveDown={() => movePattern(idx, 1)}
+            />
+          ))}
+          {visiblePatterns.length === 0 && (
+            <p className="subtle">該当するパターンがありません</p>
+          )}
+        </div>
+      </div>
+
+      <EnemyPalette
+        enemies={enemy.enemies}
+        selectedEnemyId={selectedEnemyId}
+        onSelect={setSelectedEnemyId}
+      />
+    </div>
+  )
+}
+
+function uniqueCopyId(baseId: string, patterns: Pattern[]): string {
+  const taken = new Set(patterns.map((p) => p.id))
+  if (!taken.has(baseId)) return baseId
+  for (let i = 2; i < 999; i++) {
+    const candidate = `${baseId}_${i}`
+    if (!taken.has(candidate)) return candidate
+  }
+  return `${baseId}_${Date.now()}`
+}
+
+function RawPatternEditor({
+  enemy,
+  onChange,
+}: {
+  enemy: EnemyDatabase
+  onChange: (updater: (prev: EnemyDatabase) => EnemyDatabase) => void
+}) {
+  const [text, setText] = useState(() => JSON.stringify(enemy.patterns, null, 2))
+  const [error, setError] = useState<string | null>(null)
+  const [dirty, setDirty] = useState(false)
+
+  return (
+    <div>
+      <textarea
+        className="json-editor tall"
+        value={text}
+        rows={24}
+        onChange={(e) => {
+          setText(e.target.value)
+          setDirty(true)
+          setError(null)
+        }}
+      />
+      {error && <p className="save-error">{error}</p>}
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button
+          className="btn primary"
+          disabled={!dirty}
+          onClick={() => {
+            try {
+              const parsed = JSON.parse(text)
+              if (!Array.isArray(parsed)) throw new Error('パターンは配列である必要があります')
+              onChange((prev) => ({ ...prev, patterns: parsed }))
+              setDirty(false)
+              setError(null)
+            } catch (err) {
+              setError(err instanceof Error ? err.message : String(err))
+            }
+          }}
+        >
+          パターン反映
+        </button>
+        <button
+          className="btn ghost"
+          onClick={() => {
+            setText(JSON.stringify(enemy.patterns, null, 2))
+            setDirty(false)
+            setError(null)
+          }}
+        >
+          リセット
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tools/studio/src/components/PresetList.tsx
+++ b/tools/studio/src/components/PresetList.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+
+import { usePartyStore } from '../stores/partyStore'
+
+export function PresetList() {
+  const {
+    presets,
+    presetsLoading,
+    presetsError,
+    loadPreset,
+    deletePreset,
+    renamePreset,
+    updatePreset,
+    draft,
+  } = usePartyStore()
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  if (presetsLoading) {
+    return (
+      <section className="card">
+        <h3>プリセット</h3>
+        <p className="subtle">読み込み中…</p>
+      </section>
+    )
+  }
+
+  if (presets.length === 0) {
+    return (
+      <section className="card">
+        <h3>プリセット</h3>
+        <p className="subtle">保存済みプリセットはまだありません。</p>
+        {presetsError && <p className="save-error">{presetsError}</p>}
+      </section>
+    )
+  }
+
+  const draftCount = draft.members.filter((m) => m !== null).length
+
+  return (
+    <section className="card">
+      <h3>プリセット ({presets.length})</h3>
+      {presetsError && <p className="save-error">{presetsError}</p>}
+      <ul className="preset-list">
+        {presets.map((p) => (
+          <li key={p.id} className="preset-item">
+            {renamingId === p.id ? (
+              <>
+                <input
+                  type="text"
+                  className="inline-input flex1"
+                  value={renameValue}
+                  autoFocus
+                  onChange={(e) => setRenameValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      if (renameValue.trim() !== '') renamePreset(p.id, renameValue.trim())
+                      setRenamingId(null)
+                    } else if (e.key === 'Escape') {
+                      setRenamingId(null)
+                    }
+                  }}
+                  onBlur={() => {
+                    if (renameValue.trim() !== '') renamePreset(p.id, renameValue.trim())
+                    setRenamingId(null)
+                  }}
+                />
+              </>
+            ) : (
+              <>
+                <div className="preset-info">
+                  <div className="preset-name">{p.name}</div>
+                  <div className="subtle">
+                    {p.memberIds.length} 体 · 更新 {p.updatedAt.slice(0, 10)}
+                  </div>
+                </div>
+                <div className="preset-actions">
+                  <button
+                    className="btn ghost small"
+                    onClick={() => loadPreset(p.id)}
+                    title="現在の編成に読み込む"
+                  >
+                    読込
+                  </button>
+                  <button
+                    className="btn ghost small"
+                    disabled={draftCount === 0}
+                    onClick={() => updatePreset(p.id)}
+                    title="現在の編成で上書き"
+                  >
+                    上書き
+                  </button>
+                  <button
+                    className="icon-btn small"
+                    onClick={() => {
+                      setRenamingId(p.id)
+                      setRenameValue(p.name)
+                    }}
+                    title="名前変更"
+                  >
+                    ✎
+                  </button>
+                  <button
+                    className="icon-btn small danger"
+                    onClick={() => {
+                      if (window.confirm(`プリセット「${p.name}」を削除しますか？`)) {
+                        deletePreset(p.id)
+                      }
+                    }}
+                    title="削除"
+                  >
+                    ×
+                  </button>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/tools/studio/src/components/SimulationResultView.tsx
+++ b/tools/studio/src/components/SimulationResultView.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from 'react'
+
+import type { SimulationResult } from '../lib/runExpedition'
+
+export function SimulationResultView({ result }: { result: SimulationResult }) {
+  const divisor = Math.max(1, result.trials - result.errors.length)
+  const successRate = result.success / divisor
+  const defeatedRate = result.defeated / divisor
+  const policyRate = result.policyReturned / divisor
+  const abortedRate = result.aborted / divisor
+
+  const floorEntries = useMemo(() => {
+    return Object.entries(result.floorDistribution)
+      .map(([floor, count]) => ({ floor: Number(floor), count }))
+      .sort((a, b) => a.floor - b.floor)
+  }, [result.floorDistribution])
+
+  const casualtyEntries = useMemo(() => {
+    return Object.entries(result.casualtyCounts)
+      .map(([name, count]) => ({ name, count, rate: count / divisor }))
+      .sort((a, b) => b.count - a.count)
+  }, [result.casualtyCounts, divisor])
+
+  const maxFloorCount = Math.max(1, ...floorEntries.map((e) => e.count))
+
+  return (
+    <section className="card">
+      <h2>シミュレーション結果</h2>
+      <p className="subtle">
+        試行 {result.trials} 回
+        {result.errors.length > 0 ? ` / エラー ${result.errors.length}` : ''}
+      </p>
+      <div className="result-metrics">
+        <Metric label="成功率" value={fmtPct(successRate)} sub={`${result.success} 回`} />
+        <Metric label="全滅率" value={fmtPct(defeatedRate)} sub={`${result.defeated} 回`} />
+        <Metric label="帰還率" value={fmtPct(policyRate)} sub={`${result.policyReturned} 回`} />
+        <Metric label="中断" value={fmtPct(abortedRate)} sub={`${result.aborted} 回`} />
+        <Metric label="平均到達階" value={result.avgMaxFloor.toFixed(2)} />
+        <Metric label="平均XP" value={Math.round(result.avgXpGained).toString()} />
+        <Metric label="平均Gold" value={Math.round(result.avgGoldGained).toString()} />
+        <Metric label="平均所要時間" value={`${Math.round(result.avgDurationSec)}s`} />
+      </div>
+
+      <h3>到達階層分布</h3>
+      <div className="floor-hist">
+        {floorEntries.map((entry) => {
+          const pct = entry.count / divisor
+          const width = (entry.count / maxFloorCount) * 100
+          return (
+            <div key={entry.floor} className="floor-hist-row">
+              <span className="floor-hist-label">{entry.floor}F</span>
+              <div className="floor-hist-bar">
+                <span className="floor-hist-fill" style={{ width: `${width}%` }} />
+              </div>
+              <span className="floor-hist-value">
+                {entry.count} <span className="subtle">({fmtPct(pct)})</span>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {casualtyEntries.length > 0 && (
+        <>
+          <h3>ゴブリン別死亡回数</h3>
+          <table className="enemy-table">
+            <thead>
+              <tr>
+                <th>ゴブリン名</th>
+                <th className="num">死亡回数</th>
+                <th className="num">死亡率</th>
+              </tr>
+            </thead>
+            <tbody>
+              {casualtyEntries.map((c) => (
+                <tr key={c.name}>
+                  <td>{c.name}</td>
+                  <td className="num">{c.count}</td>
+                  <td className="num">{fmtPct(c.rate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {result.errors.length > 0 && (
+        <>
+          <h3>エラー</h3>
+          <ul className="error-list">
+            {result.errors.slice(0, 5).map((e, i) => (
+              <li key={i} className="save-error">{e}</li>
+            ))}
+            {result.errors.length > 5 && (
+              <li className="subtle">… 他 {result.errors.length - 5} 件</li>
+            )}
+          </ul>
+        </>
+      )}
+    </section>
+  )
+}
+
+function Metric({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="metric">
+      <div className="metric-label">{label}</div>
+      <div className="metric-value">{value}</div>
+      {sub && <div className="metric-sub subtle">{sub}</div>}
+    </div>
+  )
+}
+
+function fmtPct(ratio: number): string {
+  return `${(ratio * 100).toFixed(1)}%`
+}

--- a/tools/studio/src/components/dragPayload.ts
+++ b/tools/studio/src/components/dragPayload.ts
@@ -1,0 +1,22 @@
+export type SlotDragPayload =
+  | { kind: 'new'; enemyId: string }
+  | { kind: 'move'; enemyId: string; source: { row: number; slot: number } }
+
+export const DRAG_MIME = 'application/x-goblin-studio'
+
+export function encodePayload(payload: SlotDragPayload): string {
+  return JSON.stringify(payload)
+}
+
+export function decodePayload(raw: string | null | undefined): SlotDragPayload | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as SlotDragPayload
+    if (parsed && typeof parsed === 'object' && 'kind' in parsed && 'enemyId' in parsed) {
+      return parsed
+    }
+    return null
+  } catch {
+    return null
+  }
+}

--- a/tools/studio/src/components/fields.tsx
+++ b/tools/studio/src/components/fields.tsx
@@ -1,0 +1,155 @@
+import type { ChangeEvent, ReactNode } from 'react'
+
+export type FieldSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+function fieldClass(size?: FieldSize): string {
+  return size ? `field field-size-${size}` : 'field'
+}
+
+export function NumberField({
+  label,
+  value,
+  onChange,
+  min,
+  step = 1,
+  suffix,
+  size,
+}: {
+  label: string
+  value: number | undefined
+  onChange: (v: number) => void
+  min?: number
+  step?: number
+  suffix?: string
+  size?: FieldSize
+}) {
+  return (
+    <label className={fieldClass(size)}>
+      <span className="field-label">{label}</span>
+      <span className="field-input">
+        <input
+          type="number"
+          value={value ?? ''}
+          min={min}
+          step={step}
+          onChange={(e) => onChange(parseNumber(e))}
+        />
+        {suffix && <span className="field-suffix">{suffix}</span>}
+      </span>
+    </label>
+  )
+}
+
+export function OptionalNumberField({
+  label,
+  value,
+  onChange,
+  min,
+  step = 1,
+  suffix,
+  size,
+}: {
+  label: string
+  value: number | undefined
+  onChange: (v: number | undefined) => void
+  min?: number
+  step?: number
+  suffix?: string
+  size?: FieldSize
+}) {
+  return (
+    <label className={fieldClass(size)}>
+      <span className="field-label">{label}</span>
+      <span className="field-input">
+        <input
+          type="number"
+          value={value ?? ''}
+          min={min}
+          step={step}
+          placeholder="(未設定)"
+          onChange={(e) => {
+            const raw = e.target.value
+            onChange(raw === '' ? undefined : Number(raw))
+          }}
+        />
+        {suffix && <span className="field-suffix">{suffix}</span>}
+      </span>
+    </label>
+  )
+}
+
+export function TextField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  size,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  size?: FieldSize
+}) {
+  return (
+    <label className={fieldClass(size)}>
+      <span className="field-label">{label}</span>
+      <span className="field-input">
+        <input
+          type="text"
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </span>
+    </label>
+  )
+}
+
+export function OptionalTextField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  size,
+}: {
+  label: string
+  value: string | undefined
+  onChange: (v: string | undefined) => void
+  placeholder?: string
+  size?: FieldSize
+}) {
+  return (
+    <label className={fieldClass(size)}>
+      <span className="field-label">{label}</span>
+      <span className="field-input">
+        <input
+          type="text"
+          value={value ?? ''}
+          placeholder={placeholder ?? '(未設定)'}
+          onChange={(e) => {
+            const raw = e.target.value
+            onChange(raw === '' ? undefined : raw)
+          }}
+        />
+      </span>
+    </label>
+  )
+}
+
+export function FieldGroup({ children, columns = 2 }: { children: ReactNode; columns?: number }) {
+  return (
+    <div className="field-group" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+      {children}
+    </div>
+  )
+}
+
+export function FieldRow({ children }: { children: ReactNode }) {
+  return <div className="field-row">{children}</div>
+}
+
+function parseNumber(e: ChangeEvent<HTMLInputElement>): number {
+  const v = Number(e.target.value)
+  return Number.isFinite(v) ? v : 0
+}

--- a/tools/studio/src/lib/backup.ts
+++ b/tools/studio/src/lib/backup.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+export const BackupMetaSchema = z.object({
+  app: z.string(),
+  formatVersion: z.number().int(),
+  appVersion: z.string().optional(),
+  schemaVersion: z.number().int().optional(),
+  exportedAt: z.string().optional(),
+  platform: z.string().optional(),
+  signatureAlgorithm: z.string().optional(),
+  signature: z.string().optional(),
+})
+
+export const BackupSchema = z.object({
+  meta: BackupMetaSchema,
+  tables: z
+    .object({
+      goblins: z.array(z.record(z.unknown())).optional(),
+      parties: z.array(z.record(z.unknown())).optional(),
+      equipment: z.array(z.record(z.unknown())).optional(),
+      pending_goblins: z.array(z.record(z.unknown())).optional(),
+      expeditions: z.array(z.record(z.unknown())).optional(),
+      base_state: z.array(z.record(z.unknown())).optional(),
+      dungeon_progress: z.array(z.record(z.unknown())).optional(),
+      story_progress: z.array(z.record(z.unknown())).optional(),
+      app_metadata: z.array(z.record(z.unknown())).optional(),
+    })
+    .passthrough(),
+  preferences: z.unknown().optional(),
+})
+
+export type BackupDocument = z.infer<typeof BackupSchema>
+
+export async function parseBackupFile(file: File): Promise<BackupDocument> {
+  const text = await file.text()
+  const json = JSON.parse(text)
+  const result = BackupSchema.safeParse(json)
+  if (!result.success) {
+    throw new Error(
+      `バックアップ形式が不正です: ${result.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join(' / ')}`,
+    )
+  }
+  if (result.data.meta.app !== 'goblin_kingdom') {
+    throw new Error(
+      `想定外の app 識別子です（meta.app = ${result.data.meta.app}）。goblin_kingdom のバックアップのみ対応しています。`,
+    )
+  }
+  return result.data
+}

--- a/tools/studio/src/lib/goblinMapper.ts
+++ b/tools/studio/src/lib/goblinMapper.ts
@@ -1,0 +1,192 @@
+import type { BackupDocument } from './backup'
+
+export interface BackupGoblinStats {
+  hp: number
+  atk: number
+  magicAtk?: number
+  def: number
+  magicDef?: number
+  attackCount: number
+  accuracy: number
+  evasion: number
+  magicHeal?: number
+  criticalRate?: number
+}
+
+export interface BackupGoblin {
+  id: number
+  name: string
+  race: string
+  raceId?: string
+  job?: string
+  level: number
+  experience: number
+  avatar: string
+  stats: BackupGoblinStats
+  effectiveStats?: BackupGoblinStats
+  currentHp?: number
+  factors?: string[]
+  variantFactorId?: string
+  individualValue?: number
+  mods?: unknown[]
+  skills: unknown[]
+  spells?: unknown[]
+  battleActionPolicy?: unknown
+}
+
+export interface BackupEquipment {
+  id: string
+  templateId: string
+  slotIndex: number
+  goblinId: number | null
+  titleId?: string
+  titleName?: string
+}
+
+export interface BackupParty {
+  id: number
+  name: string
+  memberIds: number[]
+  status?: string
+  dungeonId?: string
+  dungeonTier?: number
+  targetFloor?: number | null
+  returnPolicy?: string
+  goldMultiplier?: number
+  rareMultiplier?: number
+  titleMultiplier?: number
+}
+
+export interface BackupExtract {
+  goblins: BackupGoblin[]
+  equipmentByGoblin: Map<number, BackupEquipment[]>
+  equipmentAll: BackupEquipment[]
+  parties: BackupParty[]
+  rawBackup: BackupDocument
+}
+
+export function extractBackup(doc: BackupDocument): BackupExtract {
+  const goblinRows = doc.tables.goblins ?? []
+  const equipmentRows = doc.tables.equipment ?? []
+  const partyRows = doc.tables.parties ?? []
+
+  const goblins = goblinRows
+    .map(rowToBackupGoblin)
+    .filter((g): g is BackupGoblin => g !== null)
+
+  const equipmentAll = equipmentRows
+    .map(rowToBackupEquipment)
+    .filter((e): e is BackupEquipment => e !== null)
+
+  const equipmentByGoblin = new Map<number, BackupEquipment[]>()
+  for (const eq of equipmentAll) {
+    if (eq.goblinId === null) continue
+    const list = equipmentByGoblin.get(eq.goblinId) ?? []
+    list.push(eq)
+    equipmentByGoblin.set(eq.goblinId, list)
+  }
+
+  const parties = partyRows
+    .map(rowToBackupParty)
+    .filter((p): p is BackupParty => p !== null)
+
+  goblins.sort((a, b) => a.id - b.id)
+  parties.sort((a, b) => a.id - b.id)
+  return { goblins, equipmentByGoblin, equipmentAll, parties, rawBackup: doc }
+}
+
+function rowToBackupGoblin(row: Record<string, unknown>): BackupGoblin | null {
+  const id = toNumber(row.id)
+  if (id === null) return null
+  const name = toStringOrUndef(row.name) ?? ''
+  const race = toStringOrUndef(row.race) ?? ''
+  return {
+    id,
+    name,
+    race,
+    raceId: toStringOrUndef(row.race_id),
+    job: toStringOrUndef(row.job_id),
+    level: toNumber(row.level) ?? 1,
+    experience: toNumber(row.experience) ?? 0,
+    avatar: toStringOrUndef(row.avatar) ?? '',
+    stats: parseJsonAs<BackupGoblinStats>(row.stats_json) ?? {
+      hp: 0,
+      atk: 0,
+      def: 0,
+      attackCount: 1,
+      accuracy: 0,
+      evasion: 0,
+    },
+    effectiveStats: parseJsonAs<BackupGoblinStats>(row.effective_stats_json) ?? undefined,
+    currentHp: toNumber(row.current_hp) ?? undefined,
+    factors: parseJsonAs<string[]>(row.factors_json) ?? undefined,
+    variantFactorId: toStringOrUndef(row.variant_factor_id),
+    individualValue: toNumber(row.individual_value) ?? undefined,
+    mods: parseJsonAs<unknown[]>(row.mods_json) ?? undefined,
+    skills: parseJsonAs<unknown[]>(row.skills_json) ?? [],
+    battleActionPolicy:
+      parseJsonAs<unknown>(row.battle_action_policy_json) ?? undefined,
+  }
+}
+
+function rowToBackupEquipment(row: Record<string, unknown>): BackupEquipment | null {
+  const id = toStringOrUndef(row.id)
+  const templateId = toStringOrUndef(row.template_id)
+  if (!id || !templateId) return null
+  return {
+    id,
+    templateId,
+    slotIndex: toNumber(row.slot_index) ?? -1,
+    goblinId: toNumber(row.goblin_id),
+    titleId: toStringOrUndef(row.title_id),
+    titleName: toStringOrUndef(row.title_name),
+  }
+}
+
+function rowToBackupParty(row: Record<string, unknown>): BackupParty | null {
+  const id = toNumber(row.id)
+  if (id === null) return null
+  const name = toStringOrUndef(row.name) ?? `Party ${id}`
+  const memberIds = parseJsonAs<unknown[]>(row.member_ids_json)
+  const normalizedMemberIds = Array.isArray(memberIds)
+    ? memberIds.map(toNumber).filter((n): n is number => n !== null)
+    : []
+  return {
+    id,
+    name,
+    memberIds: normalizedMemberIds,
+    status: toStringOrUndef(row.status),
+    dungeonId: toStringOrUndef(row.dungeon_id),
+    dungeonTier: toNumber(row.dungeon_tier) ?? undefined,
+    targetFloor:
+      row.target_floor === null ? null : toNumber(row.target_floor) ?? undefined,
+    returnPolicy: toStringOrUndef(row.return_policy),
+    goldMultiplier: toNumber(row.gold_multiplier) ?? undefined,
+    rareMultiplier: toNumber(row.rare_multiplier) ?? undefined,
+    titleMultiplier: toNumber(row.title_multiplier) ?? undefined,
+  }
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+function toStringOrUndef(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value
+  return undefined
+}
+
+function parseJsonAs<T>(value: unknown): T | null {
+  if (typeof value !== 'string' || value === '') return null
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return null
+  }
+}

--- a/tools/studio/src/lib/runExpedition.ts
+++ b/tools/studio/src/lib/runExpedition.ts
@@ -1,0 +1,198 @@
+import { ExpeditionEngine } from '@app/core/services/ExpeditionEngine'
+import type {
+  Goblin,
+  GoblinStats,
+  ExpeditionReplay,
+  ExpeditionRequest,
+  DungeonTier,
+} from '@app/shared/types'
+
+import type { BackupGoblin, BackupGoblinStats } from './goblinMapper'
+
+export type ReturnPolicy = ExpeditionRequest['returnPolicy']
+
+const DEFAULT_STATS: GoblinStats = {
+  hp: 0,
+  atk: 0,
+  magicAtk: 0,
+  def: 0,
+  magicDef: 0,
+  attackCount: 1,
+  accuracy: 0,
+  evasion: 0,
+  magicHeal: 0,
+  criticalRate: 0,
+}
+
+function fillStats(partial: BackupGoblinStats | undefined): GoblinStats {
+  if (!partial) return { ...DEFAULT_STATS }
+  return {
+    hp: partial.hp,
+    atk: partial.atk,
+    magicAtk: partial.magicAtk ?? 0,
+    def: partial.def,
+    magicDef: partial.magicDef ?? 0,
+    attackCount: partial.attackCount,
+    accuracy: partial.accuracy,
+    evasion: partial.evasion,
+    magicHeal: partial.magicHeal ?? 0,
+    criticalRate: partial.criticalRate ?? 0,
+  }
+}
+
+export function backupGoblinToGoblin(g: BackupGoblin): Goblin {
+  return {
+    id: g.id,
+    name: g.name,
+    race: g.race,
+    raceId: g.raceId as Goblin['raceId'],
+    job: g.job as Goblin['job'],
+    level: g.level,
+    experience: g.experience,
+    avatar: g.avatar,
+    stats: fillStats(g.stats),
+    effectiveStats: g.effectiveStats ? fillStats(g.effectiveStats) : undefined,
+    currentHp: g.currentHp,
+    factors: g.factors,
+    variantFactorId: g.variantFactorId,
+    individualValue: g.individualValue,
+    mods: (g.mods as Goblin['mods']) ?? undefined,
+    skills: (g.skills as Goblin['skills']) ?? [],
+    spells: (g.spells as Goblin['spells']) ?? undefined,
+    battleActionPolicy: g.battleActionPolicy as Goblin['battleActionPolicy'],
+  }
+}
+
+export interface SimulationOptions {
+  areaId: string
+  party: BackupGoblin[]
+  trials: number
+  tier?: DungeonTier
+  returnPolicy: ReturnPolicy
+  seed?: number
+  onProgress?: (completed: number, total: number) => void
+}
+
+export interface SimulationResult {
+  options: SimulationOptions
+  trials: number
+  success: number
+  defeated: number
+  policyReturned: number
+  aborted: number
+  floorDistribution: Record<number, number>
+  avgMaxFloor: number
+  avgXpGained: number
+  avgGoldGained: number
+  avgDurationSec: number
+  casualtyCounts: Record<string, number>
+  replays: ExpeditionReplay[]
+  errors: string[]
+}
+
+export async function runSimulationBatch(
+  opts: SimulationOptions,
+): Promise<SimulationResult> {
+  const {
+    areaId,
+    party,
+    trials,
+    tier,
+    returnPolicy,
+    seed,
+    onProgress,
+  } = opts
+
+  const goblinParty = party.map(backupGoblinToGoblin)
+  const baseRequest: ExpeditionRequest = {
+    partyId: 'studio',
+    areaId,
+    tier,
+    returnPolicy,
+    clientVersion: 'studio',
+  }
+
+  let successCount = 0
+  let defeatedCount = 0
+  let policyReturnedCount = 0
+  let abortedCount = 0
+  let sumFloor = 0
+  let sumXp = 0
+  let sumGold = 0
+  let sumDuration = 0
+  const floorDistribution: Record<number, number> = {}
+  const casualtyCounts: Record<string, number> = {}
+  const replays: ExpeditionReplay[] = []
+  const errors: string[] = []
+
+  for (let i = 0; i < trials; i++) {
+    const trialSeed =
+      seed !== undefined ? seed + i : Math.floor(Math.random() * 0x7fffffff)
+    const engine = new ExpeditionEngine(trialSeed)
+    try {
+      const replay = await engine.generateExpedition(baseRequest, goblinParty)
+      const floor = replay.summary.maxFloorReached
+      sumFloor += floor
+      sumXp += replay.summary.xpGained
+      sumGold += replay.summary.goldGained
+      sumDuration += replay.durationSec
+      floorDistribution[floor] = (floorDistribution[floor] ?? 0) + 1
+
+      const lastEvent = replay.events[replay.events.length - 1]
+      const endReason =
+        lastEvent && lastEvent.type === 'return' ? lastEvent.reason : null
+
+      if (replay.summary.success) {
+        successCount++
+      } else if (endReason === 'defeated') {
+        defeatedCount++
+      } else if (endReason === 'policy_return') {
+        policyReturnedCount++
+      } else {
+        abortedCount++
+      }
+
+      for (const name of replay.summary.casualties) {
+        casualtyCounts[name] = (casualtyCounts[name] ?? 0) + 1
+      }
+
+      if (replays.length < 3) replays.push(replay)
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err))
+    }
+
+    if (onProgress && (i + 1) % 10 === 0) {
+      onProgress(i + 1, trials)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
+  onProgress?.(trials, trials)
+
+  const divisor = Math.max(1, trials - errors.length)
+  return {
+    options: opts,
+    trials,
+    success: successCount,
+    defeated: defeatedCount,
+    policyReturned: policyReturnedCount,
+    aborted: abortedCount,
+    floorDistribution,
+    avgMaxFloor: sumFloor / divisor,
+    avgXpGained: sumXp / divisor,
+    avgGoldGained: sumGold / divisor,
+    avgDurationSec: sumDuration / divisor,
+    casualtyCounts,
+    replays,
+    errors,
+  }
+}
+
+export const RETURN_POLICIES: { value: ReturnPolicy; label: string }[] = [
+  { value: 'never', label: '帰還しない（到達階まで進む）' },
+  { value: 'until_floor2', label: '2F到達で帰還' },
+  { value: 'until_floor3', label: '3F到達で帰還' },
+  { value: 'if_any_ko', label: '誰か気絶したら帰還' },
+  { value: 'if_two_ko', label: '2名気絶したら帰還' },
+  { value: 'last_one', label: '最後の一人になったら帰還' },
+]

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod'
+
+export const AreaConfigSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  areaLevel: z.number().int().nonnegative(),
+  floors: z.number().int().positive(),
+  baseDurationSec: z.number().int().positive(),
+  moveSpeedScale: z.number().positive().optional(),
+  description: z.string().optional(),
+  encounter: z.object({
+    perFloorEvents: z.number().int().positive(),
+    eventWeights: z.object({
+      battle: z.number().nonnegative(),
+      exploring: z.number().nonnegative(),
+      trap: z.number().nonnegative().optional(),
+      npc: z.number().nonnegative().optional(),
+    }),
+    pityTimerSec: z.number().nonnegative().optional(),
+  }),
+  enemyTable: z
+    .array(
+      z.object({
+        id: z.string(),
+        weight: z.number().nonnegative(),
+        lvl: z.number().int().nonnegative(),
+      }),
+    )
+    .optional(),
+  boss: z
+    .object({
+      id: z.string(),
+      lvl: z.number().int().nonnegative(),
+    })
+    .optional(),
+  unlockNext: z.string().optional(),
+})
+
+export const EnemySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    raceTags: z.array(z.string()),
+    level: z.number().int().nonnegative(),
+    hp: z.number().int().nonnegative(),
+    vitality: z.number().int().nonnegative().optional(),
+    atk: z.number().int().nonnegative(),
+    magicAtk: z.number().int().nonnegative().optional(),
+    def: z.number().int().nonnegative(),
+    magicDef: z.number().int().nonnegative().optional(),
+    magicHeal: z.number().int().nonnegative().optional(),
+    agility: z.number().int().nonnegative(),
+    attackCount: z.number().int().positive(),
+    accuracy: z.number().nonnegative(),
+    evasion: z.number().nonnegative(),
+    criticalRate: z.number().nonnegative().optional(),
+    physicalResistancePercent: z.number().optional(),
+    penetrationResistancePercent: z.number().optional(),
+    criticalResistancePercent: z.number().optional(),
+    magicResistancePercent: z.number().optional(),
+    exp: z.number().int().nonnegative(),
+    gold: z.number().int().nonnegative(),
+  })
+  .passthrough()
+
+export const EnemyPatternSchema = z.object({
+  id: z.string(),
+  floors: z.array(z.number().int().nonnegative()),
+  enemies: z.array(z.array(z.string())),
+  isBoss: z.boolean().optional(),
+})
+
+export const EnemyDatabaseSchema = z.object({
+  enemies: z.array(EnemySchema),
+  patterns: z.array(EnemyPatternSchema),
+})
+
+export type AreaConfig = z.infer<typeof AreaConfigSchema>
+export type EnemyDatabase = z.infer<typeof EnemyDatabaseSchema>
+
+export interface DungeonSummary {
+  areaId: string
+  name: string
+  areaLevel: number
+  floors: number
+  baseDurationSec: number
+  enemyCount: number
+  patternCount: number
+}
+
+export interface DungeonDetailDto {
+  areaId: string
+  area: AreaConfig
+  enemy: EnemyDatabase | null
+}

--- a/tools/studio/src/main.tsx
+++ b/tools/studio/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+
+import { App } from './App'
+import './styles.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+)

--- a/tools/studio/src/pages/DungeonDetail.tsx
+++ b/tools/studio/src/pages/DungeonDetail.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+import { AreaConfigSchema, EnemyDatabaseSchema } from '../lib/schema'
+import type { AreaConfig, DungeonDetailDto, EnemyDatabase } from '../lib/schema'
+import { AreaSettingsEditor } from '../components/AreaSettingsEditor'
+import { EnemyEditor } from '../components/EnemyEditor'
+import { PatternEditor } from '../components/PatternEditor'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'error'; message: string }
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+type Tab = 'area' | 'enemies' | 'patterns'
+
+interface DraftState {
+  area: AreaConfig
+  enemy: EnemyDatabase | null
+}
+
+export function DungeonDetail() {
+  const { areaId } = useParams<{ areaId: string }>()
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [tab, setTab] = useState<Tab>('area')
+  const [draft, setDraft] = useState<DraftState | null>(null)
+  const originalRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!areaId) return
+    let cancelled = false
+    setLoadState({ kind: 'loading' })
+    setSaveState({ kind: 'idle' })
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/dungeons/${areaId}`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as DungeonDetailDto
+        if (cancelled) return
+        const initial: DraftState = { area: data.area, enemy: data.enemy }
+        originalRef.current = stableStringify(initial)
+        setDraft(initial)
+        setLoadState({ kind: 'ready' })
+      } catch (err) {
+        if (!cancelled) {
+          setLoadState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [areaId])
+
+  const isDirty = useMemo(() => {
+    if (!draft || originalRef.current === null) return false
+    return stableStringify(draft) !== originalRef.current
+  }, [draft])
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  const updateArea = useCallback((updater: (prev: AreaConfig) => AreaConfig) => {
+    setDraft((prev) => (prev ? { ...prev, area: updater(prev.area) } : prev))
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const updateEnemy = useCallback(
+    (updater: (prev: EnemyDatabase) => EnemyDatabase) => {
+      setDraft((prev) => {
+        if (!prev || !prev.enemy) return prev
+        return { ...prev, enemy: updater(prev.enemy) }
+      })
+      setSaveState({ kind: 'idle' })
+    },
+    [],
+  )
+
+  const save = useCallback(async () => {
+    if (!areaId || !draft) return
+    const areaResult = AreaConfigSchema.safeParse(draft.area)
+    if (!areaResult.success) {
+      setSaveState({
+        kind: 'error',
+        message: `area 検証失敗: ${areaResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(' / ')}`,
+      })
+      return
+    }
+    let enemyPayload: EnemyDatabase | null = null
+    if (draft.enemy) {
+      const enemyResult = EnemyDatabaseSchema.safeParse(draft.enemy)
+      if (!enemyResult.success) {
+        setSaveState({
+          kind: 'error',
+          message: `enemy 検証失敗: ${enemyResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(' / ')}`,
+        })
+        return
+      }
+      enemyPayload = draft.enemy
+    }
+
+    setSaveState({ kind: 'saving' })
+    try {
+      const res = await fetch(`/api/dungeons/${areaId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ area: draft.area, enemy: enemyPayload }),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      originalRef.current = stableStringify(draft)
+      setSaveState({ kind: 'success' })
+    } catch (err) {
+      setSaveState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [areaId, draft])
+
+  const revert = useCallback(() => {
+    if (originalRef.current === null) return
+    try {
+      setDraft(JSON.parse(originalRef.current) as DraftState)
+      setSaveState({ kind: 'idle' })
+    } catch {
+      // noop
+    }
+  }, [])
+
+  const enemyNameMap = useMemo(() => {
+    if (!draft?.enemy) return new Map<string, string>()
+    return new Map(draft.enemy.enemies.map((e) => [e.id, e.name]))
+  }, [draft])
+
+  if (loadState.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {loadState.message}</p>
+  }
+  if (!draft) return null
+
+  const { area, enemy } = draft
+
+  return (
+    <div className="detail">
+      <p>
+        <Link to="/">← 一覧へ戻る</Link>
+      </p>
+      <div className="detail-head">
+        <div>
+          <h2>{area.name}</h2>
+          <p className="subtle">
+            <code>{area.id}</code> · Lv {area.areaLevel} · {area.floors}F · {area.baseDurationSec}s
+            {enemy ? ` · 敵 ${enemy.enemies.length}種 / パターン ${enemy.patterns.length}個` : ''}
+          </p>
+        </div>
+        <SaveBar
+          isDirty={isDirty}
+          saveState={saveState}
+          onSave={save}
+          onRevert={revert}
+        />
+      </div>
+      <div className="tabs">
+        <button
+          className={tab === 'area' ? 'tab active' : 'tab'}
+          onClick={() => setTab('area')}
+        >
+          エリア設定
+        </button>
+        <button
+          className={tab === 'enemies' ? 'tab active' : 'tab'}
+          onClick={() => setTab('enemies')}
+          disabled={!enemy}
+        >
+          敵リスト{enemy ? ` (${enemy.enemies.length})` : ''}
+        </button>
+        <button
+          className={tab === 'patterns' ? 'tab active' : 'tab'}
+          onClick={() => setTab('patterns')}
+          disabled={!enemy}
+        >
+          パターン{enemy ? ` (${enemy.patterns.length})` : ''}
+        </button>
+      </div>
+      <div className="tab-panel">
+        {tab === 'area' && <AreaSettingsEditor area={area} onChange={updateArea} />}
+        {tab === 'enemies' && enemy && <EnemyEditor enemy={enemy} onChange={updateEnemy} />}
+        {tab === 'patterns' && enemy && (
+          <PatternEditor enemy={enemy} enemyNameMap={enemyNameMap} onChange={updateEnemy} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SaveBar({
+  isDirty,
+  saveState,
+  onSave,
+  onRevert,
+}: {
+  isDirty: boolean
+  saveState: SaveState
+  onSave: () => void
+  onRevert: () => void
+}) {
+  return (
+    <div className="save-bar">
+      {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+      {saveState.kind === 'success' && !isDirty && <span className="saved">保存しました</span>}
+      {saveState.kind === 'error' && <span className="save-error">{saveState.message}</span>}
+      <button
+        className="btn ghost"
+        onClick={onRevert}
+        disabled={!isDirty || saveState.kind === 'saving'}
+      >
+        取り消し
+      </button>
+      <button
+        className="btn primary"
+        onClick={onSave}
+        disabled={!isDirty || saveState.kind === 'saving'}
+      >
+        保存
+      </button>
+    </div>
+  )
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {}
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k]
+      }
+      return sorted
+    }
+    return val
+  })
+}

--- a/tools/studio/src/pages/DungeonList.tsx
+++ b/tools/studio/src/pages/DungeonList.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import type { DungeonSummary } from '../lib/schema'
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: DungeonSummary[] }
+  | { kind: 'error'; message: string }
+
+export function DungeonList() {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/dungeons')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as DungeonSummary[]
+        if (!cancelled) setState({ kind: 'ready', data })
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (state.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (state.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {state.message}</p>
+  }
+
+  return (
+    <table className="dungeon-table">
+      <thead>
+        <tr>
+          <th>areaId</th>
+          <th>名前</th>
+          <th className="num">Lv</th>
+          <th className="num">階層</th>
+          <th className="num">所要時間(s)</th>
+          <th className="num">敵種類</th>
+          <th className="num">パターン</th>
+        </tr>
+      </thead>
+      <tbody>
+        {state.data.map((d) => (
+          <tr key={d.areaId}>
+            <td>
+              <Link to={`/dungeons/${d.areaId}`}>{d.areaId}</Link>
+            </td>
+            <td>{d.name}</td>
+            <td className="num">{d.areaLevel}</td>
+            <td className="num">{d.floors}</td>
+            <td className="num">{d.baseDurationSec}</td>
+            <td className="num">{d.enemyCount}</td>
+            <td className="num">{d.patternCount}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/tools/studio/src/pages/PartyPage.tsx
+++ b/tools/studio/src/pages/PartyPage.tsx
@@ -1,0 +1,55 @@
+import { usePartyStore } from '../stores/partyStore'
+import { BackupDropzone } from '../components/BackupDropzone'
+import { BackupPartyList } from '../components/BackupPartyList'
+import { GoblinBrowser } from '../components/GoblinBrowser'
+import { PartyEditor } from '../components/PartyEditor'
+import { PresetList } from '../components/PresetList'
+
+export function PartyPage() {
+  const { backup, backupError, clearBackup } = usePartyStore()
+
+  return (
+    <div className="party-layout">
+      <div className="party-main">
+        {backup ? (
+          <>
+            <div className="filters">
+              <span className="subtle">
+                バックアップ読み込み済み：ゴブリン {backup.goblins.length} 体 /
+                PT {backup.parties.length} 件 /
+                装備 {backup.equipmentAll.length} 個
+                {backup.rawBackup.meta.exportedAt
+                  ? `（${backup.rawBackup.meta.exportedAt.slice(0, 10)} 出力）`
+                  : ''}
+              </span>
+              <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.4rem' }}>
+                <BackupDropzone compact />
+                <button className="btn ghost" onClick={clearBackup}>
+                  アンロード
+                </button>
+              </div>
+            </div>
+            {backupError && <p className="save-error">{backupError}</p>}
+            <GoblinBrowser />
+          </>
+        ) : (
+          <section className="card">
+            <h2>バックアップ JSON を読み込む</h2>
+            <p className="subtle">
+              実ゲームのセーブデータ（バックアップ JSON）からゴブリンを読み込んで
+              シミュレーション用 PT を編成します。バックアップはブラウザ内のメモリにのみ保持され、
+              ファイルや外部への送信は行いません。
+            </p>
+            <BackupDropzone />
+            {backupError && <p className="save-error">{backupError}</p>}
+          </section>
+        )}
+      </div>
+      <aside className="party-side">
+        <PartyEditor />
+        <BackupPartyList />
+        <PresetList />
+      </aside>
+    </div>
+  )
+}

--- a/tools/studio/src/pages/SimulatePage.tsx
+++ b/tools/studio/src/pages/SimulatePage.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import type { DungeonSummary } from '../lib/schema'
+import {
+  RETURN_POLICIES,
+  runSimulationBatch,
+  type ReturnPolicy,
+  type SimulationResult,
+} from '../lib/runExpedition'
+import type { BackupGoblin } from '../lib/goblinMapper'
+import { usePartyStore } from '../stores/partyStore'
+import { SimulationResultView } from '../components/SimulationResultView'
+
+type PartySource = 'draft' | `preset:${string}` | `backup:${number}`
+
+const TRIAL_OPTIONS = [50, 200, 500, 1000, 3000]
+
+export function SimulatePage() {
+  const { backup, draft, presets } = usePartyStore()
+
+  const [dungeons, setDungeons] = useState<DungeonSummary[]>([])
+  const [dungeonsError, setDungeonsError] = useState<string | null>(null)
+  const [areaId, setAreaId] = useState<string>('')
+  const [tier, setTier] = useState<number>(0)
+  const [returnPolicy, setReturnPolicy] = useState<ReturnPolicy>('never')
+  const [trials, setTrials] = useState<number>(200)
+  const [seedMode, setSeedMode] = useState<'random' | 'fixed'>('random')
+  const [fixedSeed, setFixedSeed] = useState<number>(1)
+  const [partySource, setPartySource] = useState<PartySource>('draft')
+  const [running, setRunning] = useState(false)
+  const [progress, setProgress] = useState<{ completed: number; total: number } | null>(null)
+  const [result, setResult] = useState<SimulationResult | null>(null)
+  const [runError, setRunError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/dungeons')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as DungeonSummary[]
+        if (cancelled) return
+        setDungeons(data)
+        if (data.length > 0 && !areaId) setAreaId(data[0].areaId)
+      } catch (err) {
+        if (!cancelled) {
+          setDungeonsError(err instanceof Error ? err.message : String(err))
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const resolvedParty = useMemo<BackupGoblin[]>(() => {
+    if (!backup) return []
+    let ids: number[] = []
+    if (partySource === 'draft') {
+      ids = draft.members.filter((m): m is number => m !== null)
+    } else if (partySource.startsWith('preset:')) {
+      ids =
+        presets.find((p) => p.id === partySource.slice('preset:'.length))
+          ?.memberIds ?? []
+    } else if (partySource.startsWith('backup:')) {
+      const partyId = Number(partySource.slice('backup:'.length))
+      ids = backup.parties.find((p) => p.id === partyId)?.memberIds ?? []
+    }
+    return ids
+      .map((id) => backup.goblins.find((g) => g.id === id))
+      .filter((g): g is BackupGoblin => g !== undefined)
+  }, [backup, draft, presets, partySource])
+
+  const canRun =
+    !running &&
+    areaId !== '' &&
+    resolvedParty.length > 0 &&
+    trials > 0 &&
+    backup !== null
+
+  const runSimulation = useCallback(async () => {
+    setRunning(true)
+    setResult(null)
+    setRunError(null)
+    setProgress({ completed: 0, total: trials })
+    try {
+      const res = await runSimulationBatch({
+        areaId,
+        party: resolvedParty,
+        trials,
+        tier: tier as never,
+        returnPolicy,
+        seed: seedMode === 'fixed' ? fixedSeed : undefined,
+        onProgress: (completed, total) => setProgress({ completed, total }),
+      })
+      setResult(res)
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRunning(false)
+    }
+  }, [areaId, resolvedParty, trials, tier, returnPolicy, seedMode, fixedSeed])
+
+  if (!backup) {
+    return (
+      <div className="panel-stack">
+        <section className="card">
+          <h2>シミュレーション</h2>
+          <p className="subtle">
+            シミュレーションには PT を編成する必要があります。まず{' '}
+            <Link to="/party">PT編成</Link> 画面でバックアップを読み込んでください。
+          </p>
+        </section>
+      </div>
+    )
+  }
+
+  return (
+    <div className="simulate-layout">
+      <section className="card simulate-controls">
+        <h2>シミュレーション設定</h2>
+        <div className="field-group" style={{ gridTemplateColumns: '1fr 1fr' }}>
+          <label className="field">
+            <span className="field-label">ダンジョン</span>
+            <span className="field-input">
+              <select value={areaId} onChange={(e) => setAreaId(e.target.value)}>
+                {dungeons.map((d) => (
+                  <option key={d.areaId} value={d.areaId}>
+                    Lv{d.areaLevel} · {d.name}（{d.areaId}）
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+          <label className="field">
+            <span className="field-label">Tier</span>
+            <span className="field-input">
+              <select value={tier} onChange={(e) => setTier(Number(e.target.value))}>
+                {[0, 1, 2, 3].map((t) => (
+                  <option key={t} value={t}>
+                    Tier {t}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+          <label className="field">
+            <span className="field-label">帰還ポリシー</span>
+            <span className="field-input">
+              <select
+                value={returnPolicy}
+                onChange={(e) => setReturnPolicy(e.target.value as ReturnPolicy)}
+              >
+                {RETURN_POLICIES.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+          <label className="field">
+            <span className="field-label">試行回数</span>
+            <span className="field-input">
+              <select
+                value={trials}
+                onChange={(e) => setTrials(Number(e.target.value))}
+              >
+                {TRIAL_OPTIONS.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+          <label className="field">
+            <span className="field-label">シード</span>
+            <span className="field-input">
+              <select
+                value={seedMode}
+                onChange={(e) => setSeedMode(e.target.value as 'random' | 'fixed')}
+              >
+                <option value="random">ランダム</option>
+                <option value="fixed">固定</option>
+              </select>
+              {seedMode === 'fixed' && (
+                <input
+                  type="number"
+                  value={fixedSeed}
+                  min={0}
+                  onChange={(e) => setFixedSeed(Number(e.target.value) || 0)}
+                />
+              )}
+            </span>
+          </label>
+          <label className="field">
+            <span className="field-label">PT</span>
+            <span className="field-input">
+              <select
+                value={partySource}
+                onChange={(e) => setPartySource(e.target.value as PartySource)}
+              >
+                <option value="draft">
+                  編集中のPT（{draft.members.filter((m) => m !== null).length}体）
+                </option>
+                {backup.parties.map((p) => (
+                  <option key={`backup-${p.id}`} value={`backup:${p.id}`}>
+                    [バックアップ] {p.name}（{p.memberIds.length}体）
+                  </option>
+                ))}
+                {presets.map((p) => (
+                  <option key={p.id} value={`preset:${p.id}`}>
+                    [プリセット] {p.name}（{p.memberIds.length}体）
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+        </div>
+        <PartyPreview party={resolvedParty} />
+        {dungeonsError && <p className="save-error">{dungeonsError}</p>}
+        {runError && <p className="save-error">{runError}</p>}
+        <div className="simulate-actions">
+          {running && progress && (
+            <span className="subtle">
+              実行中… {progress.completed} / {progress.total}
+            </span>
+          )}
+          <button
+            className="btn primary"
+            onClick={runSimulation}
+            disabled={!canRun}
+          >
+            {running ? '実行中…' : 'シミュレーション実行'}
+          </button>
+        </div>
+      </section>
+
+      {result && <SimulationResultView result={result} />}
+    </div>
+  )
+}
+
+function PartyPreview({ party }: { party: BackupGoblin[] }) {
+  if (party.length === 0) {
+    return <p className="save-error">PTにゴブリンが割り当てられていません</p>
+  }
+  return (
+    <div className="party-preview-list">
+      {party.map((g) => (
+        <div key={g.id} className="party-preview-chip">
+          <strong>{g.name}</strong>
+          <span className="subtle"> Lv{g.level} {g.job ? `(${g.job})` : ''}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/tools/studio/src/stores/partyStore.tsx
+++ b/tools/studio/src/stores/partyStore.tsx
@@ -1,0 +1,393 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+
+import { parseBackupFile } from '../lib/backup'
+import type { BackupExtract, BackupGoblin, BackupParty } from '../lib/goblinMapper'
+import { extractBackup } from '../lib/goblinMapper'
+
+export const MAX_PARTY_MEMBERS = 6
+const PRESET_API_URL = '/api/party-presets'
+const LEGACY_STORAGE_KEY = 'goblin-studio:party-presets:v1'
+
+export interface PartyPreset {
+  id: string
+  name: string
+  memberIds: number[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PartyDraft {
+  name: string
+  members: (number | null)[]
+}
+
+interface PartyStoreValue {
+  backup: BackupExtract | null
+  backupError: string | null
+  backupLoading: boolean
+  loadBackup: (file: File) => Promise<void>
+  clearBackup: () => void
+
+  draft: PartyDraft
+  setDraftName: (name: string) => void
+  setMemberAt: (index: number, goblinId: number | null) => void
+  addMember: (goblinId: number) => boolean
+  removeMember: (index: number) => void
+  clearDraft: () => void
+
+  loadBackupParty: (partyId: number) => void
+  importBackupPartyAsPreset: (partyId: number) => PartyPreset | null
+
+  presets: PartyPreset[]
+  presetsLoading: boolean
+  presetsError: string | null
+  savePreset: () => PartyPreset | null
+  updatePreset: (id: string) => void
+  loadPreset: (id: string) => void
+  deletePreset: (id: string) => void
+  renamePreset: (id: string, name: string) => void
+}
+
+const StoreContext = createContext<PartyStoreValue | null>(null)
+
+const EMPTY_DRAFT: PartyDraft = {
+  name: '新規PT',
+  members: Array.from({ length: MAX_PARTY_MEMBERS }, () => null),
+}
+
+export function PartyStoreProvider({ children }: { children: ReactNode }) {
+  const [backup, setBackup] = useState<BackupExtract | null>(null)
+  const [backupError, setBackupError] = useState<string | null>(null)
+  const [backupLoading, setBackupLoading] = useState(false)
+  const [draft, setDraft] = useState<PartyDraft>(EMPTY_DRAFT)
+  const [presets, setPresets] = useState<PartyPreset[]>([])
+  const [presetsLoading, setPresetsLoading] = useState(true)
+  const [presetsError, setPresetsError] = useState<string | null>(null)
+  const hasLoadedRef = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const fromServer = await fetchPresets()
+        if (cancelled) return
+        const legacy = consumeLegacyLocalStorage()
+        if (legacy.length > 0 && fromServer.length === 0) {
+          // 初回移行: localStorage のプリセットをファイルに昇格
+          await persistPresets(legacy)
+          setPresets(legacy)
+        } else {
+          setPresets(fromServer)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setPresetsError(err instanceof Error ? err.message : String(err))
+        }
+      } finally {
+        if (!cancelled) {
+          setPresetsLoading(false)
+          hasLoadedRef.current = true
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!hasLoadedRef.current) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        await persistPresets(presets)
+        if (!cancelled) setPresetsError(null)
+      } catch (err) {
+        if (!cancelled) {
+          setPresetsError(err instanceof Error ? err.message : String(err))
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [presets])
+
+  const loadBackup = useCallback(async (file: File) => {
+    setBackupLoading(true)
+    setBackupError(null)
+    try {
+      const doc = await parseBackupFile(file)
+      const extract = extractBackup(doc)
+      setBackup(extract)
+    } catch (err) {
+      setBackupError(err instanceof Error ? err.message : String(err))
+      setBackup(null)
+    } finally {
+      setBackupLoading(false)
+    }
+  }, [])
+
+  const clearBackup = useCallback(() => {
+    setBackup(null)
+    setBackupError(null)
+  }, [])
+
+  const setDraftName = useCallback((name: string) => {
+    setDraft((prev) => ({ ...prev, name }))
+  }, [])
+
+  const setMemberAt = useCallback((index: number, goblinId: number | null) => {
+    setDraft((prev) => {
+      if (index < 0 || index >= MAX_PARTY_MEMBERS) return prev
+      const nextMembers = prev.members.slice()
+      nextMembers[index] = goblinId
+      return { ...prev, members: nextMembers }
+    })
+  }, [])
+
+  const addMember = useCallback((goblinId: number): boolean => {
+    let added = false
+    setDraft((prev) => {
+      if (prev.members.includes(goblinId)) return prev
+      const emptyIdx = prev.members.findIndex((m) => m === null)
+      if (emptyIdx < 0) return prev
+      const nextMembers = prev.members.slice()
+      nextMembers[emptyIdx] = goblinId
+      added = true
+      return { ...prev, members: nextMembers }
+    })
+    return added
+  }, [])
+
+  const removeMember = useCallback((index: number) => {
+    setDraft((prev) => {
+      if (index < 0 || index >= MAX_PARTY_MEMBERS) return prev
+      const nextMembers = prev.members.slice()
+      nextMembers[index] = null
+      return { ...prev, members: nextMembers }
+    })
+  }, [])
+
+  const clearDraft = useCallback(() => {
+    setDraft({ ...EMPTY_DRAFT, members: EMPTY_DRAFT.members.slice() })
+  }, [])
+
+  const loadBackupParty = useCallback((partyId: number) => {
+    setBackup((current) => {
+      const party = current?.parties.find((p) => p.id === partyId)
+      if (!party) return current
+      setDraft({
+        name: party.name,
+        members: Array.from(
+          { length: MAX_PARTY_MEMBERS },
+          (_, i) => party.memberIds[i] ?? null,
+        ),
+      })
+      return current
+    })
+  }, [])
+
+  const importBackupPartyAsPreset = useCallback(
+    (partyId: number): PartyPreset | null => {
+      const party = backup?.parties.find((p) => p.id === partyId)
+      if (!party) return null
+      const now = new Date().toISOString()
+      const preset: PartyPreset = {
+        id: `preset_backup_${party.id}_${Date.now()}`,
+        name: party.name,
+        memberIds: party.memberIds.slice(),
+        createdAt: now,
+        updatedAt: now,
+      }
+      setPresets((prev) => [preset, ...prev])
+      return preset
+    },
+    [backup],
+  )
+
+  const savePreset = useCallback((): PartyPreset | null => {
+    const memberIds = draft.members.filter((m): m is number => m !== null)
+    if (memberIds.length === 0) return null
+    const now = new Date().toISOString()
+    const preset: PartyPreset = {
+      id: `preset_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      name: draft.name.trim() === '' ? '無名PT' : draft.name,
+      memberIds,
+      createdAt: now,
+      updatedAt: now,
+    }
+    setPresets((prev) => [preset, ...prev])
+    return preset
+  }, [draft])
+
+  const updatePreset = useCallback(
+    (id: string) => {
+      const memberIds = draft.members.filter((m): m is number => m !== null)
+      setPresets((prev) =>
+        prev.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                name: draft.name.trim() === '' ? p.name : draft.name,
+                memberIds,
+                updatedAt: new Date().toISOString(),
+              }
+            : p,
+        ),
+      )
+    },
+    [draft],
+  )
+
+  const loadPreset = useCallback((id: string) => {
+    setPresets((prev) => {
+      const preset = prev.find((p) => p.id === id)
+      if (!preset) return prev
+      setDraft({
+        name: preset.name,
+        members: Array.from(
+          { length: MAX_PARTY_MEMBERS },
+          (_, i) => preset.memberIds[i] ?? null,
+        ),
+      })
+      return prev
+    })
+  }, [])
+
+  const deletePreset = useCallback((id: string) => {
+    setPresets((prev) => prev.filter((p) => p.id !== id))
+  }, [])
+
+  const renamePreset = useCallback((id: string, name: string) => {
+    setPresets((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, name, updatedAt: new Date().toISOString() } : p,
+      ),
+    )
+  }, [])
+
+  const value = useMemo<PartyStoreValue>(
+    () => ({
+      backup,
+      backupError,
+      backupLoading,
+      loadBackup,
+      clearBackup,
+      draft,
+      setDraftName,
+      setMemberAt,
+      addMember,
+      removeMember,
+      clearDraft,
+      loadBackupParty,
+      importBackupPartyAsPreset,
+      presets,
+      presetsLoading,
+      presetsError,
+      savePreset,
+      updatePreset,
+      loadPreset,
+      deletePreset,
+      renamePreset,
+    }),
+    [
+      backup,
+      backupError,
+      backupLoading,
+      loadBackup,
+      clearBackup,
+      draft,
+      setDraftName,
+      setMemberAt,
+      addMember,
+      removeMember,
+      clearDraft,
+      loadBackupParty,
+      importBackupPartyAsPreset,
+      presets,
+      presetsLoading,
+      presetsError,
+      savePreset,
+      updatePreset,
+      loadPreset,
+      deletePreset,
+      renamePreset,
+    ],
+  )
+
+  return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>
+}
+
+export function usePartyStore(): PartyStoreValue {
+  const ctx = useContext(StoreContext)
+  if (!ctx) throw new Error('usePartyStore は PartyStoreProvider 内で使用してください')
+  return ctx
+}
+
+export function useGoblinById(id: number | null | undefined): BackupGoblin | null {
+  const { backup } = usePartyStore()
+  return useMemo(() => {
+    if (!backup || id === null || id === undefined) return null
+    return backup.goblins.find((g) => g.id === id) ?? null
+  }, [backup, id])
+}
+
+export type { BackupParty }
+
+async function fetchPresets(): Promise<PartyPreset[]> {
+  const res = await fetch(PRESET_API_URL)
+  if (!res.ok) throw new Error(`プリセット読み込み失敗: HTTP ${res.status}`)
+  const data = (await res.json()) as unknown
+  if (!Array.isArray(data)) return []
+  return data.filter(
+    (p): p is PartyPreset =>
+      typeof p === 'object' &&
+      p !== null &&
+      typeof (p as PartyPreset).id === 'string' &&
+      typeof (p as PartyPreset).name === 'string' &&
+      Array.isArray((p as PartyPreset).memberIds),
+  )
+}
+
+async function persistPresets(presets: PartyPreset[]): Promise<void> {
+  const res = await fetch(PRESET_API_URL, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(presets),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error ?? `プリセット保存失敗: HTTP ${res.status}`)
+  }
+}
+
+function consumeLegacyLocalStorage(): PartyPreset[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(LEGACY_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as PartyPreset[]
+    const valid = Array.isArray(parsed)
+      ? parsed.filter(
+          (p): p is PartyPreset =>
+            typeof p.id === 'string' &&
+            typeof p.name === 'string' &&
+            Array.isArray(p.memberIds),
+        )
+      : []
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY)
+    return valid
+  } catch {
+    return []
+  }
+}

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -1,0 +1,1243 @@
+:root {
+  color-scheme: light;
+  --bg: #faf8f5;
+  --surface: #ffffff;
+  --surface-muted: #f3f0eb;
+  --surface-sunken: #efece6;
+  --border: #e8e4df;
+  --border-strong: #d0ccc7;
+  --text: #1a1a1a;
+  --text-sub: #777777;
+  --text-muted: #999999;
+  --accent: #1a1a1a;
+  --accent-fg: #ffffff;
+  --accent-hover: #333333;
+  --link: #1a1a1a;
+  --success-bg: #e8f5e9;
+  --success-fg: #2e7d32;
+  --success-border: #c8e6c9;
+  --danger-bg: #fdecea;
+  --danger-fg: #c62828;
+  --danger-border: #f5c6c2;
+  --highlight: #f1ece3;
+  --boss: #b58a00;
+  --boss-bg: #fbf4dc;
+  --radius-card: 16px;
+  --radius-sm: 8px;
+  --radius-pill: 999px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Helvetica Neue', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: baseline;
+  gap: 2rem;
+  padding: 0.9rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: saturate(180%) blur(8px);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  font-weight: 700;
+}
+
+.app-header h1 a {
+  color: inherit;
+}
+
+.app-header nav {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.88rem;
+  color: var(--text-sub);
+}
+
+.app-header nav a {
+  color: var(--text-sub);
+}
+
+.app-header nav a:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.app-main {
+  flex: 1;
+  padding: 1.5rem;
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.placeholder {
+  color: var(--text-sub);
+}
+
+.state-msg {
+  color: var(--text-sub);
+  padding: 2rem 0;
+}
+
+.state-msg.error {
+  color: var(--danger-fg);
+}
+
+.subtle {
+  color: var(--text-sub);
+  font-size: 0.85rem;
+}
+
+code {
+  font-family: 'JetBrains Mono', 'SF Mono', 'Menlo', ui-monospace, monospace;
+  font-size: 0.85em;
+  background: var(--surface-muted);
+  padding: 0.1em 0.45em;
+  border-radius: 4px;
+  color: var(--text);
+}
+
+.dungeon-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+}
+
+.dungeon-table th,
+.dungeon-table td {
+  text-align: left;
+  padding: 0.65rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.dungeon-table tr:last-child td {
+  border-bottom: none;
+}
+
+.dungeon-table th {
+  font-weight: 600;
+  color: var(--text-sub);
+  background: var(--surface-muted);
+  position: sticky;
+  top: 0;
+}
+
+.dungeon-table td.num,
+.dungeon-table th.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.dungeon-table tr:hover td {
+  background: var(--surface-muted);
+}
+
+/* detail */
+
+.detail h2 {
+  margin: 0.5rem 0 0.25rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.detail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-top: 1.5rem;
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  color: var(--text-sub);
+  padding: 0.6rem 1rem;
+  font-size: 0.88rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.tab:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.tab.active {
+  color: var(--text);
+  border-bottom-color: var(--text);
+}
+
+.tab:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tab-panel {
+  padding-top: 1rem;
+}
+
+.panel-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 1.25rem 1.5rem;
+}
+
+.card h2,
+.card h3 {
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card h2 {
+  font-size: 1.2rem;
+}
+
+.card h4 {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.82rem;
+  color: var(--text-sub);
+  font-weight: 600;
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: 10rem 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.kv dt {
+  color: var(--text-sub);
+}
+
+.kv dd {
+  margin: 0;
+}
+
+.weights,
+.enemy-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+.weights th,
+.weights td,
+.enemy-table th,
+.enemy-table td {
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.weights th,
+.enemy-table th {
+  color: var(--text-sub);
+  font-weight: 600;
+  background: var(--surface-muted);
+}
+
+.enemy-table tbody tr {
+  cursor: pointer;
+}
+
+.enemy-table tbody tr:hover {
+  background: var(--surface-muted);
+}
+
+.enemy-table tbody tr.selected {
+  background: var(--highlight);
+}
+
+.enemy-table td.num,
+.enemy-table th.num,
+.weights td.num,
+.weights th.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.enemy-layout {
+  display: grid;
+  grid-template-columns: 1fr 22rem;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1024px) {
+  .enemy-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.enemy-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.search-input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.55rem 0.85rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--text);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.stat {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.35rem 0.65rem;
+  background: var(--surface-muted);
+  border-radius: 4px;
+}
+
+.stat-label {
+  color: var(--text-sub);
+}
+
+.stat-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.json-view {
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.7rem 0.8rem;
+  font-size: 0.78rem;
+  max-height: 16rem;
+  overflow: auto;
+  margin: 0;
+  color: var(--text);
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.5rem 0;
+  margin-bottom: 0.6rem;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.filters select {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.filters select:focus {
+  outline: none;
+  border-color: var(--text);
+}
+
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
+  gap: 0.85rem;
+}
+
+.pattern-card {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: var(--surface);
+}
+
+.pattern-card.boss {
+  border-color: var(--boss);
+  background: var(--boss-bg);
+}
+
+.pattern-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.88rem;
+  flex-wrap: wrap;
+  row-gap: 0.4rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.12rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.boss-badge {
+  background: var(--boss);
+  color: #fff;
+}
+
+.formation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.formation-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.row-label {
+  color: var(--text-sub);
+  font-size: 0.75rem;
+  min-width: 2rem;
+  text-align: center;
+  padding: 0.15rem 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface-muted);
+}
+
+.formation-slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.slot {
+  background: var(--surface-muted);
+  color: var(--text);
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+  border: 1px solid var(--border);
+}
+
+.enemy-detail {
+  position: sticky;
+  top: 5rem;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+}
+
+/* save bar / buttons */
+
+.save-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 500;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.btn.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btn.ghost {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.btn.ghost:hover:not(:disabled) {
+  background: var(--surface-muted);
+}
+
+.btn.small {
+  padding: 0.3rem 0.65rem;
+  font-size: 0.8rem;
+}
+
+.saved {
+  color: var(--success-fg);
+  background: var(--success-bg);
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+}
+
+.save-error {
+  color: var(--danger-fg);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.82rem;
+  word-break: break-word;
+  margin: 0.5rem 0;
+}
+
+/* forms */
+
+.field-group {
+  display: grid;
+  gap: 0.6rem 0.85rem;
+}
+
+.field-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 0.85rem;
+  align-items: flex-end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  min-width: 0;
+}
+
+.field-size-xs {
+  flex: 0 0 6.5rem;
+}
+
+.field-size-sm {
+  flex: 0 0 9.5rem;
+}
+
+.field-size-md {
+  flex: 0 1 15rem;
+}
+
+.field-size-lg {
+  flex: 1 1 20rem;
+}
+
+.field-size-xl {
+  flex: 1 1 100%;
+}
+
+.field-label {
+  color: var(--text-sub);
+  font-weight: 500;
+}
+
+.field-input {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  transition: border-color 0.15s;
+}
+
+.field-input:focus-within {
+  border-color: var(--text);
+}
+
+.field-input input,
+.field-input select {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+  font-family: inherit;
+}
+
+.field-input input:focus,
+.field-input select:focus {
+  outline: none;
+}
+
+.field-suffix {
+  color: var(--text-sub);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.inline-input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.inline-input:focus {
+  outline: none;
+  border-color: var(--text);
+}
+
+.inline-input.narrow {
+  width: 5.5rem;
+}
+
+.inline-input.flex1 {
+  flex: 1;
+  min-width: 0;
+}
+
+/* pattern editor specific */
+
+.pattern-layout {
+  display: grid;
+  grid-template-columns: 1fr 18rem;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1100px) {
+  .pattern-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pattern-main {
+  min-width: 0;
+}
+
+.enemy-palette {
+  position: sticky;
+  top: 5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 1rem 1.1rem;
+  max-height: calc(100vh - 6rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.enemy-palette h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.palette-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+}
+
+.palette-item {
+  background: var(--surface-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 0.45rem 0.6rem;
+  cursor: grab;
+  user-select: none;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.palette-item:hover {
+  border-color: var(--border-strong);
+}
+
+.palette-item.selected {
+  border-color: var(--text);
+  background: var(--surface);
+}
+
+.palette-item:active {
+  cursor: grabbing;
+}
+
+.palette-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.palette-sub {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+}
+
+.pattern-actions {
+  display: flex;
+  gap: 0.2rem;
+  margin-left: auto;
+}
+
+.icon-btn {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  border-radius: 6px;
+  width: 1.85rem;
+  height: 1.65rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.12s;
+}
+
+.icon-btn:hover:not(:disabled) {
+  background: var(--surface-muted);
+}
+
+.icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.icon-btn.small {
+  width: 1.55rem;
+  height: 1.35rem;
+  font-size: 0.75rem;
+}
+
+.icon-btn.danger {
+  color: var(--danger-fg);
+  border-color: var(--danger-border);
+}
+
+.icon-btn.danger:hover:not(:disabled) {
+  background: var(--danger-bg);
+}
+
+.editable-formation {
+  gap: 0.45rem;
+}
+
+.formation-row-editable {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  background: var(--surface-muted);
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--radius-sm);
+}
+
+.row-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 2.4rem;
+}
+
+.row-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.slot-lane {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  flex: 1;
+  min-height: 2.4rem;
+  padding: 0.25rem;
+  border: 1px dashed var(--border-strong);
+  border-radius: 6px;
+  align-items: center;
+  background: var(--surface);
+}
+
+.slot-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: var(--surface);
+  color: var(--text);
+  padding: 0.2rem 0.35rem 0.2rem 0.6rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+  cursor: grab;
+  user-select: none;
+}
+
+.slot-tile:active {
+  cursor: grabbing;
+}
+
+.slot-tile.drag-over {
+  border-color: var(--text);
+  box-shadow: inset 3px 0 0 var(--text);
+}
+
+.slot-tile.unknown {
+  background: var(--danger-bg);
+  color: var(--danger-fg);
+  border-color: var(--danger-border);
+}
+
+.slot-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-sub);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0 0.15rem;
+}
+
+.slot-remove:hover {
+  color: var(--text);
+}
+
+.slot-add {
+  background: var(--surface);
+  border: 1px dashed var(--border-strong);
+  color: var(--text-sub);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.7rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.slot-add:hover:not(:disabled) {
+  border-color: var(--text-sub);
+  color: var(--text);
+}
+
+.slot-add:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* dropzone / party / simulate */
+
+.dropzone {
+  margin-top: 0.85rem;
+  padding: 2.5rem 1rem;
+  border: 2px dashed var(--border-strong);
+  border-radius: var(--radius-card);
+  text-align: center;
+  cursor: pointer;
+  background: var(--surface-muted);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.dropzone:hover,
+.dropzone.drag-over {
+  border-color: var(--text);
+  background: var(--surface);
+}
+
+.dropzone p {
+  margin: 0.3rem 0;
+}
+
+.party-layout {
+  display: grid;
+  grid-template-columns: 1fr 22rem;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1100px) {
+  .party-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.party-main {
+  min-width: 0;
+}
+
+.party-side {
+  position: sticky;
+  top: 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+}
+
+.goblin-toolbar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.goblin-toolbar .search-input {
+  flex: 1;
+}
+
+.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sortable:hover {
+  color: var(--text);
+}
+
+.party-editor-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.65rem;
+}
+
+.party-slots {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.party-slot {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.65rem;
+}
+
+.party-slot.empty {
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+}
+
+.slot-index {
+  color: var(--text-sub);
+  font-size: 0.72rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.slot-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.slot-title {
+  font-size: 0.88rem;
+}
+
+.slot-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  margin-top: 0.15rem;
+}
+
+.party-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin-top: 0.85rem;
+}
+
+.preset-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.preset-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+}
+
+.preset-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.preset-name {
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.preset-actions {
+  display: flex;
+  gap: 0.2rem;
+}
+
+.simulate-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.simulate-controls .field-input select,
+.simulate-controls .field-input input {
+  width: 100%;
+}
+
+.party-preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.85rem;
+}
+
+.party-preview-chip {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.7rem;
+  font-size: 0.82rem;
+}
+
+.simulate-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.result-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  gap: 0.55rem;
+  margin: 0.85rem 0 1.25rem;
+}
+
+.metric {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.8rem;
+}
+
+.metric-label {
+  color: var(--text-sub);
+  font-size: 0.75rem;
+}
+
+.metric-value {
+  font-size: 1.15rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  margin-top: 0.2rem;
+}
+
+.metric-sub {
+  font-size: 0.72rem;
+  margin-top: 0.1rem;
+}
+
+.floor-hist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 1.2rem;
+}
+
+.floor-hist-row {
+  display: grid;
+  grid-template-columns: 3rem 1fr 8rem;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.82rem;
+}
+
+.floor-hist-label {
+  color: var(--text-sub);
+  text-align: right;
+}
+
+.floor-hist-bar {
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  height: 0.75rem;
+}
+
+.floor-hist-fill {
+  display: block;
+  height: 100%;
+  background: var(--text);
+}
+
+.floor-hist-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.error-list {
+  padding-left: 1.2rem;
+  margin: 0.3rem 0;
+}
+
+/* json sections / editors */
+
+.formation-row.editable {
+  gap: 0.4rem;
+}
+
+.pattern-preview {
+  margin-top: 0.45rem;
+  padding-top: 0.45rem;
+  border-top: 1px dashed var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.json-section {
+  margin-top: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+
+.json-section > summary {
+  padding: 0.45rem 0.7rem;
+  cursor: pointer;
+  color: var(--text-sub);
+  font-size: 0.85rem;
+}
+
+.json-section > summary:hover {
+  color: var(--text);
+}
+
+.json-editor {
+  width: 100%;
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  padding: 0.6rem;
+  font-family: 'JetBrains Mono', 'SF Mono', 'Menlo', ui-monospace, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  resize: vertical;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.json-editor.tall {
+  min-height: 24rem;
+}
+
+.json-section-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.45rem 0.7rem;
+}

--- a/tools/studio/tsconfig.app.json
+++ b/tools/studio/tsconfig.app.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@studio/*": ["src/*"],
+      "@app/*": ["../../goblin_native/src/*"],
+      "@/*": ["../../goblin_native/src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/tools/studio/tsconfig.json
+++ b/tools/studio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tools/studio/tsconfig.node.json
+++ b/tools/studio/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "src/api/**/*"]
+}

--- a/tools/studio/vite.config.ts
+++ b/tools/studio/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { dataApiPlugin } from './src/api/dataPlugin'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const APP_SRC = path.resolve(__dirname, '../../goblin_native/src')
+const DATA_DIR = path.resolve(__dirname, 'data')
+
+export default defineConfig({
+  plugins: [react(), dataApiPlugin({ appSrc: APP_SRC, dataDir: DATA_DIR })],
+  resolve: {
+    alias: {
+      '@studio': path.resolve(__dirname, 'src'),
+      '@app': APP_SRC,
+      '@': APP_SRC,
+    },
+  },
+  server: {
+    port: 5180,
+    strictPort: true,
+  },
+})


### PR DESCRIPTION
## Summary
- goblin_native のダンジョン/敵マスタ JSON を直接編集できる Vite + React ツール `tools/studio` を新規追加
- バックアップ JSON からゴブリン/PTを取り込み、ExpeditionEngine を直接呼び出してN試行シミュレーション結果を集計
- 併せて各ダンジョンの areaLevel を上方に再調整（新ツールでの編集結果）

## 追加機能
- **ダンジョン編集**: 一覧 → エリア設定 / 敵リスト / エンカウントパターン（ドラッグ&ドロップ配置）の各タブで閲覧・編集・保存
- **PT編成**: バックアップ JSON から読み込んだゴブリンで編成。バックアップ内の既存 PT もそのまま読込可能
- **プリセット**: `tools/studio/data/party-presets.json` に永続化（`.gitignore` 済み、チーム共有したければ外す）
- **シミュレーション**: ダンジョン × Tier × PT × 帰還ポリシー × 試行回数で統計出力（勝率/到達階分布/期待XP/Gold/死亡率）

## 起動方法
```bash
cd tools/studio
npm install
npm run dev  # http://localhost:5180
```

## Test plan
- [ ] `cd tools/studio && npm install && npm run dev` で起動を確認
- [ ] `/` でダンジョン一覧が表示される（40件）
- [ ] 任意のダンジョンで敵ステータスを編集 → 保存 → `git diff` で JSON 反映を確認
- [ ] バックアップ JSON をドロップ → ゴブリン/PT 一覧が表示される
- [ ] PT 編成後にシミュレーション実行で結果サマリーが表示される
- [ ] areaLevel 再調整でゲーム本体の遠征難易度が想定通り変動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)