### PR TITLE
feat(studio): ストーリー/ゴブリンデータ編集ページを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## プロジェクト構成とモジュール配置
 - `goblin_ink/` は Ink 製 CLI バトルシミュレーター。ゲームロジックは `src/battle.ts`・`src/ai.ts`、UI は `src/components/` 配下、ビルド成果物は `dist/` に出力されます。
 - `goblin_web/` は Vite + React クライアント。機能別に `components/`、`contexts/`、`services/`、`repositories/`、`shared/` を分離し、静的アセットは `public/`、ビルド成果物は `dist/` に配置します。画面仕様は `SCREEN_DOCUMENTATION.md`、遠征ロジックは `EXPEDITION_IMPLEMENTATION.md` と `goblin_ink/spec.md` を参照してください。
+- `tools/studio/` は Vite + React 製のローカル開発ツールです。ダンジョン一覧・詳細編集、敵/パターン編集、PT 編成、遠征シミュレーションを提供し、`goblin_native/src` のデータを直接参照します。
 
 ## コミュニケーション方針
 - Issue、Pull Request、レビューコメント、ドキュメント更新はすべて日本語で行ってください。
@@ -11,6 +12,7 @@
 - パッケージごとに依存を導入します（例：`cd goblin_ink && npm install`、`cd ../goblin_web && npm install`）。
 - CLI 側: `npm run dev` でホットリロード、`npm run watch` は `tsc` 常駐、`npm run build` と `npm start` でビルド済みバンドルを実行します。
 - Web 側: `npm run dev` で Vite 開発サーバー（デフォルト `5173`）、`npm run build` で TypeScript 参照ビルド後にバンドル、`npm run preview` で生成物を確認、`npm run lint` で ESLint を実行します。
+- Studio 側: `cd tools/studio && npm install && npm run dev` で起動します。Vite 開発サーバーは `5180` 番ポート固定で、`npm run build`、`npm run preview`、`npm run typecheck` が利用できます。
 
 ## コーディングスタイルと命名規則
 - TypeScript は `strict` 設定。公開 API には明示的な型注釈を付け、2 スペースインデント・シングルクォートを維持してください（Ink 側はセミコロンあり、Web 側は現状なし）。
@@ -25,6 +27,12 @@
 ## プロジェクト概要
 - `goblin_ink/`: DQ 形式のターン制コマンドバトルを TypeScript で実装した CLI 版。4 人 PT（ゴブリン軍）と 3 体の敵（人間軍）が物理・魔法攻撃や防御・逃走コマンドで戦う簡易 AI 付きのシミュレーターです。`npm run build` / `npm start` でビルド・実行し、`src/` には型定義・データ・バトル/AI/UI/メインループが分割配置されています。[^goblin-ink]
 - `goblin_web/`: React + TypeScript + Vite 製のクライアントで、遠征（Expedition）機能をプリコンピュート方式で再生します。ダンジョン選択からパーティ編成・帰還条件設定、タイムライン再生、結果表示まで一連の UI が実装済みで、遠征エンジン・型定義・データを `src/services` / `src/types` / `src/data` にまとめています。未実装としてローカル保存や履歴表示などの段階 6 タスクが残っています。[^goblin-web]
+- `tools/studio/`: `goblin_native` 向けのローカル編集・検証ツールです。`/api/dungeons` 経由で `goblin_native/src/shared/data/expeditionArea/*.json` と `enemy/*.json` を直接読み書きし、`/api/party-presets` で `tools/studio/data/party-presets.json` に PT プリセットを保存します。バックアップ JSON は読み取り専用でメモリにのみ保持され、シミュレーションは `ExpeditionEngine` を直接実行します。
+
+## Studio 作業時の注意
+- `tools/studio/` は単体アプリではなく、`../../goblin_native/src` を Vite alias（`@app` / `@`）で直接参照します。`goblin_native/` が同一リポジトリ内に存在する前提です。
+- ダンジョン/敵データの保存は即座に JSON ファイルへ反映されます。変更確認は `git diff` を基準に行ってください。
+- `tools/studio/data/party-presets.json` は個人作業用で、既定では `.gitignore` 対象です。共有目的で扱う場合のみ運用を明示してください。
 
 [^goblin-ink]: 詳細は `goblin_ink/README.md` を参照してください。
 [^goblin-web]: 詳細は `goblin_web/EXPEDITION_IMPLEMENTATION.md` を参照してください。

--- a/goblin_native/src/shared/data/goblinJobs.ts
+++ b/goblin_native/src/shared/data/goblinJobs.ts
@@ -42,92 +42,132 @@ type GoblinJobDefinitionSeed = {
 
 const GOBLIN_JOB_DEFINITION_SEEDS: Record<GoblinJob, GoblinJobDefinitionSeed> = {
   guard: {
-    id: 'guard',
-    accentColor: '#2563EB',
+    accentColor: "#2563EB",
+    id: "guard",
     skills: [
       {
-        skillId: 'talent_def_150',
+        skillId: "talent_def_150"
       },
       {
-        skillId: 'armor_mastery_150',
+        skillId: "armor_mastery_150"
       },
       {
-        skillId: 'physical_reduction_5',
+        skillId: "physical_reduction_5"
       },
       {
-        unlockLevel: 15,
-        skillId: 'cover_low_hp_ally',
+        skillId: "cover_low_hp_ally",
+        unlockLevel: 15
       },
       {
-        unlockLevel: 15,
-        skillId: 'rear_guard',
-      },
+        skillId: "rear_guard",
+        unlockLevel: 15
+      }
     ],
+    baseAttributes: {
+      power: 10,
+      wisdom: 10,
+      spirit: 10,
+      vitality: 11,
+      agility: 10,
+      luck: 10
+    }
   },
   thief: {
-    id: 'thief',
-    accentColor: '#059669',
+    accentColor: "#059669",
+    id: "thief",
     skills: [
       {
-        skillId: 'action_order_150',
+        skillId: "action_order_150"
       },
       {
-        skillId: 'gold_bonus_50',
+        skillId: "gold_bonus_50"
       },
       {
-        unlockLevel: 15,
-        skillId: 'evasion_150',
-      },
+        skillId: "evasion_150",
+        unlockLevel: 15
+      }
     ],
-  },
-  mage: {
-    id: 'mage',
-    accentColor: '#B91C1C',
-    skills: [
-      {
-        skillId: 'mage_magic_lv7',
-      },
-    ],
-  },
-  warrior: {
-    id: 'warrior',
-    accentColor: '#EA580C',
-    skills: [
-      {
-        skillId: 'talent_attackCount_150',
-      },
-      {
-        skillId: 'armor_mastery_120',
-      },
-      {
-        skillId: 'inspire_150',
-      },
-    ],
-  },
-  cleric: {
-    id: 'cleric',
-    accentColor: '#0D9488',
-    unlockRequiresClearedArea: 'road_1',
-    skills: [
-      {
-        skillId: 'recovery_magic_lv7',
-      },
-    ],
-  },
-  rider: {
-    id: 'rider',
-    accentColor: '#7C3AED',
-    unlockRequiresReadStory: 'story_after_wolf_grassland',
     baseAttributes: {
-      power: 12,
-      wisdom: 8,
+      power: 10,
+      wisdom: 10,
       spirit: 10,
       vitality: 10,
+      agility: 11,
+      luck: 11
+    }
+  },
+  mage: {
+    accentColor: "#B91C1C",
+    id: "mage",
+    skills: [
+      {
+        skillId: "mage_magic_lv7"
+      }
+    ],
+    baseAttributes: {
+      power: 10,
+      wisdom: 11,
+      spirit: 10,
+      vitality: 10,
+      agility: 10,
+      luck: 10
+    }
+  },
+  warrior: {
+    accentColor: "#EA580C",
+    id: "warrior",
+    skills: [
+      {
+        skillId: "talent_attackCount_150"
+      },
+      {
+        skillId: "armor_mastery_120"
+      },
+      {
+        skillId: "inspire_150"
+      }
+    ],
+    baseAttributes: {
+      power: 10,
+      wisdom: 10,
+      spirit: 10,
+      vitality: 11,
+      agility: 10,
+      luck: 10
+    }
+  },
+  cleric: {
+    accentColor: "#0D9488",
+    id: "cleric",
+    skills: [
+      {
+        skillId: "recovery_magic_lv7"
+      }
+    ],
+    unlockRequiresClearedArea: "road_1",
+    baseAttributes: {
+      power: 10,
+      wisdom: 10,
+      spirit: 11,
+      vitality: 10,
+      agility: 10,
+      luck: 10
+    }
+  },
+  rider: {
+    accentColor: "#7C3AED",
+    baseAttributes: {
       agility: 15,
       luck: 12,
+      power: 12,
+      spirit: 10,
+      vitality: 10,
+      wisdom: 8
     },
+    id: "rider",
     skills: [],
-  },
+    unlockRequiresReadStory: "story_after_wolf_grassland"
+  }
 }
 
 function buildGoblinJobDefinition(seed: GoblinJobDefinitionSeed): GoblinJobDefinition {

--- a/goblin_native/src/shared/data/goblinVariants.ts
+++ b/goblin_native/src/shared/data/goblinVariants.ts
@@ -47,211 +47,389 @@ export const DEFAULT_GOBLIN_COMBAT_STATS: GoblinCombatStats = {
 
 export const goblinVariantDefinitions: Record<string, GoblinVariantDefinition> = {
   slime: {
-    factorId: 'slime',
-    factorName: 'スライム因子',
-    factorDescription: 'スライムの特性を宿した因子。耐久性が増す。',
-    inheritProbability: 0.3,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 100 },
-    ],
-    variantProbability: 0.2,
-    raceId: 'slime',
-    raceName: 'スライムゴブリン',
-    avatar: '/src/assets/goblin/slime_goblin.png',
-    imageKey: 'slime_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'def', value: 20 },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 20
+      }
     ],
-    baseAttributes: { power: 8, wisdom: 8, spirit: 13, vitality: 13, agility: 8, luck: 10 },
-    hpCoefficient: 1.2,
-    combatStats: { attackCount: 2, accuracy: 20, evasion: 15 },
+    avatar: "/src/assets/goblin/slime_goblin.png",
+    baseAttributes: {
+      agility: 8,
+      luck: 10,
+      power: 8,
+      spirit: 13,
+      vitality: 13,
+      wisdom: 8
+    },
+    combatStats: {
+      accuracy: 20,
+      attackCount: 2,
+      evasion: 15
+    },
     defaultSkillIds: [
-      'talent_hp_150',
-      'armor_mastery_130',
-      'rear_guard',
-      'hp_regen_20',
+      "talent_hp_150",
+      "armor_mastery_130",
+      "rear_guard",
+      "hp_regen_20"
     ],
+    factorDescription: "スライムの特性を宿した因子。耐久性が増す。",
+    factorEffects: [
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 100
+      }
+    ],
+    factorId: "slime",
+    factorName: "スライム因子",
+    hpCoefficient: 1.2,
+    imageKey: "slime_goblin",
+    inheritProbability: 0.3,
+    raceId: "slime",
+    raceName: "スライムゴブリン",
+    variantProbability: 0.2
   },
   wolf: {
-    factorId: 'wolf',
-    factorName: 'ウルフ因子',
-    factorDescription: 'ウルフの特性を宿した因子。敏捷性が増す。',
-    inheritProbability: 0.25,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'atk', value: 15 },
-    ],
-    variantProbability: 0.15,
-    raceId: 'wolf',
-    raceName: 'ウルフゴブリン',
-    avatar: '/src/assets/goblin/wolf_goblin.png',
-    imageKey: 'wolf_goblin',
     additionalEffects: [],
-    baseAttributes: { power: 11, wisdom: 9, spirit: 10, vitality: 10, agility: 13, luck: 12 },
-    hpCoefficient: 0.9,
-    combatStats: { attackCount: 3, accuracy: 20, evasion: 15 },
+    avatar: "/src/assets/goblin/wolf_goblin.png",
+    baseAttributes: {
+      agility: 13,
+      luck: 12,
+      power: 11,
+      spirit: 10,
+      vitality: 10,
+      wisdom: 9
+    },
+    combatStats: {
+      accuracy: 20,
+      attackCount: 3,
+      evasion: 15
+    },
     defaultSkillIds: [
-      'talent_accuracy_150',
-      'attack_count_up_2',
-      'equipment_accuracy_200',
-      'additional_damage_13',
+      "talent_accuracy_150",
+      "attack_count_up_2",
+      "equipment_accuracy_200",
+      "additional_damage_13"
     ],
+    factorDescription: "ウルフの特性を宿した因子。敏捷性が増す。",
+    factorEffects: [
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 15
+      }
+    ],
+    factorId: "wolf",
+    factorName: "ウルフ因子",
+    hpCoefficient: 0.9,
+    imageKey: "wolf_goblin",
+    inheritProbability: 0.25,
+    raceId: "wolf",
+    raceName: "ウルフゴブリン",
+    variantProbability: 0.15
   },
   orc: {
-    factorId: 'orc',
-    factorName: 'オーク因子',
-    factorDescription: 'オークの特性を宿した因子。攻撃力と防御力が増す。',
-    inheritProbability: 0.2,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'atk', value: 25 },
-      { type: 'stat_bonus', target: 'def', value: 20 },
-    ],
-    variantProbability: 0.1,
-    raceId: 'orc',
-    raceName: 'オークゴブリン',
-    avatar: '/src/assets/goblin/orc_goblin.png',
-    imageKey: 'orc_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 50 },
-      { type: 'stat_bonus', target: 'atk', value: 10 },
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 50
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 10
+      }
     ],
-    baseAttributes: { power: 15, wisdom: 8, spirit: 9, vitality: 15, agility: 7, luck: 8 },
-    hpCoefficient: 1.5,
-    combatStats: { attackCount: 2, accuracy: 20, evasion: 15 },
+    avatar: "/src/assets/goblin/orc_goblin.png",
+    baseAttributes: {
+      agility: 7,
+      luck: 8,
+      power: 15,
+      spirit: 9,
+      vitality: 15,
+      wisdom: 8
+    },
+    combatStats: {
+      accuracy: 20,
+      attackCount: 2,
+      evasion: 15
+    },
     defaultSkillIds: [],
+    factorDescription: "オークの特性を宿した因子。攻撃力と防御力が増す。",
+    factorEffects: [
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 25
+      },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 20
+      }
+    ],
+    factorId: "orc",
+    factorName: "オーク因子",
+    hpCoefficient: 1.5,
+    imageKey: "orc_goblin",
+    inheritProbability: 0.2,
+    raceId: "orc",
+    raceName: "オークゴブリン",
+    variantProbability: 0.1
   },
   undead: {
-    factorId: 'undead',
-    factorName: 'アンデッド因子',
-    factorDescription: 'アンデッドの特性を宿した因子。生命力と耐毒性が増す。',
-    inheritProbability: 0.2,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 80 },
-      { type: 'stat_bonus', target: 'def', value: 15 },
-    ],
-    variantProbability: 0.15,
-    raceId: 'undead',
-    raceName: 'アンデッドゴブリン',
-    avatar: '/src/assets/goblin/skelton_goblin.png',
-    imageKey: 'skelton_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 40 },
-      { type: 'stat_bonus', target: 'atk', value: 10 },
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 40
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 10
+      }
     ],
-    baseAttributes: { power: 11, wisdom: 8, spirit: 10, vitality: 15, agility: 7, luck: 9 },
+    avatar: "/src/assets/goblin/skelton_goblin.png",
+    baseAttributes: {
+      agility: 7,
+      luck: 9,
+      power: 11,
+      spirit: 10,
+      vitality: 15,
+      wisdom: 8
+    },
     defaultSkillIds: [
-      'talent_itemSlots',
-      'undead_trait',
-      'hp_regen_20',
+      "talent_itemSlots",
+      "undead_trait",
+      "hp_regen_20"
     ],
+    factorDescription: "アンデッドの特性を宿した因子。生命力と耐毒性が増す。",
+    factorEffects: [
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 80
+      },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 15
+      }
+    ],
+    factorId: "undead",
+    factorName: "アンデッド因子",
+    imageKey: "skelton_goblin",
+    inheritProbability: 0.2,
+    raceId: "undead",
+    raceName: "アンデッドゴブリン",
+    variantProbability: 0.15
   },
   hobgoblin: {
-    factorId: 'hobgoblin',
-    factorName: 'ホブゴブリン因子',
-    factorDescription: '上位ゴブリンの特性を宿した因子。全能力が底上げされる。',
-    inheritProbability: 0.25,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'atk', value: 15 },
-      { type: 'stat_bonus', target: 'def', value: 10 },
-    ],
-    variantProbability: 0.2,
-    raceId: 'hobgoblin',
-    raceName: 'ホブゴブリン',
-    avatar: '/src/assets/goblin/hobgoblin.png',
-    imageKey: 'hobgoblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 30 },
-      { type: 'stat_bonus', target: 'atk', value: 10 },
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 30
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 10
+      }
     ],
-    baseAttributes: { power: 13, wisdom: 11, spirit: 11, vitality: 11, agility: 11, luck: 10 },
-    hpCoefficient: 1.2,
-    combatStats: { attackCount: 2, accuracy: 20, evasion: 15 },
+    avatar: "/src/assets/goblin/hobgoblin.png",
+    baseAttributes: {
+      agility: 11,
+      luck: 10,
+      power: 13,
+      spirit: 11,
+      vitality: 11,
+      wisdom: 11
+    },
+    combatStats: {
+      accuracy: 20,
+      attackCount: 2,
+      evasion: 15
+    },
     defaultSkillIds: [
-      'talent_atk_150',
-      'inspire_150',
-      'survive_lethal_hp1',
+      "talent_atk_150",
+      "inspire_150",
+      "survive_lethal_hp1"
     ],
+    factorDescription: "上位ゴブリンの特性を宿した因子。全能力が底上げされる。",
+    factorEffects: [
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 15
+      },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 10
+      }
+    ],
+    factorId: "hobgoblin",
+    factorName: "ホブゴブリン因子",
+    hpCoefficient: 1.2,
+    imageKey: "hobgoblin",
+    inheritProbability: 0.25,
+    raceId: "hobgoblin",
+    raceName: "ホブゴブリン",
+    variantProbability: 0.2
   },
   dwarf: {
-    factorId: 'dwarf',
-    factorName: 'ドワーフ因子',
-    factorDescription: 'ドワーフの特性を宿した因子。防御力と耐久性が大幅に増す。',
-    inheritProbability: 0.2,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'def', value: 30 },
-      { type: 'stat_bonus', target: 'hp', value: 60 },
-    ],
-    variantProbability: 0.1,
-    raceId: 'dwarf',
-    raceName: 'ドワーフゴブリン',
-    avatar: '/src/assets/goblin/dwarf_goblin.png',
-    imageKey: 'dwarf_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'def', value: 20 },
-      { type: 'stat_bonus', target: 'atk', value: 15 },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 20
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 15
+      }
     ],
+    avatar: "/src/assets/goblin/dwarf_goblin.png",
     defaultSkillIds: [],
+    factorDescription: "ドワーフの特性を宿した因子。防御力と耐久性が大幅に増す。",
+    factorEffects: [
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 30
+      },
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 60
+      }
+    ],
+    factorId: "dwarf",
+    factorName: "ドワーフ因子",
+    imageKey: "dwarf_goblin",
+    inheritProbability: 0.2,
+    raceId: "dwarf",
+    raceName: "ドワーフゴブリン",
+    variantProbability: 0.1
   },
   elf: {
-    factorId: 'elf',
-    factorName: 'エルフ因子',
-    factorDescription: 'エルフの特性を宿した因子。敏捷性と精神力が増す。',
-    inheritProbability: 0.2,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'def', value: 15 },
-    ],
-    variantProbability: 0.1,
-    raceId: 'elf',
-    raceName: 'エルフゴブリン',
-    avatar: '/src/assets/goblin/elf_goblin.png',
-    imageKey: 'elf_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'atk', value: 10 },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 10
+      }
     ],
+    avatar: "/src/assets/goblin/elf_goblin.png",
     defaultSkillIds: [],
+    factorDescription: "エルフの特性を宿した因子。敏捷性と精神力が増す。",
+    factorEffects: [
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 15
+      }
+    ],
+    factorId: "elf",
+    factorName: "エルフ因子",
+    imageKey: "elf_goblin",
+    inheritProbability: 0.2,
+    raceId: "elf",
+    raceName: "エルフゴブリン",
+    variantProbability: 0.1
   },
   lizardman: {
-    factorId: 'lizardman',
-    factorName: 'リザードマン因子',
-    factorDescription: 'リザードマンの特性を宿した因子。全体的な耐性とHPが増す。',
-    inheritProbability: 0.15,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 70 },
-      { type: 'stat_bonus', target: 'def', value: 20 },
-      { type: 'stat_bonus', target: 'atk', value: 10 },
-    ],
-    variantProbability: 0.1,
-    raceId: 'lizardman',
-    raceName: 'リザードゴブリン',
-    avatar: '/src/assets/goblin/lizard_goblin.png',
-    imageKey: 'lizard_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'def', value: 15 },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 15
+      }
     ],
+    avatar: "/src/assets/goblin/lizard_goblin.png",
     defaultSkillIds: [],
+    factorDescription: "リザードマンの特性を宿した因子。全体的な耐性とHPが増す。",
+    factorEffects: [
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 70
+      },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 20
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 10
+      }
+    ],
+    factorId: "lizardman",
+    factorName: "リザードマン因子",
+    imageKey: "lizard_goblin",
+    inheritProbability: 0.15,
+    raceId: "lizardman",
+    raceName: "リザードゴブリン",
+    variantProbability: 0.1
   },
   troll: {
-    factorId: 'troll',
-    factorName: 'トロル因子',
-    factorDescription: 'トロルの特性を宿した因子。HPが大幅に増し、防御力も上がる。',
-    inheritProbability: 0.15,
-    factorEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 150 },
-      { type: 'stat_bonus', target: 'def', value: 15 },
-    ],
-    variantProbability: 0.08,
-    raceId: 'troll',
-    raceName: 'トロルゴブリン',
-    avatar: '/src/assets/goblin/troll_goblin.png',
-    imageKey: 'troll_goblin',
     additionalEffects: [
-      { type: 'stat_bonus', target: 'hp', value: 80 },
-      { type: 'stat_bonus', target: 'atk', value: 20 },
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 80
+      },
+      {
+        target: "atk",
+        type: "stat_bonus",
+        value: 20
+      }
     ],
-    baseAttributes: { power: 16, wisdom: 7, spirit: 8, vitality: 18, agility: 5, luck: 7 },
-    hpCoefficient: 1.7,
-    combatStats: { attackCount: 2, accuracy: 20, evasion: 15 },
+    avatar: "/src/assets/goblin/troll_goblin.png",
+    baseAttributes: {
+      agility: 5,
+      luck: 7,
+      power: 16,
+      spirit: 8,
+      vitality: 18,
+      wisdom: 7
+    },
+    combatStats: {
+      accuracy: 20,
+      attackCount: 2,
+      evasion: 15
+    },
     defaultSkillIds: [],
-  },
+    factorDescription: "トロルの特性を宿した因子。HPが大幅に増し、防御力も上がる。",
+    factorEffects: [
+      {
+        target: "hp",
+        type: "stat_bonus",
+        value: 150
+      },
+      {
+        target: "def",
+        type: "stat_bonus",
+        value: 15
+      }
+    ],
+    factorId: "troll",
+    factorName: "トロル因子",
+    hpCoefficient: 1.7,
+    imageKey: "troll_goblin",
+    inheritProbability: 0.15,
+    raceId: "troll",
+    raceName: "トロルゴブリン",
+    variantProbability: 0.08
+  }
 }
 
 export function getGoblinVariantByFactorId(factorId: string): GoblinVariantDefinition | undefined {

--- a/goblin_native/src/shared/data/races.ts
+++ b/goblin_native/src/shared/data/races.ts
@@ -1,6 +1,16 @@
 import type { RaceDict } from '../../core/services/DamageCalculator';
 
 export const races: RaceDict = {
-  beast: { label: '魔獣' },
-  goblin: { label: 'ゴブリン' },
+  beast: {
+    label: "魔獣"
+  },
+  goblin: {
+    label: "ゴブリン"
+  },
+  human: {
+    label: "人間"
+  },
+  demon_race: {
+    label: "魔族"
+  }
 };

--- a/tools/studio/src/App.tsx
+++ b/tools/studio/src/App.tsx
@@ -4,6 +4,9 @@ import { DungeonList } from './pages/DungeonList'
 import { DungeonDetail } from './pages/DungeonDetail'
 import { PartyPage } from './pages/PartyPage'
 import { SimulatePage } from './pages/SimulatePage'
+import { StoryListPage } from './pages/StoryListPage'
+import { StoryDetailPage } from './pages/StoryDetailPage'
+import { GoblinDataPage } from './pages/GoblinDataPage'
 import { PartyStoreProvider } from './stores/partyStore'
 
 export function App() {
@@ -16,6 +19,8 @@ export function App() {
           </h1>
           <nav>
             <Link to="/">ダンジョン</Link>
+            <Link to="/stories">ストーリー</Link>
+            <Link to="/goblins">ゴブリン</Link>
             <Link to="/party">PT編成</Link>
             <Link to="/simulate">シミュレーション</Link>
           </nav>
@@ -24,6 +29,10 @@ export function App() {
           <Routes>
             <Route path="/" element={<DungeonList />} />
             <Route path="/dungeons/:areaId" element={<DungeonDetail />} />
+            <Route path="/stories" element={<StoryListPage />} />
+            <Route path="/stories/new" element={<StoryDetailPage />} />
+            <Route path="/stories/:storyId" element={<StoryDetailPage />} />
+            <Route path="/goblins" element={<GoblinDataPage />} />
             <Route path="/party" element={<PartyPage />} />
             <Route path="/simulate" element={<SimulatePage />} />
           </Routes>

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Plugin } from 'vite'
+import vm from 'node:vm'
 
 interface Options {
   appSrc: string
@@ -18,9 +19,110 @@ interface DungeonSummary {
   patternCount: number
 }
 
+interface StoryRecord {
+  id: string
+  title: string
+  category: 'main' | 'side'
+  order: number
+  unlockCondition: { type: 'dungeon_cleared'; dungeonId: string } | null
+  rewards: unknown[]
+  chapters: Array<{ id: string; text: string }>
+}
+
+interface StoryFile {
+  stories: StoryRecord[]
+}
+
+interface StorySummary {
+  id: string
+  title: string
+  category: StoryRecord['category']
+  order: number
+  chapterCount: number
+  rewardCount: number
+  unlockLabel: string
+}
+
+interface GoblinRaceEntry {
+  id: string
+  label: string
+}
+
+interface GoblinJobSkillSeed {
+  unlockLevel?: number
+  skillId: string
+}
+
+interface GoblinBaseAttributes {
+  power: number
+  wisdom: number
+  spirit: number
+  vitality: number
+  agility: number
+  luck: number
+}
+
+interface GoblinFactorEffect {
+  type: 'stat_bonus' | 'resistance' | 'skill_unlock'
+  target:
+    | 'hp'
+    | 'atk'
+    | 'magicAtk'
+    | 'def'
+    | 'magicDef'
+    | 'attackCount'
+    | 'accuracy'
+    | 'evasion'
+    | 'magicHeal'
+  value: number
+}
+
+interface GoblinCombatStats {
+  attackCount: number
+  accuracy: number
+  evasion: number
+}
+
+interface GoblinJobSeed {
+  id: string
+  accentColor: string
+  skills: GoblinJobSkillSeed[]
+  unlockRequiresClearedArea?: string
+  unlockRequiresReadStory?: string
+  baseAttributes?: GoblinBaseAttributes
+}
+
+interface GoblinVariantSeed {
+  factorId: string
+  factorName: string
+  factorDescription: string
+  inheritProbability: number
+  factorEffects: GoblinFactorEffect[]
+  variantProbability: number
+  raceId: string
+  raceName: string
+  avatar: string
+  imageKey: string
+  additionalEffects: GoblinFactorEffect[]
+  baseAttributes?: GoblinBaseAttributes
+  hpCoefficient?: number
+  combatStats?: GoblinCombatStats
+  defaultSkillIds?: string[]
+}
+
+interface GoblinStudioData {
+  races: GoblinRaceEntry[]
+  jobs: GoblinJobSeed[]
+  variants: GoblinVariantSeed[]
+}
+
 export function dataApiPlugin(options: Options): Plugin {
   const areaDir = path.join(options.appSrc, 'shared', 'data', 'expeditionArea')
   const enemyDir = path.join(options.appSrc, 'shared', 'data', 'enemy')
+  const storyFile = path.join(options.appSrc, 'shared', 'data', 'story', 'stories.json')
+  const racesFile = path.join(options.appSrc, 'shared', 'data', 'races.ts')
+  const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
+  const variantsFile = path.join(options.appSrc, 'shared', 'data', 'goblinVariants.ts')
   const presetsFile = path.join(options.dataDir, 'party-presets.json')
 
   return {
@@ -67,6 +169,72 @@ export function dataApiPlugin(options: Options): Plugin {
             const body = await readBody(req)
             await writePresets(presetsFile, body)
             return json(res, 200, { ok: true })
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          return json(res, 500, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/stories', async (req, res) => {
+        try {
+          const url = new URL(req.url ?? '/', 'http://localhost')
+          const segments = url.pathname.split('/').filter(Boolean)
+
+          if (segments.length === 0) {
+            if (req.method === 'GET') {
+              return json(res, 200, await listStories(storyFile))
+            }
+            if (req.method === 'POST') {
+              const body = await readBody(req)
+              return json(res, 200, await createStory(storyFile, body))
+            }
+            return json(res, 405, { error: 'Method not allowed' })
+          }
+
+          const storyId = segments[0]
+          if (!isSafeId(storyId)) {
+            return json(res, 400, { error: 'Invalid storyId' })
+          }
+
+          if (req.method === 'GET') {
+            return json(res, 200, await readStory(storyFile, storyId))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            return json(res, 200, await updateStory(storyFile, storyId, body))
+          }
+          if (req.method === 'DELETE') {
+            return json(res, 200, await deleteStory(storyFile, storyId))
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          const status = message.startsWith('NOT_FOUND') ? 404 : 500
+          return json(res, status, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/goblin-data', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            return json(
+              res,
+              200,
+              await readGoblinStudioData({ racesFile, jobsFile, variantsFile }),
+            )
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            return json(
+              res,
+              200,
+              await writeGoblinStudioData(
+                { racesFile, jobsFile, variantsFile },
+                body,
+              ),
+            )
           }
           return json(res, 405, { error: 'Method not allowed' })
         } catch (err) {
@@ -135,6 +303,23 @@ async function listDungeons(areaDir: string, enemyDir: string): Promise<DungeonS
   return filtered
 }
 
+async function listStories(storyFile: string): Promise<StorySummary[]> {
+  const data = await readStoryFile(storyFile)
+  return data.stories
+    .map((story) => ({
+      id: story.id,
+      title: story.title,
+      category: story.category,
+      order: story.order,
+      chapterCount: Array.isArray(story.chapters) ? story.chapters.length : 0,
+      rewardCount: Array.isArray(story.rewards) ? story.rewards.length : 0,
+      unlockLabel: story.unlockCondition
+        ? `dungeon_cleared: ${story.unlockCondition.dungeonId}`
+        : '常時解放',
+    }))
+    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+}
+
 function isAreaConfigShape(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object') return false
   const record = value as Record<string, unknown>
@@ -151,6 +336,15 @@ async function readDungeon(areaDir: string, enemyDir: string, areaId: string) {
     readJson(enemyPath).catch(() => null),
   ])
   return { areaId, area, enemy }
+}
+
+async function readStory(storyFile: string, storyId: string) {
+  const data = await readStoryFile(storyFile)
+  const story = data.stories.find((entry) => entry.id === storyId)
+  if (!story) {
+    throw new Error(`NOT_FOUND: story ${storyId}`)
+  }
+  return story
 }
 
 async function writeDungeon(
@@ -171,6 +365,59 @@ async function writeDungeon(
     writes.push(writeJson(path.join(enemyDir, `${areaId}.json`), enemy))
   }
   await Promise.all(writes)
+  return { ok: true }
+}
+
+async function createStory(storyFile: string, body: unknown) {
+  if (!body || typeof body !== 'object') {
+    throw new Error('Invalid body')
+  }
+  const { story } = body as { story?: unknown }
+  if (!isStoryShape(story)) {
+    throw new Error('Invalid story payload')
+  }
+  const data = await readStoryFile(storyFile)
+  if (data.stories.some((entry) => entry.id === story.id)) {
+    throw new Error(`Story already exists: ${story.id}`)
+  }
+  data.stories.push(story)
+  sortStories(data.stories)
+  await writeJson(storyFile, data)
+  return { ok: true, id: story.id }
+}
+
+async function updateStory(storyFile: string, storyId: string, body: unknown) {
+  if (!body || typeof body !== 'object') {
+    throw new Error('Invalid body')
+  }
+  const { story } = body as { story?: unknown }
+  if (!isStoryShape(story)) {
+    throw new Error('Invalid story payload')
+  }
+  const data = await readStoryFile(storyFile)
+  const index = data.stories.findIndex((entry) => entry.id === storyId)
+  if (index < 0) {
+    throw new Error(`NOT_FOUND: story ${storyId}`)
+  }
+  const duplicate = data.stories.findIndex(
+    (entry, entryIndex) => entry.id === story.id && entryIndex !== index,
+  )
+  if (duplicate >= 0) {
+    throw new Error(`Story already exists: ${story.id}`)
+  }
+  data.stories[index] = story
+  sortStories(data.stories)
+  await writeJson(storyFile, data)
+  return { ok: true, id: story.id }
+}
+
+async function deleteStory(storyFile: string, storyId: string) {
+  const data = await readStoryFile(storyFile)
+  const nextStories = data.stories.filter((entry) => entry.id !== storyId)
+  if (nextStories.length === data.stories.length) {
+    throw new Error(`NOT_FOUND: story ${storyId}`)
+  }
+  await writeJson(storyFile, { stories: nextStories })
   return { ok: true }
 }
 
@@ -201,4 +448,254 @@ function json(res: ServerResponse, status: number, body: unknown) {
 
 function isSafeId(id: string): boolean {
   return /^[a-z0-9_]+$/.test(id)
+}
+
+async function readStoryFile(filePath: string): Promise<StoryFile> {
+  const raw = await readJson(filePath)
+  if (
+    !raw ||
+    typeof raw !== 'object' ||
+    !Array.isArray((raw as { stories?: unknown[] }).stories)
+  ) {
+    throw new Error('Invalid story file')
+  }
+  return raw as StoryFile
+}
+
+function isStoryShape(value: unknown): value is StoryRecord {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.id === 'string' &&
+    typeof record.title === 'string' &&
+    (record.category === 'main' || record.category === 'side') &&
+    typeof record.order === 'number' &&
+    Array.isArray(record.rewards) &&
+    Array.isArray(record.chapters)
+  )
+}
+
+function sortStories(stories: StoryRecord[]) {
+  stories.sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+}
+
+async function readGoblinStudioData(paths: {
+  racesFile: string
+  jobsFile: string
+  variantsFile: string
+}): Promise<GoblinStudioData> {
+  const [racesSource, jobsSource, variantsSource] = await Promise.all([
+    fs.readFile(paths.racesFile, 'utf8'),
+    fs.readFile(paths.jobsFile, 'utf8'),
+    fs.readFile(paths.variantsFile, 'utf8'),
+  ])
+
+  const racesObject = evaluateObjectLiteral<Record<string, { label: string }>>(
+    extractConstObjectLiteral(racesSource, 'races'),
+  )
+  const jobsObject = evaluateObjectLiteral<Record<string, GoblinJobSeed>>(
+    extractConstObjectLiteral(jobsSource, 'GOBLIN_JOB_DEFINITION_SEEDS'),
+  )
+  const variantsObject = evaluateObjectLiteral<Record<string, GoblinVariantSeed>>(
+    extractConstObjectLiteral(variantsSource, 'goblinVariantDefinitions'),
+  )
+
+  return {
+    races: Object.entries(racesObject).map(([id, value]) => ({ id, label: value.label })),
+    jobs: Object.values(jobsObject),
+    variants: Object.values(variantsObject),
+  }
+}
+
+async function writeGoblinStudioData(
+  paths: {
+    racesFile: string
+    jobsFile: string
+    variantsFile: string
+  },
+  body: unknown,
+) {
+  if (!isGoblinStudioDataShape(body)) {
+    throw new Error('Invalid goblin data payload')
+  }
+
+  const [racesSource, jobsSource, variantsSource] = await Promise.all([
+    fs.readFile(paths.racesFile, 'utf8'),
+    fs.readFile(paths.jobsFile, 'utf8'),
+    fs.readFile(paths.variantsFile, 'utf8'),
+  ])
+
+  const racesObject = Object.fromEntries(
+    body.races.map((race) => [race.id, { label: race.label }]),
+  )
+  const jobsObject = Object.fromEntries(body.jobs.map((job) => [job.id, job]))
+  const variantsObject = Object.fromEntries(
+    body.variants.map((variant) => [variant.factorId, variant]),
+  )
+
+  const nextRaces = replaceConstObjectLiteral(
+    racesSource,
+    'races',
+    formatJsValue(racesObject, 0),
+  )
+  const nextJobs = replaceConstObjectLiteral(
+    jobsSource,
+    'GOBLIN_JOB_DEFINITION_SEEDS',
+    formatJsValue(jobsObject, 0),
+  )
+  const nextVariants = replaceConstObjectLiteral(
+    variantsSource,
+    'goblinVariantDefinitions',
+    formatJsValue(variantsObject, 0),
+  )
+
+  await Promise.all([
+    fs.writeFile(paths.racesFile, nextRaces, 'utf8'),
+    fs.writeFile(paths.jobsFile, nextJobs, 'utf8'),
+    fs.writeFile(paths.variantsFile, nextVariants, 'utf8'),
+  ])
+
+  return { ok: true }
+}
+
+function extractConstObjectLiteral(source: string, constName: string): string {
+  const marker = `const ${constName}`
+  const markerIndex = source.indexOf(marker)
+  if (markerIndex < 0) {
+    throw new Error(`Const not found: ${constName}`)
+  }
+  const eqIndex = source.indexOf('=', markerIndex)
+  if (eqIndex < 0) {
+    throw new Error(`Assignment not found: ${constName}`)
+  }
+  const start = source.indexOf('{', eqIndex)
+  if (start < 0) {
+    throw new Error(`Object literal not found: ${constName}`)
+  }
+  const end = findMatchingBrace(source, start)
+  return source.slice(start, end + 1)
+}
+
+function replaceConstObjectLiteral(source: string, constName: string, nextObjectLiteral: string): string {
+  const marker = `const ${constName}`
+  const markerIndex = source.indexOf(marker)
+  if (markerIndex < 0) {
+    throw new Error(`Const not found: ${constName}`)
+  }
+  const eqIndex = source.indexOf('=', markerIndex)
+  if (eqIndex < 0) {
+    throw new Error(`Assignment not found: ${constName}`)
+  }
+  const start = source.indexOf('{', eqIndex)
+  if (start < 0) {
+    throw new Error(`Object literal not found: ${constName}`)
+  }
+  const end = findMatchingBrace(source, start)
+  return `${source.slice(0, start)}${nextObjectLiteral}${source.slice(end + 1)}`
+}
+
+function findMatchingBrace(source: string, start: number): number {
+  let depth = 0
+  let quote: '"' | "'" | '`' | null = null
+  let escape = false
+  let lineComment = false
+  let blockComment = false
+
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i]
+    const next = source[i + 1]
+
+    if (lineComment) {
+      if (ch === '\n') lineComment = false
+      continue
+    }
+    if (blockComment) {
+      if (ch === '*' && next === '/') {
+        blockComment = false
+        i++
+      }
+      continue
+    }
+    if (quote) {
+      if (escape) {
+        escape = false
+        continue
+      }
+      if (ch === '\\') {
+        escape = true
+        continue
+      }
+      if (ch === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (ch === '/' && next === '/') {
+      lineComment = true
+      i++
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      blockComment = true
+      i++
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch
+      continue
+    }
+    if (ch === '{') {
+      depth++
+      continue
+    }
+    if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+
+  throw new Error('Matching brace not found')
+}
+
+function evaluateObjectLiteral<T>(literal: string): T {
+  return vm.runInNewContext(`(${literal})`) as T
+}
+
+function formatJsValue(value: unknown, indent: number): string {
+  const pad = '  '.repeat(indent)
+  const childPad = '  '.repeat(indent + 1)
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    return `[\n${value
+      .map((item) => `${childPad}${formatJsValue(item, indent + 1)}`)
+      .join(',\n')}\n${pad}]`
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value).filter(([, v]) => v !== undefined)
+    if (entries.length === 0) return '{}'
+    return `{\n${entries
+      .map(([key, entryValue]) => `${childPad}${formatKey(key)}: ${formatJsValue(entryValue, indent + 1)}`)
+      .join(',\n')}\n${pad}}`
+  }
+
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (value === null) return 'null'
+  throw new Error(`Unsupported value type: ${typeof value}`)
+}
+
+function formatKey(key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key)
+}
+
+function isGoblinStudioDataShape(value: unknown): value is GoblinStudioData {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    Array.isArray(record.races) &&
+    Array.isArray(record.jobs) &&
+    Array.isArray(record.variants)
+  )
 }

--- a/tools/studio/src/components/fields.tsx
+++ b/tools/studio/src/components/fields.tsx
@@ -137,6 +137,36 @@ export function OptionalTextField({
   )
 }
 
+export function TextAreaField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  rows = 6,
+  size,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  rows?: number
+  size?: FieldSize
+}) {
+  return (
+    <label className={fieldClass(size)}>
+      <span className="field-label">{label}</span>
+      <span className="field-input textarea">
+        <textarea
+          value={value}
+          rows={rows}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </span>
+    </label>
+  )
+}
+
 export function FieldGroup({ children, columns = 2 }: { children: ReactNode; columns?: number }) {
   return (
     <div className="field-group" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -75,8 +75,45 @@ export const EnemyDatabaseSchema = z.object({
   patterns: z.array(EnemyPatternSchema),
 })
 
+export const StoryUnlockConditionSchema = z
+  .object({
+    type: z.literal('dungeon_cleared'),
+    dungeonId: z.string(),
+  })
+  .nullable()
+
+export const StoryRewardSchema = z.object({
+  type: z.enum(['gold', 'goblin', 'equipment']),
+  value: z.union([z.number(), z.string()]),
+})
+
+export const StoryChapterSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+})
+
+export const StorySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  category: z.enum(['main', 'side']),
+  order: z.number().int(),
+  unlockCondition: StoryUnlockConditionSchema,
+  rewards: z.array(StoryRewardSchema),
+  chapters: z.array(StoryChapterSchema),
+})
+
+export const StoryCollectionSchema = z.object({
+  stories: z.array(StorySchema),
+})
+
 export type AreaConfig = z.infer<typeof AreaConfigSchema>
 export type EnemyDatabase = z.infer<typeof EnemyDatabaseSchema>
+export type StoryUnlockCondition = z.infer<typeof StoryUnlockConditionSchema>
+export type StoryReward = z.infer<typeof StoryRewardSchema>
+export type StoryChapter = z.infer<typeof StoryChapterSchema>
+export type Story = z.infer<typeof StorySchema>
+export type StoryCollection = z.infer<typeof StoryCollectionSchema>
+export type StoryCategory = Story['category']
 
 export interface DungeonSummary {
   areaId: string
@@ -93,3 +130,96 @@ export interface DungeonDetailDto {
   area: AreaConfig
   enemy: EnemyDatabase | null
 }
+
+export interface StorySummary {
+  id: string
+  title: string
+  category: Story['category']
+  order: number
+  chapterCount: number
+  rewardCount: number
+  unlockLabel: string
+}
+
+export const GoblinBaseAttributesSchema = z.object({
+  power: z.number(),
+  wisdom: z.number(),
+  spirit: z.number(),
+  vitality: z.number(),
+  agility: z.number(),
+  luck: z.number(),
+})
+
+export const GoblinCombatStatsSchema = z.object({
+  attackCount: z.number(),
+  accuracy: z.number(),
+  evasion: z.number(),
+})
+
+export const GoblinFactorEffectSchema = z.object({
+  type: z.enum(['stat_bonus', 'resistance', 'skill_unlock']),
+  target: z.enum([
+    'hp',
+    'atk',
+    'magicAtk',
+    'def',
+    'magicDef',
+    'attackCount',
+    'accuracy',
+    'evasion',
+    'magicHeal',
+  ]),
+  value: z.number(),
+})
+
+export const GoblinRaceEntrySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+})
+
+export const GoblinJobSkillSeedSchema = z.object({
+  unlockLevel: z.number().optional(),
+  skillId: z.string(),
+})
+
+export const GoblinJobSeedSchema = z.object({
+  id: z.string(),
+  accentColor: z.string(),
+  skills: z.array(GoblinJobSkillSeedSchema),
+  unlockRequiresClearedArea: z.string().optional(),
+  unlockRequiresReadStory: z.string().optional(),
+  baseAttributes: GoblinBaseAttributesSchema.optional(),
+})
+
+export const GoblinVariantSeedSchema = z.object({
+  factorId: z.string(),
+  factorName: z.string(),
+  factorDescription: z.string(),
+  inheritProbability: z.number(),
+  factorEffects: z.array(GoblinFactorEffectSchema),
+  variantProbability: z.number(),
+  raceId: z.string(),
+  raceName: z.string(),
+  avatar: z.string(),
+  imageKey: z.string(),
+  additionalEffects: z.array(GoblinFactorEffectSchema),
+  baseAttributes: GoblinBaseAttributesSchema.optional(),
+  hpCoefficient: z.number().optional(),
+  combatStats: GoblinCombatStatsSchema.optional(),
+  defaultSkillIds: z.array(z.string()).optional(),
+})
+
+export const GoblinStudioDataSchema = z.object({
+  races: z.array(GoblinRaceEntrySchema),
+  jobs: z.array(GoblinJobSeedSchema),
+  variants: z.array(GoblinVariantSeedSchema),
+})
+
+export type GoblinBaseAttributes = z.infer<typeof GoblinBaseAttributesSchema>
+export type GoblinCombatStats = z.infer<typeof GoblinCombatStatsSchema>
+export type GoblinFactorEffect = z.infer<typeof GoblinFactorEffectSchema>
+export type GoblinRaceEntry = z.infer<typeof GoblinRaceEntrySchema>
+export type GoblinJobSkillSeed = z.infer<typeof GoblinJobSkillSeedSchema>
+export type GoblinJobSeed = z.infer<typeof GoblinJobSeedSchema>
+export type GoblinVariantSeed = z.infer<typeof GoblinVariantSeedSchema>
+export type GoblinStudioData = z.infer<typeof GoblinStudioDataSchema>

--- a/tools/studio/src/pages/GoblinDataPage.tsx
+++ b/tools/studio/src/pages/GoblinDataPage.tsx
@@ -1,0 +1,1040 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+
+import { getCharacterSkillDefinition } from '@app/shared/data/skillCatalog'
+import { getCharacterSkillDescription } from '@app/shared/data/characterSkills'
+import { getGoblinJobDefinition } from '@app/shared/data/goblinJobs'
+import { getSkillLabel } from '@app/shared/i18n/entityLocalization'
+
+import type {
+  GoblinBaseAttributes,
+  GoblinJobSeed,
+  GoblinJobSkillSeed,
+  GoblinRaceEntry,
+  GoblinStudioData,
+  GoblinVariantSeed,
+} from '../lib/schema'
+import { GoblinStudioDataSchema } from '../lib/schema'
+import {
+  FieldRow,
+  NumberField,
+  OptionalNumberField,
+  OptionalTextField,
+  TextAreaField,
+  TextField,
+} from '../components/fields'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'error'; message: string }
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+type Tab = 'races' | 'variants' | 'jobs' | 'skills'
+
+const EMPTY_ATTRIBUTES: GoblinBaseAttributes = {
+  power: 10,
+  wisdom: 10,
+  spirit: 10,
+  vitality: 10,
+  agility: 10,
+  luck: 10,
+}
+
+const EMPTY_RACE: GoblinRaceEntry = {
+  id: '',
+  label: '',
+}
+
+const EMPTY_VARIANT: GoblinVariantSeed = {
+  factorId: '',
+  factorName: '',
+  factorDescription: '',
+  inheritProbability: 0,
+  factorEffects: [],
+  variantProbability: 0,
+  raceId: '',
+  raceName: '',
+  avatar: '',
+  imageKey: '',
+  additionalEffects: [],
+}
+
+const EMPTY_JOB: GoblinJobSeed = {
+  id: '',
+  accentColor: '#000000',
+  skills: [],
+}
+
+export function GoblinDataPage() {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [tab, setTab] = useState<Tab>('variants')
+  const [draft, setDraft] = useState<GoblinStudioData | null>(null)
+  const [selectedRaceId, setSelectedRaceId] = useState<string | null>(null)
+  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(null)
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+  const [skillQuery, setSkillQuery] = useState('')
+  const originalRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/goblin-data')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as GoblinStudioData
+        if (cancelled) return
+        setDraft(data)
+        originalRef.current = stableStringify(data)
+        setSelectedRaceId(data.races[0]?.id ?? null)
+        setSelectedVariantId(data.variants[0]?.factorId ?? null)
+        setSelectedJobId(data.jobs[0]?.id ?? null)
+        setLoadState({ kind: 'ready' })
+      } catch (err) {
+        if (!cancelled) {
+          setLoadState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = useMemo(() => {
+    if (!draft || originalRef.current === null) return false
+    return stableStringify(draft) !== originalRef.current
+  }, [draft])
+
+  const updateDraft = useCallback((updater: (prev: GoblinStudioData) => GoblinStudioData) => {
+    setDraft((prev) => (prev ? updater(prev) : prev))
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!draft) return
+    const result = GoblinStudioDataSchema.safeParse(draft)
+    if (!result.success) {
+      setSaveState({
+        kind: 'error',
+        message: result.error.issues
+          .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+          .join(' / '),
+      })
+      return
+    }
+    setSaveState({ kind: 'saving' })
+    try {
+      const res = await fetch('/api/goblin-data', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(draft),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      originalRef.current = stableStringify(draft)
+      setSaveState({ kind: 'success' })
+    } catch (err) {
+      setSaveState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [draft])
+
+  const revert = useCallback(() => {
+    if (originalRef.current === null) return
+    const parsed = JSON.parse(originalRef.current) as GoblinStudioData
+    setDraft(parsed)
+    setSelectedRaceId(parsed.races[0]?.id ?? null)
+    setSelectedVariantId(parsed.variants[0]?.factorId ?? null)
+    setSelectedJobId(parsed.jobs[0]?.id ?? null)
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const selectedRace = draft?.races.find((race) => race.id === selectedRaceId) ?? null
+  const selectedVariant =
+    draft?.variants.find((variant) => variant.factorId === selectedVariantId) ?? null
+  const selectedJob = draft?.jobs.find((job) => job.id === selectedJobId) ?? null
+
+  const skillRows = useMemo(() => {
+    const rows = new Set<string>()
+    draft?.jobs.forEach((job) => job.skills.forEach((entry) => rows.add(entry.skillId)))
+    draft?.variants.forEach((variant) =>
+      (variant.defaultSkillIds ?? []).forEach((entry) => rows.add(entry)),
+    )
+
+    const query = skillQuery.trim().toLowerCase()
+    return [...rows]
+      .filter((skillId) => {
+        if (query === '') return true
+        try {
+          const skill = getCharacterSkillDefinition(skillId)
+          const description = getCharacterSkillDescription(skill)
+          return (
+            skillId.toLowerCase().includes(query) ||
+            description.toLowerCase().includes(query)
+          )
+        } catch {
+          return skillId.toLowerCase().includes(query)
+        }
+      })
+      .sort()
+  }, [draft, skillQuery])
+
+  if (loadState.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {loadState.message}</p>
+  }
+  if (!draft) return null
+
+  return (
+    <div className="detail">
+      <div className="detail-head">
+        <div>
+          <h2>ゴブリンデータ</h2>
+          <p className="subtle">
+            race / variant / job / skill を確認し、主要定義は編集できます。
+          </p>
+        </div>
+        <div className="save-bar">
+          {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+          {saveState.kind === 'success' && !isDirty && (
+            <span className="saved">保存しました</span>
+          )}
+          <button
+            className="btn ghost"
+            onClick={revert}
+            disabled={!isDirty || saveState.kind === 'saving'}
+          >
+            取り消し
+          </button>
+          <button className="btn primary" onClick={save} disabled={saveState.kind === 'saving'}>
+            保存
+          </button>
+        </div>
+      </div>
+
+      {saveState.kind === 'error' && <p className="save-error">{saveState.message}</p>}
+
+      <div className="tabs">
+        <button className={tab === 'races' ? 'tab active' : 'tab'} onClick={() => setTab('races')}>
+          Race
+        </button>
+        <button
+          className={tab === 'variants' ? 'tab active' : 'tab'}
+          onClick={() => setTab('variants')}
+        >
+          亜種
+        </button>
+        <button className={tab === 'jobs' ? 'tab active' : 'tab'} onClick={() => setTab('jobs')}>
+          Job
+        </button>
+        <button className={tab === 'skills' ? 'tab active' : 'tab'} onClick={() => setTab('skills')}>
+          Skill
+        </button>
+      </div>
+
+      <div className="tab-panel">
+        {tab === 'races' && (
+          <DataEditorLayout
+            items={draft.races}
+            getKey={(item) => item.id}
+            getLabel={(item) => item.label || item.id || '(新規 race)'}
+            selectedKey={selectedRaceId}
+            onSelect={setSelectedRaceId}
+            onAdd={() => {
+              const next = { ...EMPTY_RACE, id: `new_race_${Date.now()}` }
+              updateDraft((prev) => ({ ...prev, races: [...prev.races, next] }))
+              setSelectedRaceId(next.id)
+            }}
+            onDelete={() => {
+              if (!selectedRaceId) return
+              updateDraft((prev) => ({
+                ...prev,
+                races: prev.races.filter((race) => race.id !== selectedRaceId),
+              }))
+              setSelectedRaceId(draft.races.find((race) => race.id !== selectedRaceId)?.id ?? null)
+            }}
+          >
+            {selectedRace && (
+              <section className="card">
+                <h3>Race 定義</h3>
+                <FieldRow>
+                  <TextField
+                    size="md"
+                    label="id"
+                    value={selectedRace.id}
+                    onChange={(value) => {
+                      updateDraft((prev) => ({
+                        ...prev,
+                        races: prev.races.map((race) =>
+                          race.id === selectedRaceId ? { ...race, id: value } : race,
+                        ),
+                      }))
+                      setSelectedRaceId(value)
+                    }}
+                  />
+                  <TextField
+                    size="lg"
+                    label="label"
+                    value={selectedRace.label}
+                    onChange={(value) =>
+                      updateDraft((prev) => ({
+                        ...prev,
+                        races: prev.races.map((race) =>
+                          race.id === selectedRaceId ? { ...race, label: value } : race,
+                        ),
+                      }))
+                    }
+                  />
+                </FieldRow>
+              </section>
+            )}
+          </DataEditorLayout>
+        )}
+
+        {tab === 'variants' && (
+          <DataEditorLayout
+            items={draft.variants}
+            getKey={(item) => item.factorId}
+            getLabel={(item) => item.factorName || item.factorId || '(新規亜種)'}
+            selectedKey={selectedVariantId}
+            onSelect={setSelectedVariantId}
+            onAdd={() => {
+              const next = { ...EMPTY_VARIANT, factorId: `new_variant_${Date.now()}` }
+              updateDraft((prev) => ({ ...prev, variants: [...prev.variants, next] }))
+              setSelectedVariantId(next.factorId)
+            }}
+            onDelete={() => {
+              if (!selectedVariantId) return
+              updateDraft((prev) => ({
+                ...prev,
+                variants: prev.variants.filter((variant) => variant.factorId !== selectedVariantId),
+              }))
+              setSelectedVariantId(
+                draft.variants.find((variant) => variant.factorId !== selectedVariantId)?.factorId ??
+                  null,
+              )
+            }}
+          >
+            {selectedVariant && (
+              <VariantEditor
+                variant={selectedVariant}
+                onIdChange={setSelectedVariantId}
+                onChange={(nextVariant) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    variants: prev.variants.map((variant) =>
+                      variant.factorId === selectedVariantId ? nextVariant : variant,
+                    ),
+                  }))
+                }
+              />
+            )}
+          </DataEditorLayout>
+        )}
+
+        {tab === 'jobs' && (
+          <DataEditorLayout
+            items={draft.jobs}
+            getKey={(item) => item.id}
+            getLabel={(item) => {
+              try {
+                return getGoblinJobDefinition(item.id as never).name
+              } catch {
+                return item.id || '(新規 job)'
+              }
+            }}
+            selectedKey={selectedJobId}
+            onSelect={setSelectedJobId}
+            onAdd={() => {
+              const next = { ...EMPTY_JOB, id: `new_job_${Date.now()}` }
+              updateDraft((prev) => ({ ...prev, jobs: [...prev.jobs, next] }))
+              setSelectedJobId(next.id)
+            }}
+            onDelete={() => {
+              if (!selectedJobId) return
+              updateDraft((prev) => ({
+                ...prev,
+                jobs: prev.jobs.filter((job) => job.id !== selectedJobId),
+              }))
+              setSelectedJobId(draft.jobs.find((job) => job.id !== selectedJobId)?.id ?? null)
+            }}
+          >
+            {selectedJob && (
+              <JobEditor
+                job={selectedJob}
+                onIdChange={setSelectedJobId}
+                onChange={(nextJob) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    jobs: prev.jobs.map((job) => (job.id === selectedJobId ? nextJob : job)),
+                  }))
+                }
+              />
+            )}
+          </DataEditorLayout>
+        )}
+
+        {tab === 'skills' && (
+          <section className="card">
+            <div className="section-head">
+              <h3>使用中スキル</h3>
+              <input
+                type="search"
+                className="search-input goblin-skill-search"
+                placeholder="skillId / 説明で絞り込み"
+                value={skillQuery}
+                onChange={(e) => setSkillQuery(e.target.value)}
+              />
+            </div>
+            <table className="enemy-table">
+              <thead>
+                <tr>
+                  <th>skillId</th>
+                  <th>i18n key</th>
+                  <th>日本語名</th>
+                  <th>説明</th>
+                  <th>定義</th>
+                </tr>
+              </thead>
+              <tbody>
+                {skillRows.map((skillId) => {
+                  try {
+                    const skill = getCharacterSkillDefinition(skillId)
+                    const i18nKey = getSkillNameKey(skillId)
+                    return (
+                      <tr key={skillId}>
+                        <td><code>{skillId}</code></td>
+                        <td><code>{i18nKey}</code></td>
+                        <td>{getSkillLabel(skill)}</td>
+                        <td>{getCharacterSkillDescription(skill)}</td>
+                        <td>
+                          <code>{compactSkill(skill)}</code>
+                        </td>
+                      </tr>
+                    )
+                  } catch {
+                    return (
+                      <tr key={skillId}>
+                        <td><code>{skillId}</code></td>
+                        <td><code>{getSkillNameKey(skillId)}</code></td>
+                        <td className="save-error">未定義</td>
+                        <td className="save-error">skillCatalog に存在しません</td>
+                        <td />
+                      </tr>
+                    )
+                  }
+                })}
+              </tbody>
+            </table>
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DataEditorLayout<T>({
+  items,
+  getKey,
+  getLabel,
+  selectedKey,
+  onSelect,
+  onAdd,
+  onDelete,
+  children,
+}: {
+  items: T[]
+  getKey: (item: T) => string
+  getLabel: (item: T) => string
+  selectedKey: string | null
+  onSelect: (key: string | null) => void
+  onAdd: () => void
+  onDelete: () => void
+  children: ReactNode
+}) {
+  return (
+    <div className="goblin-data-layout">
+      <aside className="card goblin-data-list">
+        <div className="section-head">
+          <h3>一覧</h3>
+          <div className="field-row">
+            <button className="btn ghost small" onClick={onAdd}>
+              + 追加
+            </button>
+            <button className="btn ghost small" onClick={onDelete} disabled={!selectedKey}>
+              削除
+            </button>
+          </div>
+        </div>
+        <div className="goblin-list-items">
+          {items.map((item, index) => {
+            const key = getKey(item)
+            return (
+              <button
+                key={key || `empty-${index}`}
+                className={selectedKey === key ? 'goblin-list-item active' : 'goblin-list-item'}
+                onClick={() => onSelect(key)}
+              >
+                <strong>{getLabel(item)}</strong>
+                <span className="subtle">{key || '(id未設定)'}</span>
+              </button>
+            )
+          })}
+        </div>
+      </aside>
+      <div className="panel-stack">{children}</div>
+    </div>
+  )
+}
+
+function VariantEditor({
+  variant,
+  onIdChange,
+  onChange,
+}: {
+  variant: GoblinVariantSeed
+  onIdChange: (id: string) => void
+  onChange: (variant: GoblinVariantSeed) => void
+}) {
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <h3>基本情報</h3>
+        <FieldRow>
+          <TextField size="md" label="factorId" value={variant.factorId} onChange={(value) => { onIdChange(value); onChange({ ...variant, factorId: value }) }} />
+          <TextField size="lg" label="factorName" value={variant.factorName} onChange={(value) => onChange({ ...variant, factorName: value })} />
+          <TextField size="md" label="raceId" value={variant.raceId} onChange={(value) => onChange({ ...variant, raceId: value })} />
+          <TextField size="lg" label="raceName" value={variant.raceName} onChange={(value) => onChange({ ...variant, raceName: value })} />
+          <NumberField size="sm" label="inheritProbability" value={variant.inheritProbability} step={0.01} onChange={(value) => onChange({ ...variant, inheritProbability: value })} />
+          <NumberField size="sm" label="variantProbability" value={variant.variantProbability} step={0.01} onChange={(value) => onChange({ ...variant, variantProbability: value })} />
+          <OptionalNumberField size="sm" label="hpCoefficient" value={variant.hpCoefficient} step={0.1} onChange={(value) => onChange({ ...variant, hpCoefficient: value })} />
+          <TextField size="lg" label="avatar" value={variant.avatar} onChange={(value) => onChange({ ...variant, avatar: value })} />
+          <TextField size="md" label="imageKey" value={variant.imageKey} onChange={(value) => onChange({ ...variant, imageKey: value })} />
+        </FieldRow>
+        <FieldRow>
+          <TextAreaField
+            size="xl"
+            label="factorDescription"
+            value={variant.factorDescription}
+            rows={4}
+            onChange={(value) => onChange({ ...variant, factorDescription: value })}
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <div className="section-head">
+          <h3>基本能力値</h3>
+          <button
+            className="btn ghost small"
+            onClick={() =>
+              onChange({
+                ...variant,
+                baseAttributes: variant.baseAttributes ? undefined : { ...EMPTY_ATTRIBUTES },
+              })
+            }
+          >
+            {variant.baseAttributes ? '削除' : '追加'}
+          </button>
+        </div>
+        {variant.baseAttributes ? (
+          <AttributeEditor
+            value={variant.baseAttributes}
+            onChange={(value) => onChange({ ...variant, baseAttributes: value })}
+          />
+        ) : (
+          <p className="subtle">未設定</p>
+        )}
+      </section>
+
+      <section className="card">
+        <div className="section-head">
+          <h3>戦闘補正</h3>
+          <button
+            className="btn ghost small"
+            onClick={() =>
+              onChange({
+                ...variant,
+                combatStats: variant.combatStats
+                  ? undefined
+                  : { attackCount: 2, accuracy: 20, evasion: 15 },
+              })
+            }
+          >
+            {variant.combatStats ? '削除' : '追加'}
+          </button>
+        </div>
+        {variant.combatStats ? (
+          <FieldRow>
+            <NumberField
+              size="sm"
+              label="attackCount"
+              value={variant.combatStats.attackCount}
+              onChange={(value) =>
+                onChange({
+                  ...variant,
+                  combatStats: { ...variant.combatStats!, attackCount: value },
+                })
+              }
+            />
+            <NumberField
+              size="sm"
+              label="accuracy"
+              value={variant.combatStats.accuracy}
+              onChange={(value) =>
+                onChange({
+                  ...variant,
+                  combatStats: { ...variant.combatStats!, accuracy: value },
+                })
+              }
+            />
+            <NumberField
+              size="sm"
+              label="evasion"
+              value={variant.combatStats.evasion}
+              onChange={(value) =>
+                onChange({
+                  ...variant,
+                  combatStats: { ...variant.combatStats!, evasion: value },
+                })
+              }
+            />
+          </FieldRow>
+        ) : (
+          <p className="subtle">未設定</p>
+        )}
+      </section>
+
+      <EffectListEditor
+        title="因子効果"
+        effects={variant.factorEffects}
+        onChange={(effects) => onChange({ ...variant, factorEffects: effects })}
+      />
+      <EffectListEditor
+        title="追加効果"
+        effects={variant.additionalEffects}
+        onChange={(effects) => onChange({ ...variant, additionalEffects: effects })}
+      />
+
+      <section className="card">
+        <h3>デフォルトスキル</h3>
+        <SkillIdListEditor
+          skillIds={variant.defaultSkillIds ?? []}
+          onChange={(skillIds) => onChange({ ...variant, defaultSkillIds: skillIds })}
+        />
+      </section>
+    </div>
+  )
+}
+
+function JobEditor({
+  job,
+  onIdChange,
+  onChange,
+}: {
+  job: GoblinJobSeed
+  onIdChange: (id: string) => void
+  onChange: (job: GoblinJobSeed) => void
+}) {
+  let derivedName = job.id
+  let derivedSummary = ''
+  let derivedDescription = ''
+  try {
+    const derived = getGoblinJobDefinition(job.id as never)
+    derivedName = derived.name
+    derivedSummary = derived.summary
+    derivedDescription = derived.description
+  } catch {
+    // noop
+  }
+
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <h3>基本情報</h3>
+        <FieldRow>
+          <TextField size="md" label="id" value={job.id} onChange={(value) => { onIdChange(value); onChange({ ...job, id: value }) }} />
+          <TextField
+            size="sm"
+            label="accentColor"
+            value={job.accentColor}
+            onChange={(value) => onChange({ ...job, accentColor: value })}
+          />
+          <OptionalTextField
+            size="md"
+            label="unlockRequiresClearedArea"
+            value={job.unlockRequiresClearedArea}
+            onChange={(value) => onChange({ ...job, unlockRequiresClearedArea: value })}
+          />
+          <OptionalTextField
+            size="md"
+            label="unlockRequiresReadStory"
+            value={job.unlockRequiresReadStory}
+            onChange={(value) => onChange({ ...job, unlockRequiresReadStory: value })}
+          />
+        </FieldRow>
+        <div className="goblin-derived">
+          <div><strong>{derivedName}</strong></div>
+          {derivedSummary && <div className="subtle">{derivedSummary}</div>}
+          {derivedDescription && <div className="subtle">{derivedDescription}</div>}
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="section-head">
+          <h3>基本能力値</h3>
+          <button
+            className="btn ghost small"
+            onClick={() =>
+              onChange({
+                ...job,
+                baseAttributes: job.baseAttributes ? undefined : { ...EMPTY_ATTRIBUTES },
+              })
+            }
+          >
+            {job.baseAttributes ? '削除' : '追加'}
+          </button>
+        </div>
+        {job.baseAttributes ? (
+          <AttributeEditor
+            value={job.baseAttributes}
+            onChange={(value) => onChange({ ...job, baseAttributes: value })}
+          />
+        ) : (
+          <p className="subtle">未設定</p>
+        )}
+      </section>
+
+      <section className="card">
+        <div className="section-head">
+          <h3>ジョブスキル</h3>
+          <button
+            className="btn ghost small"
+            onClick={() =>
+              onChange({
+                ...job,
+                skills: [...job.skills, { skillId: '', unlockLevel: undefined }],
+              })
+            }
+          >
+            + 追加
+          </button>
+        </div>
+        <div className="story-block-list">
+          {job.skills.map((skill, index) => (
+            <div key={`${skill.skillId}-${index}`} className="story-block">
+              <div className="story-block-head">
+                <strong>{skill.skillId || '(skill 未設定)'}</strong>
+                <div className="pattern-actions">
+                  <button
+                    className="icon-btn"
+                    onClick={() => onChange({ ...job, skills: moveItem(job.skills, index, -1) })}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    className="icon-btn"
+                    onClick={() => onChange({ ...job, skills: moveItem(job.skills, index, 1) })}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    className="icon-btn danger"
+                    onClick={() =>
+                      onChange({
+                        ...job,
+                        skills: job.skills.filter((_, entryIndex) => entryIndex !== index),
+                      })
+                    }
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+              <FieldRow>
+                <TextField
+                  size="lg"
+                  label="skillId"
+                  value={skill.skillId}
+                  onChange={(value) =>
+                    onChange({
+                      ...job,
+                      skills: job.skills.map((entry, entryIndex) =>
+                        entryIndex === index ? { ...entry, skillId: value } : entry,
+                      ),
+                    })
+                  }
+                />
+                <OptionalNumberField
+                  size="sm"
+                  label="unlockLevel"
+                  value={skill.unlockLevel}
+                  min={1}
+                  onChange={(value) =>
+                    onChange({
+                      ...job,
+                      skills: job.skills.map((entry, entryIndex) =>
+                        entryIndex === index
+                          ? { ...entry, unlockLevel: value }
+                          : entry,
+                      ),
+                    })
+                  }
+                />
+              </FieldRow>
+              <SkillMeta skillId={skill.skillId} />
+            </div>
+          ))}
+          {job.skills.length === 0 && <p className="subtle">未設定</p>}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function AttributeEditor({
+  value,
+  onChange,
+}: {
+  value: GoblinBaseAttributes
+  onChange: (value: GoblinBaseAttributes) => void
+}) {
+  return (
+    <FieldRow>
+      {(['power', 'wisdom', 'spirit', 'vitality', 'agility', 'luck'] as const).map((key) => (
+        <NumberField
+          key={key}
+          size="sm"
+          label={key}
+          value={value[key]}
+          onChange={(nextValue) => onChange({ ...value, [key]: nextValue })}
+        />
+      ))}
+    </FieldRow>
+  )
+}
+
+function EffectListEditor({
+  title,
+  effects,
+  onChange,
+}: {
+  title: string
+  effects: GoblinVariantSeed['factorEffects']
+  onChange: (effects: GoblinVariantSeed['factorEffects']) => void
+}) {
+  return (
+    <section className="card">
+      <div className="section-head">
+        <h3>{title}</h3>
+        <button
+          className="btn ghost small"
+          onClick={() =>
+            onChange([...effects, { type: 'stat_bonus', target: 'hp', value: 0 }])
+          }
+        >
+          + 追加
+        </button>
+      </div>
+      <div className="story-block-list">
+        {effects.map((effect, index) => (
+          <div key={`${effect.type}-${effect.target}-${index}`} className="story-block">
+            <div className="story-block-head">
+              <strong>{effect.target}</strong>
+              <div className="pattern-actions">
+                <button className="icon-btn" onClick={() => onChange(moveItem(effects, index, -1))}>
+                  ↑
+                </button>
+                <button className="icon-btn" onClick={() => onChange(moveItem(effects, index, 1))}>
+                  ↓
+                </button>
+                <button
+                  className="icon-btn danger"
+                  onClick={() => onChange(effects.filter((_, entryIndex) => entryIndex !== index))}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <FieldRow>
+              <label className="field field-size-sm">
+                <span className="field-label">type</span>
+                <span className="field-input">
+                  <select
+                    value={effect.type}
+                    onChange={(e) =>
+                      onChange(
+                        effects.map((entry, entryIndex) =>
+                          entryIndex === index
+                            ? { ...entry, type: e.target.value as typeof effect.type }
+                            : entry,
+                        ),
+                      )
+                    }
+                  >
+                    <option value="stat_bonus">stat_bonus</option>
+                    <option value="resistance">resistance</option>
+                    <option value="skill_unlock">skill_unlock</option>
+                  </select>
+                </span>
+              </label>
+              <label className="field field-size-sm">
+                <span className="field-label">target</span>
+                <span className="field-input">
+                  <select
+                    value={effect.target}
+                    onChange={(e) =>
+                      onChange(
+                        effects.map((entry, entryIndex) =>
+                          entryIndex === index
+                            ? { ...entry, target: e.target.value as typeof effect.target }
+                            : entry,
+                        ),
+                      )
+                    }
+                  >
+                    {['hp', 'atk', 'magicAtk', 'def', 'magicDef', 'attackCount', 'accuracy', 'evasion', 'magicHeal'].map((target) => (
+                      <option key={target} value={target}>
+                        {target}
+                      </option>
+                    ))}
+                  </select>
+                </span>
+              </label>
+              <NumberField
+                size="sm"
+                label="value"
+                value={effect.value}
+                onChange={(value) =>
+                  onChange(
+                    effects.map((entry, entryIndex) =>
+                      entryIndex === index ? { ...entry, value } : entry,
+                    ),
+                  )
+                }
+              />
+            </FieldRow>
+          </div>
+        ))}
+        {effects.length === 0 && <p className="subtle">未設定</p>}
+      </div>
+    </section>
+  )
+}
+
+function SkillIdListEditor({
+  skillIds,
+  onChange,
+}: {
+  skillIds: string[]
+  onChange: (skillIds: string[]) => void
+}) {
+  return (
+    <div className="story-block-list">
+      {skillIds.map((skillId, index) => (
+            <div key={`${skillId}-${index}`} className="story-block">
+          <div className="story-block-head">
+            <strong>{skillId || '(skill 未設定)'}</strong>
+            <div className="pattern-actions">
+              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, -1))}>
+                ↑
+              </button>
+              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, 1))}>
+                ↓
+              </button>
+              <button
+                className="icon-btn danger"
+                onClick={() => onChange(skillIds.filter((_, entryIndex) => entryIndex !== index))}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <TextField
+            size="xl"
+            label="skillId"
+            value={skillId}
+            onChange={(value) =>
+              onChange(
+                skillIds.map((entry, entryIndex) => (entryIndex === index ? value : entry)),
+              )
+            }
+          />
+          <SkillMeta skillId={skillId} />
+        </div>
+      ))}
+      <button className="btn ghost small" onClick={() => onChange([...skillIds, ''])}>
+        + 追加
+      </button>
+    </div>
+  )
+}
+
+function SkillMeta({ skillId }: { skillId: string }) {
+  if (!skillId) return null
+  try {
+    const skill = getCharacterSkillDefinition(skillId)
+    return (
+      <div className="goblin-skill-meta">
+        <div className="subtle">
+          <code>{getSkillNameKey(skillId)}</code>
+        </div>
+        <div>{getSkillLabel(skill)}</div>
+      </div>
+    )
+  } catch {
+    return (
+      <div className="goblin-skill-meta">
+        <div className="subtle">
+          <code>{getSkillNameKey(skillId)}</code>
+        </div>
+        <div className="save-error">skillCatalog に存在しません</div>
+      </div>
+    )
+  }
+}
+
+function moveItem<T>(items: T[], index: number, direction: -1 | 1): T[] {
+  const target = index + direction
+  if (target < 0 || target >= items.length) return items
+  const next = items.slice()
+  ;[next[index], next[target]] = [next[target], next[index]]
+  return next
+}
+
+function compactSkill(skill: object): string {
+  const filtered = Object.fromEntries(
+    Object.entries(skill as Record<string, unknown>).filter(([key]) => key !== 'id'),
+  )
+  return JSON.stringify(filtered)
+}
+
+function getSkillNameKey(skillId: string): string {
+  return `entities.skill.${skillId}.name`
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {}
+      for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[key] = (val as Record<string, unknown>)[key]
+      }
+      return sorted
+    }
+    return val
+  })
+}

--- a/tools/studio/src/pages/StoryDetailPage.tsx
+++ b/tools/studio/src/pages/StoryDetailPage.tsx
@@ -1,0 +1,563 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+
+import { StorySchema } from '../lib/schema'
+import type {
+  Story,
+  StoryCategory,
+  StoryChapter,
+  StoryReward,
+  StoryUnlockCondition,
+} from '../lib/schema'
+import {
+  FieldRow,
+  NumberField,
+  TextAreaField,
+  TextField,
+} from '../components/fields'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'error'; message: string }
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+const EMPTY_STORY: Story = {
+  id: '',
+  title: '',
+  category: 'main',
+  order: 0,
+  unlockCondition: null,
+  rewards: [],
+  chapters: [{ id: 'chapter_1', text: '' }],
+}
+
+export function StoryDetailPage() {
+  const { storyId } = useParams<{ storyId: string }>()
+  const navigate = useNavigate()
+  const isNew = storyId === undefined
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [draft, setDraft] = useState<Story | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const originalRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (isNew) {
+      setDraft(structuredClone(EMPTY_STORY))
+      originalRef.current = stableStringify(EMPTY_STORY)
+      setLoadState({ kind: 'ready' })
+      setSaveState({ kind: 'idle' })
+      return
+    }
+
+    setLoadState({ kind: 'loading' })
+    setSaveState({ kind: 'idle' })
+    setDeleteError(null)
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/stories/${storyId}`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as Story
+        if (cancelled) return
+        setDraft(data)
+        originalRef.current = stableStringify(data)
+        setLoadState({ kind: 'ready' })
+      } catch (err) {
+        if (!cancelled) {
+          setLoadState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isNew, storyId])
+
+  const isDirty = useMemo(() => {
+    if (!draft || originalRef.current === null) return false
+    return stableStringify(draft) !== originalRef.current
+  }, [draft])
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  const updateDraft = useCallback((updater: (prev: Story) => Story) => {
+    setDraft((prev) => (prev ? updater(prev) : prev))
+    setSaveState({ kind: 'idle' })
+    setDeleteError(null)
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!draft) return
+    const result = StorySchema.safeParse(draft)
+    if (!result.success) {
+      setSaveState({
+        kind: 'error',
+        message: `story 検証失敗: ${result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(' / ')}`,
+      })
+      return
+    }
+
+    setSaveState({ kind: 'saving' })
+    try {
+      const method = isNew ? 'POST' : 'PUT'
+      const url = isNew ? '/api/stories' : `/api/stories/${storyId}`
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ story: draft }),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      originalRef.current = stableStringify(draft)
+      setSaveState({ kind: 'success' })
+      if (isNew) {
+        navigate(`/stories/${draft.id}`, { replace: true })
+      }
+    } catch (err) {
+      setSaveState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [draft, isNew, navigate, storyId])
+
+  const revert = useCallback(() => {
+    if (originalRef.current === null) return
+    setDraft(JSON.parse(originalRef.current) as Story)
+    setSaveState({ kind: 'idle' })
+    setDeleteError(null)
+  }, [])
+
+  const remove = useCallback(async () => {
+    if (isNew || !storyId) return
+    const confirmed = window.confirm(`ストーリー ${storyId} を削除しますか？`)
+    if (!confirmed) return
+    setDeleteError(null)
+    try {
+      const res = await fetch(`/api/stories/${storyId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      navigate('/stories')
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : String(err))
+    }
+  }, [isNew, navigate, storyId])
+
+  if (loadState.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {loadState.message}</p>
+  }
+  if (!draft) return null
+
+  return (
+    <div className="detail story-detail">
+      <p>
+        <Link to="/stories">← ストーリー一覧へ戻る</Link>
+      </p>
+      <div className="detail-head">
+        <div>
+          <h2>{isNew ? '新規ストーリー' : draft.title || draft.id}</h2>
+          <p className="subtle">
+            <code>{draft.id || '(id未設定)'}</code> · {draft.category} · order {draft.order}
+          </p>
+        </div>
+        <div className="save-bar">
+          {!isNew && (
+            <button className="btn ghost" onClick={remove}>
+              削除
+            </button>
+          )}
+          {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+          {saveState.kind === 'success' && !isDirty && (
+            <span className="saved">保存しました</span>
+          )}
+          <button
+            className="btn ghost"
+            onClick={revert}
+            disabled={!isDirty || saveState.kind === 'saving'}
+          >
+            取り消し
+          </button>
+          <button
+            className="btn primary"
+            onClick={save}
+            disabled={saveState.kind === 'saving'}
+          >
+            保存
+          </button>
+        </div>
+      </div>
+
+      {saveState.kind === 'error' && <p className="save-error">{saveState.message}</p>}
+      {deleteError && <p className="save-error">{deleteError}</p>}
+
+      <div className="panel-stack">
+        <section className="card">
+          <h3>基本情報</h3>
+          <FieldRow>
+            <TextField
+              size="md"
+              label="id"
+              value={draft.id}
+              onChange={(value) => updateDraft((prev) => ({ ...prev, id: value }))}
+              placeholder="story_id"
+            />
+            <TextField
+              size="xl"
+              label="title"
+              value={draft.title}
+              onChange={(value) => updateDraft((prev) => ({ ...prev, title: value }))}
+            />
+            <label className="field field-size-sm">
+              <span className="field-label">category</span>
+              <span className="field-input">
+                <select
+                  value={draft.category}
+                  onChange={(e) =>
+                    updateDraft((prev) => ({
+                      ...prev,
+                      category: e.target.value as StoryCategory,
+                    }))
+                  }
+                >
+                  <option value="main">main</option>
+                  <option value="side">side</option>
+                </select>
+              </span>
+            </label>
+            <NumberField
+              size="xs"
+              label="order"
+              value={draft.order}
+              onChange={(value) => updateDraft((prev) => ({ ...prev, order: value }))}
+            />
+          </FieldRow>
+        </section>
+
+        <section className="card">
+          <div className="section-head">
+            <h3>解放条件</h3>
+            <button
+              className="btn ghost small"
+              onClick={() =>
+                updateDraft((prev) => ({
+                  ...prev,
+                  unlockCondition: prev.unlockCondition
+                    ? null
+                    : { type: 'dungeon_cleared', dungeonId: '' },
+                }))
+              }
+            >
+              {draft.unlockCondition ? '常時解放にする' : '条件を追加'}
+            </button>
+          </div>
+
+          {draft.unlockCondition ? (
+            <FieldRow>
+              <label className="field field-size-sm">
+                <span className="field-label">type</span>
+                <span className="field-input">
+                  <select value={draft.unlockCondition.type} disabled>
+                    <option value="dungeon_cleared">dungeon_cleared</option>
+                  </select>
+                </span>
+              </label>
+              <TextField
+                size="md"
+                label="dungeonId"
+                value={draft.unlockCondition.dungeonId}
+                onChange={(value) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    unlockCondition: {
+                      type: 'dungeon_cleared',
+                      dungeonId: value,
+                    } satisfies StoryUnlockCondition,
+                  }))
+                }
+              />
+            </FieldRow>
+          ) : (
+            <p className="subtle">このストーリーは常時解放です。</p>
+          )}
+        </section>
+
+        <section className="card">
+          <div className="section-head">
+            <h3>報酬</h3>
+            <button
+              className="btn ghost small"
+              onClick={() =>
+                updateDraft((prev) => ({
+                  ...prev,
+                  rewards: [...prev.rewards, { type: 'gold', value: 0 }],
+                }))
+              }
+            >
+              + 報酬を追加
+            </button>
+          </div>
+          {draft.rewards.length === 0 ? (
+            <p className="subtle">報酬はありません。</p>
+          ) : (
+            <div className="story-block-list">
+              {draft.rewards.map((reward, index) => (
+                <StoryRewardCard
+                  key={`${index}-${reward.type}`}
+                  reward={reward}
+                  onChange={(nextReward) =>
+                    updateDraft((prev) => ({
+                      ...prev,
+                      rewards: prev.rewards.map((entry, entryIndex) =>
+                        entryIndex === index ? nextReward : entry,
+                      ),
+                    }))
+                  }
+                  onMoveUp={() => moveItem(index, -1, draft.rewards, (next) =>
+                    updateDraft((prev) => ({ ...prev, rewards: next })),
+                  )}
+                  onMoveDown={() => moveItem(index, 1, draft.rewards, (next) =>
+                    updateDraft((prev) => ({ ...prev, rewards: next })),
+                  )}
+                  onDelete={() =>
+                    updateDraft((prev) => ({
+                      ...prev,
+                      rewards: prev.rewards.filter((_, entryIndex) => entryIndex !== index),
+                    }))
+                  }
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="card">
+          <div className="section-head">
+            <h3>チャプター</h3>
+            <button
+              className="btn ghost small"
+              onClick={() =>
+                updateDraft((prev) => ({
+                  ...prev,
+                  chapters: [
+                    ...prev.chapters,
+                    createChapter(prev.id || 'story', prev.chapters.length + 1),
+                  ],
+                }))
+              }
+            >
+              + チャプターを追加
+            </button>
+          </div>
+          <div className="story-block-list">
+            {draft.chapters.map((chapter, index) => (
+              <StoryChapterCard
+                key={chapter.id || index}
+                chapter={chapter}
+                onChange={(nextChapter) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    chapters: prev.chapters.map((entry, entryIndex) =>
+                      entryIndex === index ? nextChapter : entry,
+                    ),
+                  }))
+                }
+                onMoveUp={() => moveItem(index, -1, draft.chapters, (next) =>
+                  updateDraft((prev) => ({ ...prev, chapters: next })),
+                )}
+                onMoveDown={() => moveItem(index, 1, draft.chapters, (next) =>
+                  updateDraft((prev) => ({ ...prev, chapters: next })),
+                )}
+                onDelete={() =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    chapters:
+                      prev.chapters.length <= 1
+                        ? [createChapter(prev.id || 'story', 1)]
+                        : prev.chapters.filter((_, entryIndex) => entryIndex !== index),
+                  }))
+                }
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function StoryRewardCard({
+  reward,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: {
+  reward: StoryReward
+  onChange: (reward: StoryReward) => void
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onDelete: () => void
+}) {
+  return (
+    <div className="story-block">
+      <div className="story-block-head">
+        <strong>報酬</strong>
+        <div className="pattern-actions">
+          <button className="icon-btn" title="上へ" onClick={onMoveUp}>
+            ↑
+          </button>
+          <button className="icon-btn" title="下へ" onClick={onMoveDown}>
+            ↓
+          </button>
+          <button className="icon-btn danger" title="削除" onClick={onDelete}>
+            ×
+          </button>
+        </div>
+      </div>
+      <FieldRow>
+        <label className="field field-size-sm">
+          <span className="field-label">type</span>
+          <span className="field-input">
+            <select
+              value={reward.type}
+              onChange={(e) =>
+                onChange({
+                  type: e.target.value as StoryReward['type'],
+                  value: e.target.value === 'gold' ? 0 : '',
+                })
+              }
+            >
+              <option value="gold">gold</option>
+              <option value="goblin">goblin</option>
+              <option value="equipment">equipment</option>
+            </select>
+          </span>
+        </label>
+        {reward.type === 'gold' ? (
+          <NumberField
+            size="sm"
+            label="value"
+            value={typeof reward.value === 'number' ? reward.value : 0}
+            min={0}
+            onChange={(value) => onChange({ ...reward, value })}
+          />
+        ) : (
+          <TextField
+            size="lg"
+            label="value"
+            value={typeof reward.value === 'string' ? reward.value : String(reward.value)}
+            onChange={(value) => onChange({ ...reward, value })}
+          />
+        )}
+      </FieldRow>
+    </div>
+  )
+}
+
+function StoryChapterCard({
+  chapter,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: {
+  chapter: StoryChapter
+  onChange: (chapter: StoryChapter) => void
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onDelete: () => void
+}) {
+  return (
+    <div className="story-block">
+      <div className="story-block-head">
+        <strong>{chapter.id || 'チャプター'}</strong>
+        <div className="pattern-actions">
+          <button className="icon-btn" title="上へ" onClick={onMoveUp}>
+            ↑
+          </button>
+          <button className="icon-btn" title="下へ" onClick={onMoveDown}>
+            ↓
+          </button>
+          <button className="icon-btn danger" title="削除" onClick={onDelete}>
+            ×
+          </button>
+        </div>
+      </div>
+      <FieldRow>
+        <TextField
+          size="lg"
+          label="id"
+          value={chapter.id}
+          onChange={(value) => onChange({ ...chapter, id: value })}
+        />
+      </FieldRow>
+      <FieldRow>
+        <TextAreaField
+          size="xl"
+          label="text"
+          value={chapter.text}
+          rows={8}
+          onChange={(value) => onChange({ ...chapter, text: value })}
+        />
+      </FieldRow>
+    </div>
+  )
+}
+
+function moveItem<T>(
+  index: number,
+  direction: -1 | 1,
+  items: T[],
+  commit: (items: T[]) => void,
+) {
+  const target = index + direction
+  if (target < 0 || target >= items.length) return
+  const next = items.slice()
+  ;[next[index], next[target]] = [next[target], next[index]]
+  commit(next)
+}
+
+function createChapter(storyId: string, number: number): StoryChapter {
+  return {
+    id: `${storyId}_chapter_${number}`,
+    text: '',
+  }
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {}
+      for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[key] = (val as Record<string, unknown>)[key]
+      }
+      return sorted
+    }
+    return val
+  })
+}

--- a/tools/studio/src/pages/StoryListPage.tsx
+++ b/tools/studio/src/pages/StoryListPage.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import type { StorySummary } from '../lib/schema'
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: StorySummary[] }
+  | { kind: 'error'; message: string }
+
+export function StoryListPage() {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/stories')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as StorySummary[]
+        if (!cancelled) setState({ kind: 'ready', data })
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (state.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (state.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {state.message}</p>
+  }
+
+  return (
+    <div className="panel-stack">
+      <div className="list-header">
+        <div>
+          <h2 className="page-title">ストーリー</h2>
+          <p className="subtle">`stories.json` を一覧・編集します。</p>
+        </div>
+        <Link to="/stories/new" className="btn primary">
+          新規ストーリー
+        </Link>
+      </div>
+
+      <table className="dungeon-table">
+        <thead>
+          <tr>
+            <th>id</th>
+            <th>タイトル</th>
+            <th>種別</th>
+            <th className="num">order</th>
+            <th>解放条件</th>
+            <th className="num">章数</th>
+            <th className="num">報酬数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.data.map((story) => (
+            <tr key={story.id}>
+              <td>
+                <Link to={`/stories/${story.id}`}>{story.id}</Link>
+              </td>
+              <td>{story.title}</td>
+              <td>{story.category}</td>
+              <td className="num">{story.order}</td>
+              <td>{story.unlockLabel}</td>
+              <td className="num">{story.chapterCount}</td>
+              <td className="num">{story.rewardCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -630,7 +630,8 @@ code {
 }
 
 .field-input input,
-.field-input select {
+.field-input select,
+.field-input textarea {
   flex: 1;
   background: transparent;
   border: none;
@@ -642,8 +643,18 @@ code {
 }
 
 .field-input input:focus,
-.field-input select:focus {
+.field-input select:focus,
+.field-input textarea:focus {
   outline: none;
+}
+
+.field-input.textarea {
+  align-items: stretch;
+}
+
+.field-input textarea {
+  resize: vertical;
+  line-height: 1.55;
 }
 
 .field-suffix {
@@ -902,6 +913,133 @@ code {
 .slot-add:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* story */
+
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.section-head h3 {
+  margin: 0;
+}
+
+.story-block-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.story-block {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  padding: 0.85rem;
+}
+
+.story-block-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.story-detail .card {
+  overflow: hidden;
+}
+
+/* goblin data */
+
+.goblin-data-layout {
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1100px) {
+  .goblin-data-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.goblin-data-list {
+  position: sticky;
+  top: 5rem;
+  max-height: calc(100vh - 6rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.goblin-list-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  overflow-y: auto;
+}
+
+.goblin-list-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.goblin-list-item:hover {
+  background: var(--surface-muted);
+}
+
+.goblin-list-item.active {
+  border-color: var(--text);
+  background: var(--highlight);
+}
+
+.goblin-derived {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.goblin-skill-search {
+  width: min(28rem, 100%);
+}
+
+.goblin-skill-meta {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 /* dropzone / party / simulate */

--- a/tools/studio/tsconfig.app.json
+++ b/tools/studio/tsconfig.app.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": false,
+    "noEmit": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- Studio にストーリー一覧/詳細ページを追加し、章テキスト・解放条件・報酬を JSON へ書き戻せるようにしました。
- ゴブリンデータ編集ページを追加し、種族/職業/バリアントを Studio から編集できるようにしました。
- 上記に合わせて `goblin_native` 側の `goblinJobs` へ `baseAttributes` を補完し、`races` に `human` / `demon_race` を追加しています。
- `dataPlugin` にストーリー/ゴブリン用の読み書き API、`schema` に対応する zod 型、共通フォームに `TextAreaField` を追加しました。
- AGENTS.md に Studio 関連の構成・運用手順を追記しています。

## Test plan
- [ ] `cd tools/studio && npm install && npm run dev` で起動し、ストーリー一覧→詳細編集→保存が動作することを確認
- [ ] ゴブリンデータページから種族/職業/バリアントを編集し、`goblin_native/src/shared/data/*.ts` に意図通り反映されることを確認
- [ ] `npm run typecheck`（Studio 側）と `cd goblin_native && npx tsc --noEmit` がパスすることを確認