### PR TITLE
feat(race): race.skillIdsとstudioスキル編集UI共通化

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -25,7 +25,8 @@ import i18n from '../../shared/i18n'
 import { getSpellLabel } from '../../shared/i18n/entityLocalization'
 import { normalizeBattleActionPolicy, shouldRunRate } from '../../shared/utils/battleActionPolicy'
 import { races as RACE_DICT } from '../../shared/data/races'
-import { getRaceResistanceTotals } from '../../shared/data/races'
+import { getRaceResistanceTotals, getRaceSkills } from '../../shared/data/races'
+import { getUniqueSkillsById } from '../../shared/data/characterSkills'
 import type {
   Combatant,
   DamageOptions,
@@ -921,7 +922,7 @@ export class BattleSystem {
 
   private createEnemyUnit(enemy: Enemy, originalIndex: number, row: number, rowSlot: number): BattleUnit {
     const combatant = this.combatantManager.fromEnemy(enemy)
-    const skills = enemy.skills ?? []
+    const skills = getUniqueSkillsById([...(enemy.skills ?? []), ...getRaceSkills(enemy.raceTags)])
     const learnedSpells = this.mergeLearnedSpells(enemy.spells, skills, enemy.level)
     const raceResistance = getRaceResistanceTotals(enemy.raceTags)
     return {

--- a/goblin_native/src/core/services/DamageCalculator.ts
+++ b/goblin_native/src/core/services/DamageCalculator.ts
@@ -10,6 +10,7 @@ export type RaceKey = string;
 export type RaceDefinition = {
   label: string;
   implies?: RaceKey[];
+  skillIds?: string[];
   physicalResistancePercent?: number;
   penetrationResistancePercent?: number;
   criticalResistancePercent?: number;

--- a/goblin_native/src/shared/data/raceSkills.ts
+++ b/goblin_native/src/shared/data/raceSkills.ts
@@ -3,6 +3,7 @@ import { getGoblinVariantByRace } from './goblinVariants'
 import { getCharacterSkills } from './skillCatalog'
 import type { CharacterSkillId } from './skillCatalog'
 import { normalizeGoblinRaceId } from '../types/Race'
+import { getRaceSkillIds } from './races'
 
 const PURE_GOBLIN_DEFAULT_SKILL_IDS: CharacterSkillId[] = [
   'exp_bonus_70',
@@ -10,8 +11,11 @@ const PURE_GOBLIN_DEFAULT_SKILL_IDS: CharacterSkillId[] = [
 
 export function getDefaultSkillsForRace(race: string): CharacterSkill[] {
   const normalizedRace = normalizeGoblinRaceId(race)
-  if (normalizedRace === 'goblin') {
-    return getCharacterSkills(PURE_GOBLIN_DEFAULT_SKILL_IDS)
-  }
-  return getCharacterSkills(getGoblinVariantByRace(normalizedRace)?.defaultSkillIds ?? [])
+  const raceSkillIds = getRaceSkillIds([normalizedRace])
+  const defaultSkillIds =
+    normalizedRace === 'goblin'
+      ? PURE_GOBLIN_DEFAULT_SKILL_IDS
+      : (getGoblinVariantByRace(normalizedRace)?.defaultSkillIds ?? [])
+
+  return getCharacterSkills([...new Set([...raceSkillIds, ...defaultSkillIds])])
 }

--- a/goblin_native/src/shared/data/races.ts
+++ b/goblin_native/src/shared/data/races.ts
@@ -1,4 +1,6 @@
 import type { RaceDict } from '../../core/services/DamageCalculator';
+import type { CharacterSkill } from '../types/CharacterSkill';
+import { getCharacterSkills } from './skillCatalog';
 
 export const races: RaceDict = {
   beast: {
@@ -181,4 +183,35 @@ export function getRaceResistanceTotals(raceTags: readonly string[]): RaceResist
     },
     { ...ZERO_RACE_RESISTANCE },
   )
+}
+
+export function getRaceSkillIds(raceTags: readonly string[]): string[] {
+  const uniqueSkillIds = new Set<string>()
+  const visitedRaceTags = new Set<string>()
+
+  const visit = (raceTag: string) => {
+    if (visitedRaceTags.has(raceTag)) return
+    visitedRaceTags.add(raceTag)
+
+    const race = races[raceTag]
+    if (!race) return
+
+    for (const skillId of race.skillIds ?? []) {
+      uniqueSkillIds.add(skillId)
+    }
+
+    for (const implied of race.implies ?? []) {
+      visit(implied)
+    }
+  }
+
+  for (const raceTag of raceTags) {
+    visit(raceTag)
+  }
+
+  return [...uniqueSkillIds]
+}
+
+export function getRaceSkills(raceTags: readonly string[]): CharacterSkill[] {
+  return getCharacterSkills(getRaceSkillIds(raceTags))
 }

--- a/goblin_native/src/shared/i18n/index.ts
+++ b/goblin_native/src/shared/i18n/index.ts
@@ -15,23 +15,39 @@ const resources = {
 } as const
 
 function detectLanguage(): SupportedLanguage {
-  if (process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID) {
+  const nodeEnv =
+    typeof process !== 'undefined' && process.env
+      ? process.env.NODE_ENV
+      : undefined
+  const jestWorkerId =
+    typeof process !== 'undefined' && process.env
+      ? process.env.JEST_WORKER_ID
+      : undefined
+
+  if (nodeEnv === 'test' || jestWorkerId) {
     return DEFAULT_LANGUAGE
   }
 
   try {
-    const localizationModule = require('expo-localization') as {
-      getLocales?: () => Array<{ languageCode?: string | null }>
-    }
-    const locale = localizationModule.getLocales?.()[0]?.languageCode?.toLowerCase()
-    if (locale && SUPPORTED_LANGUAGES.includes(locale as SupportedLanguage)) {
-      return locale as SupportedLanguage
+    if (typeof require === 'function') {
+      const localizationModule = require('expo-localization') as {
+        getLocales?: () => Array<{ languageCode?: string | null }>
+      }
+      const locale = localizationModule.getLocales?.()[0]?.languageCode?.toLowerCase()
+      if (locale && SUPPORTED_LANGUAGES.includes(locale as SupportedLanguage)) {
+        return locale as SupportedLanguage
+      }
     }
   } catch {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale.slice(0, 2).toLowerCase()
     if (SUPPORTED_LANGUAGES.includes(locale as SupportedLanguage)) {
       return locale as SupportedLanguage
     }
+  }
+
+  const locale = Intl.DateTimeFormat().resolvedOptions().locale.slice(0, 2).toLowerCase()
+  if (SUPPORTED_LANGUAGES.includes(locale as SupportedLanguage)) {
+    return locale as SupportedLanguage
   }
   return DEFAULT_LANGUAGE
 }

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -47,6 +47,7 @@ interface GoblinRaceEntry {
   id: string
   label: string
   implies?: string[]
+  skillIds?: string[]
   physicalResistancePercent?: number
   penetrationResistancePercent?: number
   criticalResistancePercent?: number
@@ -535,6 +536,7 @@ async function readGoblinStudioData(paths: {
       {
         label: string
         implies?: string[]
+        skillIds?: string[]
         physicalResistancePercent?: number
         penetrationResistancePercent?: number
         criticalResistancePercent?: number
@@ -556,6 +558,7 @@ async function readGoblinStudioData(paths: {
       id,
       label: value.label,
       implies: Array.isArray(value.implies) ? value.implies : undefined,
+      skillIds: Array.isArray(value.skillIds) ? value.skillIds : undefined,
       physicalResistancePercent: value.physicalResistancePercent,
       penetrationResistancePercent: value.penetrationResistancePercent,
       criticalResistancePercent: value.criticalResistancePercent,
@@ -590,6 +593,7 @@ async function writeGoblinStudioData(
       {
         label: race.label,
         ...(race.implies && race.implies.length > 0 ? { implies: race.implies } : {}),
+        ...(race.skillIds && race.skillIds.length > 0 ? { skillIds: race.skillIds } : {}),
         ...(race.physicalResistancePercent !== undefined ? { physicalResistancePercent: race.physicalResistancePercent } : {}),
         ...(race.penetrationResistancePercent !== undefined ? { penetrationResistancePercent: race.penetrationResistancePercent } : {}),
         ...(race.criticalResistancePercent !== undefined ? { criticalResistancePercent: race.criticalResistancePercent } : {}),

--- a/tools/studio/src/components/EnemyEditor.tsx
+++ b/tools/studio/src/components/EnemyEditor.tsx
@@ -7,6 +7,7 @@ import {
 } from '@app/shared/utils/enemyStats'
 import { races } from '@app/shared/data/races'
 import { getRaceResistanceTotals } from '@app/shared/data/races'
+import type { CharacterSkill } from '@app/shared/types/CharacterSkill'
 
 import type { EnemyDatabase } from '../lib/schema'
 import {
@@ -16,6 +17,7 @@ import {
   OptionalNumberField,
   TextField,
 } from './fields'
+import { EnemySkillListEditor } from './SkillEditors'
 
 type Enemy = EnemyDatabase['enemies'][number]
 const raceEntries = Object.entries(races).sort((a, b) => a[1].label.localeCompare(b[1].label, 'ja'))
@@ -296,8 +298,12 @@ function EnemyForm({
         />
       </FieldGroup>
 
+      <EnemySkillListEditor
+        skills={(enemy as Enemy & { skills?: CharacterSkill[] }).skills}
+        onChange={(skills) => onChange((prev) => ({ ...prev, skills }) as Enemy)}
+      />
       <ExtraJsonSection
-        label="skills"
+        label="skills JSON"
         value={(enemy as any).skills}
         onChange={(v) => onChange((prev) => ({ ...prev, skills: v }) as Enemy)}
       />
@@ -334,6 +340,12 @@ function ExtraJsonSection({
   )
   const [dirtyLocal, setDirtyLocal] = useState(false)
   const [parseError, setParseError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (dirtyLocal) return
+    setText(value === undefined ? '' : JSON.stringify(value, null, 2))
+    setParseError(null)
+  }, [dirtyLocal, value])
 
   return (
     <details className="json-section">

--- a/tools/studio/src/components/SkillEditors.tsx
+++ b/tools/studio/src/components/SkillEditors.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  CHARACTER_SKILL_CATALOG,
+  getCharacterSkill,
+  getCharacterSkillDefinition,
+  isCharacterSkillId,
+} from '@app/shared/data/skillCatalog'
+import { getCharacterSkillDescription } from '@app/shared/data/characterSkills'
+import ja from '@app/shared/i18n/resources/ja'
+import { getSkillLabel } from '@app/shared/i18n/entityLocalization'
+import type { CharacterSkill } from '@app/shared/types/CharacterSkill'
+
+import { FieldRow, OptionalNumberField, type FieldSize } from './fields'
+
+const SKILL_IDS = Object.keys(CHARACTER_SKILL_CATALOG).sort((a, b) =>
+  getSkillOptionLabel(a).localeCompare(getSkillOptionLabel(b), 'ja'),
+)
+
+export function SkillIdListEditor({
+  skillIds,
+  onChange,
+  addLabel = '+ 追加',
+}: {
+  skillIds: string[]
+  onChange: (skillIds: string[]) => void
+  addLabel?: string
+}) {
+  return (
+    <div className="story-block-list">
+      {skillIds.map((skillId, index) => (
+        <div key={`${skillId}-${index}`} className="story-block">
+          <div className="story-block-head">
+            <strong>{skillId || '(skill 未設定)'}</strong>
+            <div className="pattern-actions">
+              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, -1))}>
+                ↑
+              </button>
+              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, 1))}>
+                ↓
+              </button>
+              <button
+                className="icon-btn danger"
+                onClick={() => onChange(skillIds.filter((_, entryIndex) => entryIndex !== index))}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <SkillSelectField
+            size="xl"
+            label="skillId"
+            value={skillId}
+            onChange={(value) =>
+              onChange(skillIds.map((entry, entryIndex) => (entryIndex === index ? value : entry)))
+            }
+          />
+          <SkillMeta skillId={skillId} />
+        </div>
+      ))}
+      <button className="btn ghost small" onClick={() => onChange([...skillIds, ''])}>
+        {addLabel}
+      </button>
+    </div>
+  )
+}
+
+export function JobSkillListEditor({
+  skills,
+  onChange,
+}: {
+  skills: Array<{ skillId: string; unlockLevel?: number }>
+  onChange: (skills: Array<{ skillId: string; unlockLevel?: number }>) => void
+}) {
+  return (
+    <div className="story-block-list">
+      {skills.map((skill, index) => (
+        <div key={`${skill.skillId}-${index}`} className="story-block">
+          <div className="story-block-head">
+            <strong>{skill.skillId || '(skill 未設定)'}</strong>
+            <div className="pattern-actions">
+              <button className="icon-btn" onClick={() => onChange(moveItem(skills, index, -1))}>
+                ↑
+              </button>
+              <button className="icon-btn" onClick={() => onChange(moveItem(skills, index, 1))}>
+                ↓
+              </button>
+              <button
+                className="icon-btn danger"
+                onClick={() => onChange(skills.filter((_, entryIndex) => entryIndex !== index))}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <FieldRow>
+            <SkillSelectField
+              size="lg"
+              label="skillId"
+              value={skill.skillId}
+              onChange={(value) =>
+                onChange(
+                  skills.map((entry, entryIndex) =>
+                    entryIndex === index ? { ...entry, skillId: value } : entry,
+                  ),
+                )
+              }
+            />
+            <OptionalNumberField
+              size="sm"
+              label="unlockLevel"
+              value={skill.unlockLevel}
+              min={1}
+              onChange={(value) =>
+                onChange(
+                  skills.map((entry, entryIndex) =>
+                    entryIndex === index ? { ...entry, unlockLevel: value } : entry,
+                  ),
+                )
+              }
+            />
+          </FieldRow>
+          <SkillMeta skillId={skill.skillId} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function EnemySkillListEditor({
+  skills,
+  onChange,
+}: {
+  skills: CharacterSkill[] | undefined
+  onChange: (skills: CharacterSkill[] | undefined) => void
+}) {
+  const entries = skills ?? []
+
+  return (
+    <section className="card">
+      <div className="section-head">
+        <h4>スキル</h4>
+        <button
+          className="btn ghost small"
+          onClick={() => onChange([...entries, { id: '' }])}
+        >
+          + 追加
+        </button>
+      </div>
+      <div className="story-block-list">
+        {entries.map((skill, index) => (
+          <div key={`${skill.id}-${index}`} className="story-block">
+            <div className="story-block-head">
+              <strong>{skill.id || '(skill 未設定)'}</strong>
+              <div className="pattern-actions">
+                <button className="icon-btn" onClick={() => onChange(moveItem(entries, index, -1))}>
+                  ↑
+                </button>
+                <button className="icon-btn" onClick={() => onChange(moveItem(entries, index, 1))}>
+                  ↓
+                </button>
+                <button
+                  className="icon-btn danger"
+                  onClick={() => {
+                    const next = entries.filter((_, entryIndex) => entryIndex !== index)
+                    onChange(next.length > 0 ? next : undefined)
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <SkillSelectField
+              size="xl"
+              label="skillId"
+              value={skill.id}
+              onChange={(value) =>
+                onChange(
+                  entries.map((entry, entryIndex) =>
+                    entryIndex === index ? toEnemySkill(value, entry) : entry,
+                  ),
+                )
+              }
+            />
+            {!isCharacterSkillId(skill.id) && skill.id && (
+              <p className="subtle skill-editor-note">
+                catalog 未登録の独自スキルです。選び直すと skillCatalog 定義に置き換わります。
+              </p>
+            )}
+            <SkillMeta skillId={skill.id} />
+          </div>
+        ))}
+        {entries.length === 0 && <p className="subtle">未設定</p>}
+      </div>
+    </section>
+  )
+}
+
+export function SkillSelectField({
+  label,
+  value,
+  onChange,
+  size,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  size?: FieldSize
+}) {
+  const [query, setQuery] = useState('')
+  const className = size ? `field field-size-${size}` : 'field'
+  const options = value && !SKILL_IDS.includes(value) ? [value, ...SKILL_IDS] : SKILL_IDS
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (normalizedQuery === '') return options
+
+    return options.filter((skillId) => {
+      const skill = isCharacterSkillId(skillId) ? getCharacterSkillDefinition(skillId) : null
+      const label = skill ? getStudioSkillLabel(skill) : ''
+      const description = skill ? getCharacterSkillDescription(skill) : ''
+      const haystacks = [skillId, label, description].map((entry) => String(entry ?? ''))
+      return haystacks.some((entry) => entry.toLowerCase().includes(normalizedQuery))
+    })
+  }, [options, query])
+
+  useEffect(() => {
+    setQuery('')
+  }, [value])
+
+  return (
+    <label className={className}>
+      <span className="field-label">{label}</span>
+      <span className="skill-select-stack">
+        <span className="field-input">
+          <input
+            type="search"
+            value={query}
+            placeholder="日本語名 / skillId / 説明で絞り込み"
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </span>
+        <span className="field-input">
+          <select value={value} onChange={(e) => onChange(e.target.value)}>
+            <option value="">(未設定)</option>
+            {filteredOptions.map((skillId) => (
+              <option key={skillId} value={skillId}>
+                {getSkillOptionLabel(skillId)}
+              </option>
+            ))}
+          </select>
+        </span>
+        {query.trim() !== '' && filteredOptions.length === 0 && (
+          <span className="subtle skill-select-empty">該当するスキルがありません</span>
+        )}
+      </span>
+    </label>
+  )
+}
+
+export function SkillMeta({ skillId }: { skillId: string }) {
+  if (!skillId) return null
+  try {
+    const skill = getCharacterSkillDefinition(skillId)
+    return (
+      <div className="goblin-skill-meta">
+        <div className="subtle">
+          <code>{getSkillNameKey(skillId)}</code>
+        </div>
+        <div>{getStudioSkillLabel(skill)}</div>
+        <div className="subtle">{getCharacterSkillDescription(skill)}</div>
+      </div>
+    )
+  } catch {
+    return (
+      <div className="goblin-skill-meta">
+        <div className="subtle">
+          <code>{getSkillNameKey(skillId)}</code>
+        </div>
+        <div className="save-error">skillCatalog に存在しません</div>
+      </div>
+    )
+  }
+}
+
+function getSkillOptionLabel(skillId: string): string {
+  if (!isCharacterSkillId(skillId)) {
+    return `${skillId} / catalog未登録`
+  }
+
+  const skill = getCharacterSkillDefinition(skillId)
+  const label = getStudioSkillLabel(skill) || getCharacterSkillDescription(skill) || skillId
+  return `${label} / ${skillId}`
+}
+
+function getStudioSkillLabel(skill: CharacterSkill): string {
+  const localized = ja.entities.skill[skill.id as keyof typeof ja.entities.skill]?.name
+  return localized || getSkillLabel(skill) || skill.id
+}
+
+function getSkillNameKey(skillId: string): string {
+  return `entities.skill.${skillId}.name`
+}
+
+function toEnemySkill(skillId: string, current: CharacterSkill): CharacterSkill {
+  if (skillId === '') return { id: '' }
+  if (!isCharacterSkillId(skillId)) return current.id === skillId ? current : { id: skillId }
+  return getCharacterSkill(skillId)
+}
+
+function moveItem<T>(items: T[], index: number, direction: -1 | 1): T[] {
+  const target = index + direction
+  if (target < 0 || target >= items.length) return items
+  const next = items.slice()
+  ;[next[index], next[target]] = [next[target], next[index]]
+  return next
+}

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -186,6 +186,7 @@ export const GoblinRaceEntrySchema = z.object({
   id: z.string(),
   label: z.string(),
   implies: z.array(z.string()).optional(),
+  skillIds: z.array(z.string()).optional(),
   physicalResistancePercent: z.number().optional(),
   penetrationResistancePercent: z.number().optional(),
   criticalResistancePercent: z.number().optional(),

--- a/tools/studio/src/pages/GoblinDataPage.tsx
+++ b/tools/studio/src/pages/GoblinDataPage.tsx
@@ -1,18 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 
-import { getCharacterSkillDefinition } from '@app/shared/data/skillCatalog'
 import { getGoblinJobDefinition } from '@app/shared/data/goblinJobs'
-import { getSkillLabel } from '@app/shared/i18n/entityLocalization'
 
 import type {
   GoblinBaseAttributes,
   GoblinJobSeed,
-  GoblinJobSkillSeed,
   GoblinRaceEntry,
   GoblinStudioData,
   GoblinVariantSeed,
 } from '../lib/schema'
 import { GoblinStudioDataSchema } from '../lib/schema'
+import { JobSkillListEditor, SkillIdListEditor } from '../components/SkillEditors'
 import {
   FieldRow,
   NumberField,
@@ -348,6 +346,20 @@ export function GoblinDataPage() {
                 <p className="subtle">
                   例: <code>slime</code> → <code>beast</code>, <code>undead</code> → <code>demon_race</code>
                 </p>
+                <section className="card nested-card">
+                  <h3>Race スキル</h3>
+                  <SkillIdListEditor
+                    skillIds={selectedRace.skillIds ?? []}
+                    onChange={(skillIds) =>
+                      updateDraft((prev) => ({
+                        ...prev,
+                        races: prev.races.map((race) =>
+                          race.id === selectedRaceId ? { ...race, skillIds } : race,
+                        ),
+                      }))
+                    }
+                  />
+                </section>
               </section>
             )}
           </DataEditorLayout>
@@ -727,73 +739,8 @@ function JobEditor({
             + 追加
           </button>
         </div>
-        <div className="story-block-list">
-          {job.skills.map((skill, index) => (
-            <div key={`${skill.skillId}-${index}`} className="story-block">
-              <div className="story-block-head">
-                <strong>{skill.skillId || '(skill 未設定)'}</strong>
-                <div className="pattern-actions">
-                  <button
-                    className="icon-btn"
-                    onClick={() => onChange({ ...job, skills: moveItem(job.skills, index, -1) })}
-                  >
-                    ↑
-                  </button>
-                  <button
-                    className="icon-btn"
-                    onClick={() => onChange({ ...job, skills: moveItem(job.skills, index, 1) })}
-                  >
-                    ↓
-                  </button>
-                  <button
-                    className="icon-btn danger"
-                    onClick={() =>
-                      onChange({
-                        ...job,
-                        skills: job.skills.filter((_, entryIndex) => entryIndex !== index),
-                      })
-                    }
-                  >
-                    ×
-                  </button>
-                </div>
-              </div>
-              <FieldRow>
-                <TextField
-                  size="lg"
-                  label="skillId"
-                  value={skill.skillId}
-                  onChange={(value) =>
-                    onChange({
-                      ...job,
-                      skills: job.skills.map((entry, entryIndex) =>
-                        entryIndex === index ? { ...entry, skillId: value } : entry,
-                      ),
-                    })
-                  }
-                />
-                <OptionalNumberField
-                  size="sm"
-                  label="unlockLevel"
-                  value={skill.unlockLevel}
-                  min={1}
-                  onChange={(value) =>
-                    onChange({
-                      ...job,
-                      skills: job.skills.map((entry, entryIndex) =>
-                        entryIndex === index
-                          ? { ...entry, unlockLevel: value }
-                          : entry,
-                      ),
-                    })
-                  }
-                />
-              </FieldRow>
-              <SkillMeta skillId={skill.skillId} />
-            </div>
-          ))}
-          {job.skills.length === 0 && <p className="subtle">未設定</p>}
-        </div>
+        <JobSkillListEditor skills={job.skills} onChange={(skills) => onChange({ ...job, skills })} />
+        {job.skills.length === 0 && <p className="subtle">未設定</p>}
       </section>
     </div>
   )
@@ -929,88 +876,12 @@ function EffectListEditor({
   )
 }
 
-function SkillIdListEditor({
-  skillIds,
-  onChange,
-}: {
-  skillIds: string[]
-  onChange: (skillIds: string[]) => void
-}) {
-  return (
-    <div className="story-block-list">
-      {skillIds.map((skillId, index) => (
-            <div key={`${skillId}-${index}`} className="story-block">
-          <div className="story-block-head">
-            <strong>{skillId || '(skill 未設定)'}</strong>
-            <div className="pattern-actions">
-              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, -1))}>
-                ↑
-              </button>
-              <button className="icon-btn" onClick={() => onChange(moveItem(skillIds, index, 1))}>
-                ↓
-              </button>
-              <button
-                className="icon-btn danger"
-                onClick={() => onChange(skillIds.filter((_, entryIndex) => entryIndex !== index))}
-              >
-                ×
-              </button>
-            </div>
-          </div>
-          <TextField
-            size="xl"
-            label="skillId"
-            value={skillId}
-            onChange={(value) =>
-              onChange(
-                skillIds.map((entry, entryIndex) => (entryIndex === index ? value : entry)),
-              )
-            }
-          />
-          <SkillMeta skillId={skillId} />
-        </div>
-      ))}
-      <button className="btn ghost small" onClick={() => onChange([...skillIds, ''])}>
-        + 追加
-      </button>
-    </div>
-  )
-}
-
-function SkillMeta({ skillId }: { skillId: string }) {
-  if (!skillId) return null
-  try {
-    const skill = getCharacterSkillDefinition(skillId)
-    return (
-      <div className="goblin-skill-meta">
-        <div className="subtle">
-          <code>{getSkillNameKey(skillId)}</code>
-        </div>
-        <div>{getSkillLabel(skill)}</div>
-      </div>
-    )
-  } catch {
-    return (
-      <div className="goblin-skill-meta">
-        <div className="subtle">
-          <code>{getSkillNameKey(skillId)}</code>
-        </div>
-        <div className="save-error">skillCatalog に存在しません</div>
-      </div>
-    )
-  }
-}
-
 function moveItem<T>(items: T[], index: number, direction: -1 | 1): T[] {
   const target = index + direction
   if (target < 0 || target >= items.length) return items
   const next = items.slice()
   ;[next[index], next[target]] = [next[target], next[index]]
   return next
-}
-
-function getSkillNameKey(skillId: string): string {
-  return `entities.skill.${skillId}.name`
 }
 
 function stableStringify(value: unknown): string {

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -1084,6 +1084,25 @@ code {
   gap: 0.2rem;
 }
 
+.nested-card {
+  margin-top: 1rem;
+}
+
+.skill-editor-note {
+  margin: 0.5rem 0 0;
+}
+
+.skill-select-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.skill-select-empty {
+  font-size: 0.8rem;
+  padding: 0 0.1rem;
+}
+
 .unlock-flow-card {
   margin-top: 1rem;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- `races` に `skillIds` を追加し、敵ユニット生成 (`BattleSystem.createEnemyUnit`) と既定スキル取得 (`getDefaultSkillsForRace`) で種族スキルを自動的に付与
- studio の `EnemyEditor` と種族編集ページに共通の `SkillEditors`（`SkillIdListEditor` / `JobSkillListEditor` / `EnemySkillListEditor`）を追加し、selector 形式でスキルを編集可能に
- studio の race データ I/O (`dataPlugin` / `schema`) に `skillIds` を追加
- i18n 初期化を Vite 環境でも例外を投げないようにガード

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] studio で種族にスキルを設定 → 保存 → JSON に反映されることを確認
- [ ] studio で敵にスキルを selector から設定できることを確認
- [ ] アプリ実機/シミュレーターで戦闘を起動し、敵が race.skillIds を保持して動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)