### PR TITLE
feat(skill): 探索時間を短縮する軽足スキルを追加

### DIFF
--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -23,6 +23,8 @@ import { useStoryStore } from '../stores/useStoryStore'
 import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
 import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
+import { getExpeditionTimeMultiplierFromSkills } from '../../shared/data/characterSkills'
+import { EquipmentService } from '../../core/services/EquipmentService'
 import i18n from '../../shared/i18n'
 
 interface UseExpeditionFlowParams {
@@ -100,6 +102,24 @@ export const useExpeditionFlow = ({
     return new CompleteExpeditionUseCase(goblinRepository, partyRepository, baseStateRepository, SQLiteEquipmentRepository.getInstance())
   }, [goblinRepository, partyRepository, baseStateRepository])
 
+  const getPartyExpeditionTimeMultiplier = useCallback(async (party: Party): Promise<number> => {
+    const members = (
+      await Promise.all(party.memberIds.map((id) => goblinRepository.getGoblin(id)))
+    ).filter((goblin): goblin is NonNullable<typeof goblin> => goblin !== null)
+
+    if (members.length === 0) {
+      return 1
+    }
+
+    const skillSets = await Promise.all(members.map(async (goblin) => {
+      const equippedItems = await equipmentRepository.getByGoblinId(goblin.id)
+      const equipmentSkills = EquipmentService.collectGrantedSkills(equippedItems)
+      return [...goblin.skills, ...equipmentSkills]
+    }))
+
+    return getExpeditionTimeMultiplierFromSkills(skillSets.flat())
+  }, [equipmentRepository, goblinRepository])
+
   const handleDungeonClear = useCallback(async (record: ExpeditionRecord) => {
     if (!record.replay || isPendingLoading || isBaseLoading) return
 
@@ -145,6 +165,7 @@ export const useExpeditionFlow = ({
   const estimateExplorationTime = useCallback((
     dungeon: Dungeon,
     returnPolicy: ExpeditionRequest['returnPolicy'],
+    partyExpeditionTimeMultiplier: number = 1,
   ): number => {
     if (instantDungeonExploration) {
       return 1
@@ -163,7 +184,7 @@ export const useExpeditionFlow = ({
     }
     const multiplier = multiplierMap[returnPolicy] ?? 1.0
     const speedMultiplier = getSpeedMultiplier()
-    return Math.floor(baseTime * multiplier * speedMultiplier)
+    return Math.floor(baseTime * multiplier * speedMultiplier * partyExpeditionTimeMultiplier)
   }, [instantDungeonExploration])
 
   const formatTime = useCallback((date: Date) => {
@@ -206,7 +227,8 @@ export const useExpeditionFlow = ({
     async ({ party, dungeon, returnPolicy, tier }: StartExpeditionInput): Promise<StartExpeditionResult> => {
       setIsProcessing(true)
       try {
-        const durationSec = estimateExplorationTime(dungeon, returnPolicy)
+        const partyExpeditionTimeMultiplier = await getPartyExpeditionTimeMultiplier(party)
+        const durationSec = estimateExplorationTime(dungeon, returnPolicy, partyExpeditionTimeMultiplier)
         const request: ExpeditionRequest = {
           partyId: party.id.toString(),
           areaId: dungeon.id,
@@ -253,7 +275,7 @@ export const useExpeditionFlow = ({
         setIsProcessing(false)
       }
     },
-    [estimateExplorationTime, saveExpeditionRecord, startExpeditionUseCase, scheduleExpeditionNotification],
+    [estimateExplorationTime, getPartyExpeditionTimeMultiplier, saveExpeditionRecord, startExpeditionUseCase, scheduleExpeditionNotification],
   )
 
   interface BulkStartResult {
@@ -269,7 +291,8 @@ export const useExpeditionFlow = ({
 
       try {
         for (const { party, dungeon, returnPolicy, tier } of inputs) {
-          const durationSec = estimateExplorationTime(dungeon, returnPolicy)
+          const partyExpeditionTimeMultiplier = await getPartyExpeditionTimeMultiplier(party)
+          const durationSec = estimateExplorationTime(dungeon, returnPolicy, partyExpeditionTimeMultiplier)
           const request: ExpeditionRequest = {
             partyId: party.id.toString(),
             areaId: dungeon.id,
@@ -324,7 +347,7 @@ export const useExpeditionFlow = ({
         setIsProcessing(false)
       }
     },
-    [estimateExplorationTime, saveBulkExpeditionRecords, startExpeditionUseCase, scheduleExpeditionNotification],
+    [estimateExplorationTime, getPartyExpeditionTimeMultiplier, saveBulkExpeditionRecords, startExpeditionUseCase, scheduleExpeditionNotification],
   )
 
   const updateExpeditionReplay = useExpeditionStore((state) => state.updateExpeditionReplay)

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -3,6 +3,7 @@ import {
   getActionOrderMultiplierFromSkills,
   describeCharacterSkill,
   getAdditionalDamageFromSkills,
+  getExpeditionTimeMultiplierFromSkills,
   getLearnedSpellsFromSkills,
   getPhysicalDamageReductionFromSkills,
   getRearAllyDamageMultiplierFromSkills,
@@ -81,6 +82,16 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     ]
 
     expect(getRearAllyDamageMultiplierFromSkills(skills)).toBe(1.5)
+  })
+
+  it('遠征時間倍率スキルはPT内で重複せず乗算される', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'light_footed_4_5', expeditionTimeMultiplier: 0.8 },
+      { id: 'light_footed_4_5', expeditionTimeMultiplier: 0.8 },
+      { id: 'other_time_0_5', expeditionTimeMultiplier: 0.5 },
+    ]
+
+    expect(getExpeditionTimeMultiplierFromSkills(skills)).toBeCloseTo(0.4)
   })
 
   it('呪文ごとの被ダメ倍率は対象呪文だけ乗算する', () => {
@@ -281,6 +292,9 @@ describe('characterSkills - 物理ダメージ軽減', () => {
   })
 
   it('カタログ定義の説明キーからスキル説明文を返す', () => {
+    expect(getCharacterSkillDescription(getCharacterSkill('light_footed_4_5'))).toBe(
+      'PTに1人でもいると探索時間が4/5になります。複数いても重複しません。',
+    )
     expect(getCharacterSkillDescription(getCharacterSkill('weapon_melee_attack'))).toBe(
       '隊列の後ろに行くほど通常攻撃のダメージが低下します。',
     )

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -363,6 +363,13 @@ export function getGoldBonusPercentFromSkills(skills: CharacterSkill[]): number 
   )
 }
 
+export function getExpeditionTimeMultiplierFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (product, skill) => product * (skill.expeditionTimeMultiplier ?? 1),
+    1,
+  )
+}
+
 export function hasUndeadSkill(skills: CharacterSkill[]): boolean {
   return getUniqueSkillsById(skills).some((skill) => skill.undead)
 }

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -335,6 +335,12 @@ export const CHARACTER_SKILL_CATALOG = {
     goldBonusPercent: 50,
   },
 
+  light_footed_4_5: {
+    id: 'light_footed_4_5',
+    expeditionTimeMultiplier: 4 / 5,
+    descriptionKey: 'entities.skill.light_footed_4_5.description',
+  },
+
   beast_slayer_1_2: createRaceSlayerSkill('beast', 1.2),
   beast_slayer_1_5: createRaceSlayerSkill('beast', 1.5),
   beast_slayer_2_0: createRaceSlayerSkill('beast', 2.0),

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -603,6 +603,10 @@ const en = {
       inspire_150: { name: 'Inspire' },
       rear_guard: { name: 'Rear Guard' },
       survive_lethal_hp1: { name: 'Guts' },
+      light_footed_4_5: {
+        name: 'Light Footed',
+        description: 'If at least one party member has this skill, expedition time becomes 4/5. It does not stack.',
+      },
       beast_slayer_1_2: { name: '[1.2x] Beast Slayer' },
       beast_slayer_1_5: { name: '[1.5x] Beast Slayer' },
       beast_slayer_2_0: { name: '[2.0x] Beast Slayer' },

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -612,6 +612,10 @@ const ja = {
       survive_lethal_hp1: { name: '気合い' },
       exp_bonus_70: { name: '[+70%]獲得経験値' },
       gold_bonus_50: { name: '[+50%]取得Gold' },
+      light_footed_4_5: {
+        name: '軽足',
+        description: 'PTに1人でもいると探索時間が4/5になります。複数いても重複しません。',
+      },
       beast_slayer_1_2: { name: '[1.2倍]魔獣特攻' },
       beast_slayer_1_5: { name: '[1.5倍]魔獣特攻' },
       beast_slayer_2_0: { name: '[2.0倍]魔獣特攻' },

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -603,6 +603,10 @@ const ko = {
       inspire_150: { name: '고무' },
       rear_guard: { name: '후열 보호' },
       survive_lethal_hp1: { name: '근성' },
+      light_footed_4_5: {
+        name: '경쾌한 발',
+        description: 'PT에 1명이라도 이 스킬이 있으면 탐색 시간이 4/5가 됩니다. 여러 명이 있어도 중첩되지 않습니다.',
+      },
       beast_slayer_1_2: { name: '[1.2배] 마수 특공' },
       beast_slayer_1_5: { name: '[1.5배] 마수 특공' },
       beast_slayer_2_0: { name: '[2.0배] 마수 특공' },

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -35,6 +35,7 @@ export interface CharacterSkill {
   extraSpellCharges?: number
   expBonusPercent?: number
   goldBonusPercent?: number
+  expeditionTimeMultiplier?: number
   raceBonus?: RaceBuckets
   raceTakenBonus?: RaceBuckets
   spellTakenMultipliers?: Partial<Record<string, number>>


### PR DESCRIPTION
## Summary
- PTに1人でもいると探索時間が4/5になる軽足スキル `light_footed_4_5` を追加
- スキルカタログに `expeditionTimeMultiplier` を新設し、`useExpeditionFlow` の探索時間計算へ反映
- 装備付与スキルも含めて集計し、複数所持時も重複しない乗算方式（PT全員の同IDスキルを1回として扱う）を採用
- ja/en/ko の説明文を整備

## Test plan
- [ ] `npm test -- characterSkills` で軽足スキルの倍率計算テストが通ること
- [ ] 軽足を持つゴブリンを編成して遠征時間が4/5になることを実機/シミュレーターで確認
- [ ] 軽足を複数所持しても探索時間が変わらないこと
- [ ] 装備で軽足を付与した場合も時間短縮が反映されること