### PR TITLE
feat(studio): キャラクターのローカル保存・新規作成と単発戦闘ログ閲覧

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -84,6 +84,17 @@ interface BattleUnit {
   isDefending: boolean
 }
 
+function toCombatBuffsFromSkills(skills: CharacterSkill[]) {
+  return getUniqueSkillsById(skills)
+    .filter((skill) => skill.raceBonus || skill.raceTakenBonus)
+    .map((skill) => ({
+      id: skill.id,
+      name: skill.id,
+      raceBonus: skill.raceBonus,
+      raceTakenBonus: skill.raceTakenBonus,
+    }))
+}
+
 export interface BattleResult {
   rounds: number
   outcome: 'win' | 'lose' | 'retreat'
@@ -1042,7 +1053,9 @@ export class BattleSystem {
   }
 
   private createAllyUnit(goblin: Goblin, initialHP: number | undefined, originalIndex: number): BattleUnit {
+    const skills = getUniqueSkillsById(goblin.skills)
     const combatant = this.combatantManager.fromGoblin(goblin)
+    combatant.buffs = toCombatBuffsFromSkills(skills)
     const actionOrderAgility = (goblin as Goblin & { agility?: number }).agility
     // Mod適用後のステータスを使用
     const effectiveStats = getEffectiveStats(goblin)
@@ -1081,15 +1094,16 @@ export class BattleSystem {
       rowSlot: 0,
       level: goblin.level,
       spellCharges: this.initSpellCharges(learnedSpells),
-      skills: goblin.skills,
+      skills,
       battleActionPolicy: normalizeBattleActionPolicy(goblin.battleActionPolicy),
       isDefending: false,
     }
   }
 
   private createEnemyUnit(enemy: Enemy, originalIndex: number, row: number, rowSlot: number): BattleUnit {
-    const combatant = this.combatantManager.fromEnemy(enemy)
     const skills = getUniqueSkillsById([...(enemy.skills ?? []), ...getRaceSkills(enemy.raceTags)])
+    const combatant = this.combatantManager.fromEnemy(enemy)
+    combatant.buffs = toCombatBuffsFromSkills(skills)
     const learnedSpells = this.mergeLearnedSpells(enemy.spells, skills, enemy.level)
     const raceResistance = getRaceResistanceTotals(enemy.raceTags)
     return {

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -456,10 +456,6 @@ export class ExpeditionEngine {
         attackCount: Math.max(1, Math.floor(enemy.attackCount * countScale)),
         accuracy: Math.round(enemy.accuracy * statScale),
         evasion: this.scaleDefensiveStat(enemy.evasion, scaling.evasionScale),
-        physicalResistancePercent: scaling.physicalResistancePercent,
-        penetrationResistancePercent: scaling.penetrationResistancePercent,
-        criticalResistancePercent: scaling.criticalResistancePercent,
-        magicResistancePercent: scaling.magicResistancePercent,
         exp: Math.floor(enemy.exp * statScale),
         gold: Math.floor(enemy.gold * goldScale),
       }))

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -848,6 +848,60 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     expect(wolfDamage - normalDamage).toBe(13 * wolfLog.hitCount)
   })
 
+  it.each([
+    {
+      name: '魔獣特攻',
+      skillId: 'beast_slayer_2_0' as const,
+      raceTags: ['slime'],
+    },
+    {
+      name: 'アンデッド特攻',
+      skillId: 'undead_slayer_2_0' as const,
+      raceTags: ['skeleton'],
+    },
+    {
+      name: '人間特攻',
+      skillId: 'human_slayer_2_0' as const,
+      raceTags: ['elf'],
+    },
+    {
+      name: '魔族特攻',
+      skillId: 'demon_race_slayer_2_0' as const,
+      raceTags: ['construct'],
+    },
+    {
+      name: 'ドラゴン特攻',
+      skillId: 'dragon_slayer_2_0' as const,
+      raceTags: ['dragon'],
+    },
+  ])('$name は通常攻撃へ適用される', ({ skillId, raceTags }) => {
+    const plainEnemy = [[createTestEnemy({ raceTags, hp: 9999, agility: 1, evasion: 0, def: 0 })]]
+    const buffedEnemy = [[createTestEnemy({ raceTags, hp: 9999, agility: 1, evasion: 0, def: 0 })]]
+    const rngA = createSeededRng(77)
+    const rngB = createSeededRng(77)
+
+    const plainResult = new BattleSystem().executeBattle([
+      createTestGoblin({
+        race: 'ゴブリン',
+        stats: { hp: 100, atk: 50, agility: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 10 },
+        skills: [],
+      }),
+    ], [100], plainEnemy, rngA, 1)
+    const buffedResult = new BattleSystem().executeBattle([
+      createTestGoblin({
+        race: 'ゴブリン',
+        stats: { hp: 100, atk: 50, agility: 100, def: 10, attackCount: 1, accuracy: 999, evasion: 10 },
+        skills: [getCharacterSkill(skillId)],
+      }),
+    ], [100], buffedEnemy, rngB, 1)
+
+    const plainLog = plainResult.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+    const buffedLog = buffedResult.detailedLog.find(log => log.action === '通常攻撃' && log.isAlly)!
+
+    expect(buffedLog.hitCount).toBe(plainLog.hitCount)
+    expect(buffedLog.targets[0].totalDamage).toBe(plainLog.targets[0].totalDamage * 2)
+  })
+
   it('スライムゴブリンより後列の仲間は通常攻撃ダメージが軽減される', () => {
     const protectedAllies = [
       createTestGoblin({

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -187,8 +187,6 @@ describe('ExpeditionEngine dungeon tier scaling', () => {
     cases.forEach(({ enemy, expected }) => {
       const scaledByTier = DUNGEON_TIER_SCALING.map((scaling) => {
         const [[scaled]] = (engine as any).applyTierScaling([[{ ...baseEnemy, ...enemy }]], scaling)
-        expect(scaled.penetrationResistancePercent).toBe(100)
-        expect(scaled.criticalResistancePercent).toBe(50)
         return scaled
       })
 

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -22,10 +22,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 1.0,
     evasionScale: 1.0,
     magicDefScale: 1.0,
-    physicalResistancePercent: 44.2,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 42.5,
   },
   {
     statScale: 1.58,
@@ -40,10 +36,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 3950 / 2500,
     evasionScale: 1.58,
     magicDefScale: 1.58,
-    physicalResistancePercent: 38.0,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 36.5,
   },
   {
     statScale: 2.10,
@@ -57,10 +49,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 5250 / 2500,
     evasionScale: 2.10,
     magicDefScale: 2.10,
-    physicalResistancePercent: 32.7,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 34.8,
   },
   {
     statScale: 2.75,
@@ -70,10 +58,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 6875 / 2500,
     evasionScale: 2.75,
     magicDefScale: 2.75,
-    physicalResistancePercent: 28.3,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 33.1,
   },
   {
     statScale: 3.50,
@@ -83,10 +67,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 7.0,
     evasionScale: 7.0,
     magicDefScale: 7.0,
-    physicalResistancePercent: 24.3,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 31.4,
   },
   {
     statScale: 5.00,
@@ -96,10 +76,6 @@ export const DUNGEON_TIER_SCALING = [
     defScale: 10.0,
     evasionScale: 10.0,
     magicDefScale: 10.0,
-    physicalResistancePercent: 21.2,
-    penetrationResistancePercent: 100.0,
-    criticalResistancePercent: 50.0,
-    magicResistancePercent: 29.7,
   },
 ] as const
 

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -122,6 +122,7 @@ export function dataApiPlugin(options: Options): Plugin {
   const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
   const variantsFile = path.join(options.appSrc, 'shared', 'data', 'goblinVariants.ts')
   const presetsFile = path.join(options.dataDir, 'party-presets.json')
+  const libraryFile = path.join(options.dataDir, 'character-library.json')
 
   return {
     name: 'studio-data-api',
@@ -161,6 +162,27 @@ export function dataApiPlugin(options: Options): Plugin {
       server.middlewares.use('/api/dungeon-unlocks', async (_req, res) => {
         try {
           return json(res, 200, await readDungeonUnlocks(areaDir))
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          return json(res, 500, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/character-library', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            return json(res, 200, await readLibrary(libraryFile))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            await writeLibrary(libraryFile, body)
+            return json(res, 200, { ok: true })
+          }
+          if (req.method === 'DELETE') {
+            await deleteLibrary(libraryFile)
+            return json(res, 200, { ok: true })
+          }
+          return json(res, 405, { error: 'Method not allowed' })
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Unknown error'
           return json(res, 500, { error: message })
@@ -250,6 +272,44 @@ export function dataApiPlugin(options: Options): Plugin {
         }
       })
     },
+  }
+}
+
+async function readLibrary(filePath: string): Promise<unknown> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { goblins: [], equipment: [], parties: [], meta: null }
+    }
+    throw err
+  }
+}
+
+async function writeLibrary(filePath: string, body: unknown): Promise<void> {
+  if (!body || typeof body !== 'object') {
+    throw new Error('Body must be an object')
+  }
+  const record = body as Record<string, unknown>
+  if (
+    !Array.isArray(record.goblins) ||
+    !Array.isArray(record.equipment) ||
+    !Array.isArray(record.parties)
+  ) {
+    throw new Error('Library must contain goblins, equipment, parties arrays')
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const formatted = `${JSON.stringify(body, null, 2)}\n`
+  await fs.writeFile(filePath, formatted, 'utf8')
+}
+
+async function deleteLibrary(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw err
   }
 }
 

--- a/tools/studio/src/components/BackupDropzone.tsx
+++ b/tools/studio/src/components/BackupDropzone.tsx
@@ -3,13 +3,13 @@ import { useRef, useState } from 'react'
 import { usePartyStore } from '../stores/partyStore'
 
 export function BackupDropzone({ compact = false }: { compact?: boolean }) {
-  const { loadBackup, backupLoading } = usePartyStore()
+  const { importBackup, importBackupBusy } = usePartyStore()
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [dragging, setDragging] = useState(false)
 
   const handleFile = (file: File | undefined | null) => {
     if (!file) return
-    void loadBackup(file)
+    void importBackup(file)
   }
 
   if (compact) {
@@ -18,9 +18,9 @@ export function BackupDropzone({ compact = false }: { compact?: boolean }) {
         <button
           className="btn ghost"
           onClick={() => inputRef.current?.click()}
-          disabled={backupLoading}
+          disabled={importBackupBusy}
         >
-          別のバックアップを読み込む
+          バックアップを再取り込み
         </button>
         <input
           ref={inputRef}
@@ -57,7 +57,7 @@ export function BackupDropzone({ compact = false }: { compact?: boolean }) {
       <p className="subtle">
         対応形式: ゴブリンキングダムのバックアップ JSON（<code>meta.app = "goblin_kingdom"</code>）
       </p>
-      {backupLoading && <p className="subtle">読み込み中…</p>}
+      {importBackupBusy && <p className="subtle">読み込み中…</p>}
       <input
         ref={inputRef}
         type="file"

--- a/tools/studio/src/components/BackupPartyList.tsx
+++ b/tools/studio/src/components/BackupPartyList.tsx
@@ -2,19 +2,19 @@ import { usePartyStore } from '../stores/partyStore'
 import type { BackupGoblin } from '../lib/goblinMapper'
 
 export function BackupPartyList() {
-  const { backup, loadBackupParty, importBackupPartyAsPreset } = usePartyStore()
-  if (!backup || backup.parties.length === 0) return null
+  const { library, loadLibraryParty, importLibraryPartyAsPreset } = usePartyStore()
+  if (library.parties.length === 0) return null
 
-  const goblinById = new Map(backup.goblins.map((g) => [g.id, g]))
+  const goblinById = new Map(library.goblins.map((g) => [g.id, g]))
 
   return (
     <section className="card">
-      <h3>バックアップ内のPT ({backup.parties.length})</h3>
+      <h3>取り込み済みのPT ({library.parties.length})</h3>
       <p className="subtle" style={{ margin: '0 0 0.5rem' }}>
         ゲーム本体で作成済みのPTをそのまま読み込めます。
       </p>
       <ul className="preset-list">
-        {backup.parties.map((p) => {
+        {library.parties.map((p) => {
           const members = p.memberIds
             .map((id) => goblinById.get(id))
             .filter((g): g is BackupGoblin => g !== undefined)
@@ -36,21 +36,21 @@ export function BackupPartyList() {
                 )}
                 {members.length < p.memberIds.length && (
                   <div className="save-error" style={{ marginTop: '0.3rem', padding: '0.3rem 0.5rem' }}>
-                    {p.memberIds.length - members.length}体のゴブリンがバックアップ内に見つかりません
+                    {p.memberIds.length - members.length}体のゴブリンが見つかりません
                   </div>
                 )}
               </div>
               <div className="preset-actions">
                 <button
                   className="btn ghost small"
-                  onClick={() => loadBackupParty(p.id)}
+                  onClick={() => loadLibraryParty(p.id)}
                   title="現在の編成に読み込む"
                 >
                   読込
                 </button>
                 <button
                   className="btn ghost small"
-                  onClick={() => importBackupPartyAsPreset(p.id)}
+                  onClick={() => importLibraryPartyAsPreset(p.id)}
                   title="プリセットとして永続化"
                 >
                   プリセット化

--- a/tools/studio/src/components/CharacterEditor.tsx
+++ b/tools/studio/src/components/CharacterEditor.tsx
@@ -67,11 +67,8 @@ export function CharacterEditor({
 
   const filteredSkills = useMemo(() => {
     const q = skillQuery.trim().toLowerCase()
-    if (q === '') return SKILL_OPTIONS.slice(0, 60)
-    return SKILL_OPTIONS.filter((s) => s.label.toLowerCase().includes(q)).slice(
-      0,
-      120,
-    )
+    if (q === '') return SKILL_OPTIONS
+    return SKILL_OPTIONS.filter((s) => s.label.toLowerCase().includes(q))
   }, [skillQuery])
 
   if (!open) return null

--- a/tools/studio/src/components/CharacterEditor.tsx
+++ b/tools/studio/src/components/CharacterEditor.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  DEFAULT_DRAFT,
+  PURE_GOBLIN_VARIANT_ID,
+  buildCustomGoblin,
+  draftFromBackupGoblin,
+  listJobOptions,
+  listSkillOptions,
+  listVariantOptions,
+  nextCustomGoblinId,
+  type CharacterDraft,
+} from '../lib/customGoblin'
+import type { CharacterSkillId } from '@app/shared/data/skillCatalog'
+import type { GoblinJob } from '@app/shared/types'
+import type { BackupGoblin } from '../lib/goblinMapper'
+
+const SKILL_OPTIONS = listSkillOptions()
+const VARIANT_OPTIONS = listVariantOptions()
+const JOB_OPTIONS = listJobOptions()
+
+interface Props {
+  open: boolean
+  editingId: number | null
+  existingGoblins: BackupGoblin[]
+  onClose: () => void
+  onSubmit: (goblin: BackupGoblin) => void | Promise<void>
+  onDelete?: (id: number) => void | Promise<void>
+}
+
+export function CharacterEditor({
+  open,
+  editingId,
+  existingGoblins,
+  onClose,
+  onSubmit,
+  onDelete,
+}: Props) {
+  const [draft, setDraft] = useState<CharacterDraft>(DEFAULT_DRAFT)
+  const [skillQuery, setSkillQuery] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setSubmitError(null)
+    setSkillQuery('')
+    if (editingId !== null) {
+      const target = existingGoblins.find((g) => g.id === editingId)
+      if (target) {
+        setDraft(draftFromBackupGoblin(target))
+        return
+      }
+    }
+    setDraft({ ...DEFAULT_DRAFT })
+  }, [open, editingId, existingGoblins])
+
+  const previewResult = useMemo(() => {
+    if (!open) return null
+    try {
+      const id = editingId ?? nextCustomGoblinId(existingGoblins.map((g) => g.id))
+      return buildCustomGoblin(draft, { id })
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) } as const
+    }
+  }, [draft, editingId, existingGoblins, open])
+
+  const filteredSkills = useMemo(() => {
+    const q = skillQuery.trim().toLowerCase()
+    if (q === '') return SKILL_OPTIONS.slice(0, 60)
+    return SKILL_OPTIONS.filter((s) => s.label.toLowerCase().includes(q)).slice(
+      0,
+      120,
+    )
+  }, [skillQuery])
+
+  if (!open) return null
+
+  const previewGoblin =
+    previewResult && 'goblin' in previewResult ? previewResult.goblin : null
+  const previewError =
+    previewResult && 'error' in previewResult ? previewResult.error : null
+  const baseSkillIds =
+    previewResult && 'baseDefaultSkillIds' in previewResult
+      ? previewResult.baseDefaultSkillIds
+      : []
+  const baseSkillIdSet = new Set(baseSkillIds)
+
+  const toggleSkill = (id: CharacterSkillId) => {
+    setDraft((prev) => {
+      if (prev.extraSkillIds.includes(id)) {
+        return { ...prev, extraSkillIds: prev.extraSkillIds.filter((x) => x !== id) }
+      }
+      if (baseSkillIdSet.has(id)) return prev
+      return { ...prev, extraSkillIds: [...prev.extraSkillIds, id] }
+    })
+  }
+
+  const handleSubmit = async () => {
+    if (!previewGoblin) return
+    if (draft.name.trim() === '') {
+      setSubmitError('名前を入力してください')
+      return
+    }
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onSubmit(previewGoblin)
+      onClose()
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (editingId === null || !onDelete) return
+    if (
+      !window.confirm('このキャラクターを削除しますか？（PT/プリセット側からも外れます）')
+    )
+      return
+    setSubmitting(true)
+    try {
+      await onDelete(editingId)
+      onClose()
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-panel" onClick={(e) => e.stopPropagation()}>
+        <header className="modal-head">
+          <h2>{editingId !== null ? 'キャラクター編集' : '新規キャラクター作成'}</h2>
+          <button className="icon-btn" onClick={onClose} title="閉じる">
+            ×
+          </button>
+        </header>
+
+        <div className="modal-body">
+          <div className="character-editor-grid">
+            <label className="field">
+              <span className="field-label">名前</span>
+              <span className="field-input">
+                <input
+                  type="text"
+                  value={draft.name}
+                  placeholder="例: 試作ゴブリン"
+                  onChange={(e) =>
+                    setDraft((prev) => ({ ...prev, name: e.target.value }))
+                  }
+                />
+              </span>
+            </label>
+
+            <label className="field">
+              <span className="field-label">亜種（因子）</span>
+              <span className="field-input">
+                <select
+                  value={draft.variantId}
+                  onChange={(e) =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      variantId: e.target.value,
+                      job: e.target.value === PURE_GOBLIN_VARIANT_ID ? prev.job : null,
+                    }))
+                  }
+                >
+                  {VARIANT_OPTIONS.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {v.label}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
+
+            <label className="field">
+              <span className="field-label">ジョブ</span>
+              <span className="field-input">
+                <select
+                  value={draft.job ?? ''}
+                  onChange={(e) =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      job: (e.target.value || null) as GoblinJob | null,
+                    }))
+                  }
+                  disabled={draft.variantId !== PURE_GOBLIN_VARIANT_ID}
+                  title={
+                    draft.variantId !== PURE_GOBLIN_VARIANT_ID
+                      ? '亜種ゴブリンはジョブを設定できません'
+                      : undefined
+                  }
+                >
+                  {JOB_OPTIONS.map((j) => (
+                    <option key={j.id ?? '__none__'} value={j.id ?? ''}>
+                      {j.label}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
+
+            <label className="field">
+              <span className="field-label">レベル</span>
+              <span className="field-input">
+                <input
+                  type="number"
+                  min={1}
+                  max={200}
+                  value={draft.level}
+                  onChange={(e) =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      level: clamp(Number(e.target.value) || 1, 1, 200),
+                    }))
+                  }
+                />
+              </span>
+            </label>
+
+            <label className="field">
+              <span className="field-label">個体値 (1〜64)</span>
+              <span className="field-input">
+                <input
+                  type="number"
+                  min={1}
+                  max={64}
+                  value={draft.individualValue}
+                  onChange={(e) =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      individualValue: clamp(
+                        Number(e.target.value) || 1,
+                        1,
+                        64,
+                      ),
+                    }))
+                  }
+                />
+              </span>
+            </label>
+          </div>
+
+          <section className="character-editor-section">
+            <h3>付与スキル</h3>
+            <p className="subtle" style={{ marginTop: 0 }}>
+              種族・亜種・ジョブの既定スキルは自動付与されます。それ以外で追加したいスキルを選択してください。
+            </p>
+            <div className="character-editor-skill-summary">
+              <div>
+                <strong>既定:</strong>{' '}
+                {baseSkillIds.length === 0 ? (
+                  <span className="subtle">なし</span>
+                ) : (
+                  baseSkillIds.map((id) => (
+                    <code key={id} className="skill-chip">
+                      {id}
+                    </code>
+                  ))
+                )}
+              </div>
+              <div>
+                <strong>追加 ({draft.extraSkillIds.length}):</strong>{' '}
+                {draft.extraSkillIds.length === 0 ? (
+                  <span className="subtle">なし</span>
+                ) : (
+                  draft.extraSkillIds.map((id) => (
+                    <button
+                      key={id}
+                      type="button"
+                      className="skill-chip removable"
+                      onClick={() => toggleSkill(id)}
+                      title="クリックで外す"
+                    >
+                      {id} ×
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+            <input
+              type="search"
+              className="search-input"
+              placeholder="スキル名 / IDで絞り込み"
+              value={skillQuery}
+              onChange={(e) => setSkillQuery(e.target.value)}
+              style={{ marginTop: '0.5rem' }}
+            />
+            <div className="character-editor-skill-list">
+              {filteredSkills.map((s) => {
+                const isBase = baseSkillIdSet.has(s.id)
+                const isExtra = draft.extraSkillIds.includes(s.id)
+                return (
+                  <button
+                    key={s.id}
+                    type="button"
+                    className={`skill-chip ${isExtra ? 'selected' : ''} ${
+                      isBase ? 'base' : ''
+                    }`}
+                    onClick={() => toggleSkill(s.id)}
+                    disabled={isBase}
+                    title={isBase ? '既定で付与済み' : s.label}
+                  >
+                    {s.label}
+                  </button>
+                )
+              })}
+              {filteredSkills.length === 0 && (
+                <span className="subtle">該当スキルがありません</span>
+              )}
+            </div>
+          </section>
+
+          <section className="character-editor-section">
+            <h3>ステータスプレビュー</h3>
+            {previewError && <p className="save-error">{previewError}</p>}
+            {previewGoblin && (
+              <div className="character-editor-stats">
+                <StatRow label="HP" value={previewGoblin.effectiveStats?.hp ?? previewGoblin.stats.hp} base={previewGoblin.stats.hp} />
+                <StatRow label="ATK" value={previewGoblin.effectiveStats?.atk ?? previewGoblin.stats.atk} base={previewGoblin.stats.atk} />
+                <StatRow label="DEF" value={previewGoblin.effectiveStats?.def ?? previewGoblin.stats.def} base={previewGoblin.stats.def} />
+                <StatRow label="M-ATK" value={previewGoblin.effectiveStats?.magicAtk ?? previewGoblin.stats.magicAtk ?? 0} base={previewGoblin.stats.magicAtk ?? 0} />
+                <StatRow label="M-DEF" value={previewGoblin.effectiveStats?.magicDef ?? previewGoblin.stats.magicDef ?? 0} base={previewGoblin.stats.magicDef ?? 0} />
+                <StatRow label="HEAL" value={previewGoblin.effectiveStats?.magicHeal ?? previewGoblin.stats.magicHeal ?? 0} base={previewGoblin.stats.magicHeal ?? 0} />
+                <StatRow label="ATK回数" value={previewGoblin.effectiveStats?.attackCount ?? previewGoblin.stats.attackCount} base={previewGoblin.stats.attackCount} />
+                <StatRow label="命中" value={previewGoblin.effectiveStats?.accuracy ?? previewGoblin.stats.accuracy} base={previewGoblin.stats.accuracy} />
+                <StatRow label="回避" value={previewGoblin.effectiveStats?.evasion ?? previewGoblin.stats.evasion} base={previewGoblin.stats.evasion} />
+                <StatRow label="必殺" value={previewGoblin.effectiveStats?.criticalRate ?? previewGoblin.stats.criticalRate ?? 0} base={previewGoblin.stats.criticalRate ?? 0} />
+              </div>
+            )}
+          </section>
+
+          {submitError && <p className="save-error">{submitError}</p>}
+        </div>
+
+        <footer className="modal-foot">
+          {editingId !== null && onDelete && (
+            <button
+              className="btn ghost"
+              onClick={handleDelete}
+              disabled={submitting}
+              style={{ marginRight: 'auto' }}
+            >
+              削除
+            </button>
+          )}
+          <button className="btn ghost" onClick={onClose} disabled={submitting}>
+            キャンセル
+          </button>
+          <button
+            className="btn primary"
+            onClick={handleSubmit}
+            disabled={submitting || !previewGoblin}
+          >
+            {editingId !== null ? '保存' : '作成'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function StatRow({
+  label,
+  value,
+  base,
+}: {
+  label: string
+  value: number
+  base: number
+}) {
+  return (
+    <div className="stat">
+      <span className="stat-label">{label}</span>
+      <span className="stat-value">
+        {value}
+        {value !== base && <span className="subtle"> (基本 {base})</span>}
+      </span>
+    </div>
+  )
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/tools/studio/src/components/ExpeditionReplayView.tsx
+++ b/tools/studio/src/components/ExpeditionReplayView.tsx
@@ -1,0 +1,258 @@
+import { useState } from 'react'
+
+import type {
+  BattleLogEntry,
+  CombatReplay,
+  ExpeditionReplay,
+  TimelineEvent,
+} from '@app/shared/types'
+
+import type { SingleRunResult } from '../lib/runExpedition'
+
+export function ExpeditionReplayView({ result }: { result: SingleRunResult }) {
+  const { replay, seed } = result
+  const summary = replay.summary
+  const lastEvent = replay.events[replay.events.length - 1]
+  const endReason =
+    lastEvent && lastEvent.type === 'return' ? lastEvent.reason : null
+
+  return (
+    <section className="card">
+      <h2>単発シミュレーション結果</h2>
+      <p className="subtle">
+        seed: <code>{seed}</code> / 所要時間 {Math.round(replay.durationSec)}s /
+        到達 {summary.maxFloorReached}F /
+        XP {summary.xpGained} / Gold {summary.goldGained}
+        {endReason ? ` / 終了理由: ${endReason}` : ''}
+        {summary.casualties.length > 0
+          ? ` / 戦闘不能: ${summary.casualties.join(', ')}`
+          : ''}
+      </p>
+
+      <h3>タイムライン ({replay.events.length} 件)</h3>
+      <ul className="replay-timeline">
+        {replay.events.map((event, idx) => (
+          <TimelineEventRow key={idx} event={event} index={idx} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function TimelineEventRow({
+  event,
+  index,
+}: {
+  event: TimelineEvent
+  index: number
+}) {
+  const at = `${Math.round(event.at)}s`
+  switch (event.type) {
+    case 'move_start':
+      return (
+        <li className="replay-row">
+          <span className="replay-time">{at}</span>
+          <span className="replay-tag">出発</span>
+          <span>{event.floor}F に向かう</span>
+        </li>
+      )
+    case 'floor_up':
+      return (
+        <li className="replay-row">
+          <span className="replay-time">{at}</span>
+          <span className="replay-tag">階移動</span>
+          <span>
+            {event.from}F → {event.to}F
+          </span>
+        </li>
+      )
+    case 'exploring':
+      return (
+        <li className="replay-row">
+          <span className="replay-time">{at}</span>
+          <span className="replay-tag">探索</span>
+          <span>{event.floor}F</span>
+        </li>
+      )
+    case 'treasure':
+      return (
+        <li className="replay-row">
+          <span className="replay-time">{at}</span>
+          <span className="replay-tag">宝箱</span>
+          <span>
+            {event.floor}F /{' '}
+            {event.items
+              .map((it) =>
+                it.titleId ? `${it.titleId}/${it.templateId}` : it.templateId,
+              )
+              .join(', ')}
+          </span>
+        </li>
+      )
+    case 'return':
+      return (
+        <li className="replay-row">
+          <span className="replay-time">{at}</span>
+          <span className="replay-tag end">帰還</span>
+          <span>{event.reason}</span>
+        </li>
+      )
+    case 'battle':
+    case 'boss':
+      return (
+        <BattleEventRow event={event} at={at} index={index} />
+      )
+  }
+}
+
+function BattleEventRow({
+  event,
+  at,
+  index,
+}: {
+  event: Extract<TimelineEvent, { type: 'battle' | 'boss' }>
+  at: string
+  index: number
+}) {
+  const [open, setOpen] = useState(false)
+  const tag = event.type === 'boss' ? 'BOSS' : '戦闘'
+  const outcome = event.combat.outcome
+  const enemy = event.enemy
+  const log = event.combat.detailedLog ?? []
+
+  return (
+    <li className={`replay-row battle ${outcome}`}>
+      <div className="replay-summary" onClick={() => setOpen((o) => !o)}>
+        <span className="replay-time">{at}</span>
+        <span className={`replay-tag ${event.type}`}>{tag}</span>
+        <span className="replay-battle-summary">
+          {event.floor}F / vs <strong>{enemy.name}</strong> Lv{enemy.lvl} ×
+          {enemy.count} ／ 結果:{' '}
+          <strong className={`outcome ${outcome}`}>{outcome}</strong> ／{' '}
+          {event.combat.rounds}ラウンド ／ XP +{event.xp}
+        </span>
+        <button
+          className="btn ghost small"
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpen((o) => !o)
+          }}
+        >
+          {open ? 'ログを閉じる' : `ログを開く (${log.length})`}
+        </button>
+      </div>
+      {open && (
+        <CombatLogTable
+          log={log}
+          combat={event.combat}
+          eventIndex={index}
+        />
+      )}
+    </li>
+  )
+}
+
+function CombatLogTable({
+  log,
+  combat,
+  eventIndex,
+}: {
+  log: BattleLogEntry[]
+  combat: CombatReplay
+  eventIndex: number
+}) {
+  if (log.length === 0) {
+    return (
+      <div className="replay-combat-empty subtle">
+        詳細ログが記録されていません（ラウンド数: {combat.rounds}）
+      </div>
+    )
+  }
+
+  let lastTurn = -1
+  return (
+    <div className="replay-combat-log">
+      <table className="enemy-table replay-combat-table">
+        <thead>
+          <tr>
+            <th className="num">T</th>
+            <th>行動者</th>
+            <th>行動</th>
+            <th>ターゲット / 結果</th>
+            <th className="num">HP</th>
+          </tr>
+        </thead>
+        <tbody>
+          {log.map((entry, i) => {
+            const newTurn = entry.turn !== lastTurn
+            lastTurn = entry.turn
+            return (
+              <tr
+                key={`${eventIndex}-${i}`}
+                className={`${entry.isAlly ? 'ally' : 'enemy'} ${
+                  newTurn ? 'turn-start' : ''
+                } ${entry.isCritical ? 'critical' : ''}`}
+              >
+                <td className="num">{entry.turn}</td>
+                <td>
+                  <span
+                    className={`replay-actor-row r${entry.actorRow}`}
+                    title={`row ${entry.actorRow}`}
+                  >
+                    {entry.actorName}
+                  </span>
+                </td>
+                <td>
+                  {entry.action}
+                  {entry.isCritical ? ' ★' : ''}
+                  {entry.actionEffect ? ` (${entry.actionEffect})` : ''}
+                </td>
+                <td>
+                  {entry.targets.length === 0 ? (
+                    <span className="subtle">—</span>
+                  ) : (
+                    <ul className="replay-targets">
+                      {entry.targets.map((t, ti) => (
+                        <li key={ti}>
+                          <span>{t.targetName}</span>
+                          <span className="subtle">
+                            {' '}
+                            ({t.hitCount}/{entry.attackCount} 命中)
+                          </span>{' '}
+                          <strong
+                            className={
+                              t.totalDamage > 0
+                                ? 'damage'
+                                : t.totalDamage < 0
+                                ? 'heal'
+                                : 'subtle'
+                            }
+                          >
+                            {t.totalDamage > 0
+                              ? `${t.totalDamage} dmg`
+                              : t.totalDamage < 0
+                              ? `+${-t.totalDamage} heal`
+                              : '0'}
+                          </strong>
+                          {t.defeated && (
+                            <span className="badge danger"> 撃破</span>
+                          )}
+                          <span className="subtle"> HP {t.targetHP}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </td>
+                <td className="num">
+                  {entry.actorHP}/{entry.actorMaxHP}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export type { ExpeditionReplay }

--- a/tools/studio/src/components/GoblinBrowser.tsx
+++ b/tools/studio/src/components/GoblinBrowser.tsx
@@ -5,8 +5,12 @@ import type { BackupGoblin } from '../lib/goblinMapper'
 
 type SortKey = 'id' | 'level' | 'name' | 'job' | 'race'
 
-export function GoblinBrowser() {
-  const { backup, draft, addMember } = usePartyStore()
+export function GoblinBrowser({
+  onEditGoblin,
+}: {
+  onEditGoblin?: (id: number) => void
+}) {
+  const { library, draft, addMember } = usePartyStore()
   const [query, setQuery] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('level')
   const [sortDesc, setSortDesc] = useState(true)
@@ -17,9 +21,8 @@ export function GoblinBrowser() {
   )
 
   const filtered = useMemo(() => {
-    if (!backup) return []
     const q = query.trim().toLowerCase()
-    let list = backup.goblins
+    let list = library.goblins
     if (q !== '') {
       list = list.filter(
         (g) =>
@@ -32,10 +35,10 @@ export function GoblinBrowser() {
     const sorted = list.slice().sort((a, b) => compareByKey(a, b, sortKey))
     if (sortDesc) sorted.reverse()
     return sorted
-  }, [backup, query, sortKey, sortDesc])
+  }, [library, query, sortKey, sortDesc])
 
-  if (!backup) return null
-  const equipmentByGoblin = backup.equipmentByGoblin
+  if (library.goblins.length === 0) return null
+  const equipmentByGoblin = library.equipmentByGoblin
 
   return (
     <div>
@@ -47,7 +50,7 @@ export function GoblinBrowser() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-        <span className="subtle">{filtered.length} / {backup.goblins.length} 体表示</span>
+        <span className="subtle">{filtered.length} / {library.goblins.length} 体表示</span>
       </div>
       <table className="enemy-table">
         <thead>
@@ -81,13 +84,24 @@ export function GoblinBrowser() {
                 <td className="num">{stats.def}</td>
                 <td className="num">{equipCount}</td>
                 <td>
-                  <button
-                    className="btn ghost small"
-                    disabled={inParty}
-                    onClick={() => addMember(g.id)}
-                  >
-                    {inParty ? '編成済' : '+ PT'}
-                  </button>
+                  <div style={{ display: 'flex', gap: '0.3rem' }}>
+                    <button
+                      className="btn ghost small"
+                      disabled={inParty}
+                      onClick={() => addMember(g.id)}
+                    >
+                      {inParty ? '編成済' : '+ PT'}
+                    </button>
+                    {onEditGoblin && (
+                      <button
+                        className="btn ghost small"
+                        onClick={() => onEditGoblin(g.id)}
+                        title="編集"
+                      >
+                        編集
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             )

--- a/tools/studio/src/lib/customGoblin.ts
+++ b/tools/studio/src/lib/customGoblin.ts
@@ -1,0 +1,246 @@
+import {
+  goblinVariantDefinitions,
+  getGoblinVariantByFactorId,
+  BASE_GOBLIN_BASE_ATTRIBUTES,
+} from '@app/shared/data/goblinVariants'
+import {
+  getGoblinJobDefinitions,
+  getGoblinJobDefinition,
+} from '@app/shared/data/goblinJobs'
+import { getDefaultSkillsForRace } from '@app/shared/data/raceSkills'
+import {
+  CHARACTER_SKILL_CATALOG,
+  getCharacterSkill,
+  getCharacterSkillDefinition,
+  type CharacterSkillId,
+} from '@app/shared/data/skillCatalog'
+import {
+  syncGoblinDerivedStats,
+  calculateGoblinEffectiveStats,
+} from '@app/shared/utils/goblinStats'
+import type { CharacterSkill, Goblin, GoblinJob } from '@app/shared/types'
+import { getLegacyRaceName, type GoblinRaceId } from '@app/shared/types/Race'
+import { getSkillLabel } from '@app/shared/i18n/entityLocalization'
+
+import type { BackupGoblin } from './goblinMapper'
+
+export const PURE_GOBLIN_VARIANT_ID = '__pure__'
+
+export type VariantOptionId = string
+
+export interface VariantOption {
+  id: VariantOptionId
+  label: string
+  raceId: string
+  isPure: boolean
+}
+
+export interface JobOption {
+  id: GoblinJob | null
+  label: string
+}
+
+export interface SkillOption {
+  id: CharacterSkillId
+  label: string
+}
+
+export interface CharacterDraft {
+  id: number | null
+  name: string
+  variantId: VariantOptionId
+  job: GoblinJob | null
+  level: number
+  individualValue: number
+  extraSkillIds: CharacterSkillId[]
+}
+
+export const DEFAULT_DRAFT: CharacterDraft = {
+  id: null,
+  name: '',
+  variantId: PURE_GOBLIN_VARIANT_ID,
+  job: 'guard',
+  level: 1,
+  individualValue: 64,
+  extraSkillIds: [],
+}
+
+const VARIANT_OPTIONS: VariantOption[] = [
+  {
+    id: PURE_GOBLIN_VARIANT_ID,
+    label: 'ゴブリン (純正)',
+    raceId: 'goblin',
+    isPure: true,
+  },
+  ...Object.values(goblinVariantDefinitions).map((v) => ({
+    id: v.factorId,
+    label: v.raceName,
+    raceId: v.raceId,
+    isPure: false,
+  })),
+]
+
+export function listVariantOptions(): VariantOption[] {
+  return VARIANT_OPTIONS
+}
+
+export function listJobOptions(): JobOption[] {
+  return [
+    { id: null, label: 'なし' },
+    ...getGoblinJobDefinitions().map((j) => ({ id: j.id, label: j.name })),
+  ]
+}
+
+export function listSkillOptions(): SkillOption[] {
+  return Object.keys(CHARACTER_SKILL_CATALOG)
+    .map((id) => {
+      const skill = getCharacterSkillDefinition(id)
+      return {
+        id: id as CharacterSkillId,
+        label: skillLabelOrId(skill),
+      }
+    })
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+function skillLabelOrId(skill: CharacterSkill): string {
+  const localized = getSkillLabel(skill)
+  return localized && localized !== skill.id ? `${localized} (${skill.id})` : skill.id
+}
+
+export interface BuildGoblinResult {
+  goblin: BackupGoblin
+  baseDefaultSkillIds: string[]
+}
+
+export function buildCustomGoblin(
+  draft: CharacterDraft,
+  options: { id: number },
+): BuildGoblinResult {
+  const variant =
+    draft.variantId !== PURE_GOBLIN_VARIANT_ID
+      ? getGoblinVariantByFactorId(draft.variantId) ?? null
+      : null
+  const raceId: GoblinRaceId = variant?.raceId ?? 'goblin'
+  const race = getLegacyRaceName(raceId)
+  const jobDef = draft.job ? getGoblinJobDefinition(draft.job) : null
+
+  const baseAttributes =
+    variant?.baseAttributes ??
+    jobDef?.baseAttributes ??
+    BASE_GOBLIN_BASE_ATTRIBUTES
+
+  const raceDefaultSkills = getDefaultSkillsForRace(raceId)
+  const jobSkills = jobDef
+    ? jobDef.skills
+        .filter((s) => (s.unlockLevel ?? 1) <= draft.level)
+        .map((s) => getCharacterSkill(s.skillId))
+    : []
+  const extraSkills = draft.extraSkillIds.map((id) => getCharacterSkill(id))
+
+  const baseDefaultSkillIds = [
+    ...raceDefaultSkills.map((s) => s.id),
+    ...jobSkills.map((s) => s.id),
+  ]
+
+  const skillMap = new Map<string, CharacterSkill>()
+  for (const s of [...raceDefaultSkills, ...jobSkills, ...extraSkills]) {
+    skillMap.set(s.id, s)
+  }
+  const skills = Array.from(skillMap.values())
+
+  const proto: Goblin = {
+    id: options.id,
+    name: draft.name,
+    race,
+    raceId,
+    job: draft.job ?? undefined,
+    level: draft.level,
+    experience: 0,
+    avatar: variant?.avatar ?? '',
+    stats: {
+      hp: 0,
+      atk: 0,
+      magicAtk: 0,
+      def: 0,
+      magicDef: 0,
+      attackCount: 1,
+      accuracy: 0,
+      evasion: 0,
+      magicHeal: 0,
+      criticalRate: 0,
+    },
+    baseAttributes,
+    factors: variant ? [variant.factorId] : [],
+    variantFactorId: variant?.factorId,
+    individualValue: draft.individualValue,
+    skills,
+  }
+
+  const synced = syncGoblinDerivedStats(proto)
+  const effective = calculateGoblinEffectiveStats(synced)
+
+  const goblin: BackupGoblin = {
+    id: synced.id,
+    name: synced.name,
+    race: synced.race,
+    raceId: synced.raceId as string,
+    job: synced.job as string | undefined,
+    level: synced.level,
+    experience: synced.experience,
+    avatar: synced.avatar,
+    stats: {
+      hp: synced.stats.hp,
+      atk: synced.stats.atk,
+      magicAtk: synced.stats.magicAtk,
+      def: synced.stats.def,
+      magicDef: synced.stats.magicDef,
+      attackCount: synced.stats.attackCount,
+      accuracy: synced.stats.accuracy,
+      evasion: synced.stats.evasion,
+      magicHeal: synced.stats.magicHeal,
+      criticalRate: synced.stats.criticalRate,
+    },
+    effectiveStats: { ...effective },
+    currentHp: effective.hp,
+    factors: synced.factors,
+    variantFactorId: synced.variantFactorId,
+    individualValue: synced.individualValue,
+    skills: synced.skills,
+  }
+
+  return { goblin, baseDefaultSkillIds }
+}
+
+export function nextCustomGoblinId(existingIds: number[]): number {
+  const max = existingIds.reduce((acc, id) => (id > acc ? id : acc), 0)
+  return Math.max(max + 1, 100_000)
+}
+
+export function draftFromBackupGoblin(g: BackupGoblin): CharacterDraft {
+  const variantId = g.variantFactorId ?? PURE_GOBLIN_VARIANT_ID
+  const validVariant = listVariantOptions().some((v) => v.id === variantId)
+  const job = (g.job ?? null) as GoblinJob | null
+  const raceDefaultSkillIds = new Set(
+    getDefaultSkillsForRace(g.raceId ?? 'goblin').map((s) => s.id),
+  )
+  const jobSkillIds = new Set(
+    job
+      ? getGoblinJobDefinition(job).skills.map((s) => s.skillId as string)
+      : [],
+  )
+  const extraSkillIds = (g.skills ?? [])
+    .map((s) => (s as CharacterSkill).id as string)
+    .filter((id) => !raceDefaultSkillIds.has(id) && !jobSkillIds.has(id))
+    .filter((id): id is CharacterSkillId => id in CHARACTER_SKILL_CATALOG)
+
+  return {
+    id: g.id,
+    name: g.name,
+    variantId: validVariant ? variantId : PURE_GOBLIN_VARIANT_ID,
+    job,
+    level: g.level,
+    individualValue: g.individualValue ?? 64,
+    extraSkillIds,
+  }
+}

--- a/tools/studio/src/lib/goblinMapper.ts
+++ b/tools/studio/src/lib/goblinMapper.ts
@@ -65,6 +65,62 @@ export interface BackupExtract {
   rawBackup: BackupDocument
 }
 
+export interface CharacterLibraryMeta {
+  importedAt: string
+  sourceExportedAt?: string
+}
+
+export interface CharacterLibrary {
+  goblins: BackupGoblin[]
+  equipment: BackupEquipment[]
+  parties: BackupParty[]
+  meta: CharacterLibraryMeta | null
+}
+
+export interface CharacterLibraryView extends CharacterLibrary {
+  equipmentByGoblin: Map<number, BackupEquipment[]>
+}
+
+export const EMPTY_LIBRARY: CharacterLibrary = {
+  goblins: [],
+  equipment: [],
+  parties: [],
+  meta: null,
+}
+
+export function buildLibraryView(library: CharacterLibrary): CharacterLibraryView {
+  const equipmentByGoblin = new Map<number, BackupEquipment[]>()
+  for (const eq of library.equipment) {
+    if (eq.goblinId === null) continue
+    const list = equipmentByGoblin.get(eq.goblinId) ?? []
+    list.push(eq)
+    equipmentByGoblin.set(eq.goblinId, list)
+  }
+  return { ...library, equipmentByGoblin }
+}
+
+export function backupToLibrary(extract: BackupExtract): CharacterLibrary {
+  return {
+    goblins: extract.goblins,
+    equipment: extract.equipmentAll,
+    parties: extract.parties,
+    meta: {
+      importedAt: new Date().toISOString(),
+      sourceExportedAt: extract.rawBackup.meta.exportedAt,
+    },
+  }
+}
+
+export function isCharacterLibraryShape(value: unknown): value is CharacterLibrary {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    Array.isArray(record.goblins) &&
+    Array.isArray(record.equipment) &&
+    Array.isArray(record.parties)
+  )
+}
+
 export function extractBackup(doc: BackupDocument): BackupExtract {
   const goblinRows = doc.tables.goblins ?? []
   const equipmentRows = doc.tables.equipment ?? []

--- a/tools/studio/src/lib/runExpedition.ts
+++ b/tools/studio/src/lib/runExpedition.ts
@@ -188,6 +188,40 @@ export async function runSimulationBatch(
   }
 }
 
+export interface SingleRunOptions {
+  areaId: string
+  party: BackupGoblin[]
+  tier?: DungeonTier
+  returnPolicy: ReturnPolicy
+  seed?: number
+}
+
+export interface SingleRunResult {
+  options: SingleRunOptions
+  seed: number
+  replay: ExpeditionReplay
+  party: Goblin[]
+}
+
+export async function runSingleExpedition(
+  opts: SingleRunOptions,
+): Promise<SingleRunResult> {
+  const { areaId, party, tier, returnPolicy, seed } = opts
+  const trialSeed =
+    seed !== undefined ? seed : Math.floor(Math.random() * 0x7fffffff)
+  const goblinParty = party.map(backupGoblinToGoblin)
+  const baseRequest: ExpeditionRequest = {
+    partyId: 'studio',
+    areaId,
+    tier,
+    returnPolicy,
+    clientVersion: 'studio',
+  }
+  const engine = new ExpeditionEngine(trialSeed)
+  const replay = await engine.generateExpedition(baseRequest, goblinParty)
+  return { options: opts, seed: trialSeed, replay, party: goblinParty }
+}
+
 export const RETURN_POLICIES: { value: ReturnPolicy; label: string }[] = [
   { value: 'never', label: '帰還しない（到達階まで進む）' },
   { value: 'until_floor2', label: '2F到達で帰還' },

--- a/tools/studio/src/pages/PartyPage.tsx
+++ b/tools/studio/src/pages/PartyPage.tsx
@@ -1,48 +1,104 @@
+import { useState } from 'react'
+
 import { usePartyStore } from '../stores/partyStore'
 import { BackupDropzone } from '../components/BackupDropzone'
 import { BackupPartyList } from '../components/BackupPartyList'
+import { CharacterEditor } from '../components/CharacterEditor'
 import { GoblinBrowser } from '../components/GoblinBrowser'
 import { PartyEditor } from '../components/PartyEditor'
 import { PresetList } from '../components/PresetList'
 
 export function PartyPage() {
-  const { backup, backupError, clearBackup } = usePartyStore()
+  const {
+    library,
+    libraryLoading,
+    libraryError,
+    importBackupError,
+    clearLibrary,
+    upsertCharacter,
+    removeCharacter,
+  } = usePartyStore()
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+
+  const hasCharacters = library.goblins.length > 0
+  const openCreate = () => {
+    setEditingId(null)
+    setEditorOpen(true)
+  }
+  const openEdit = (id: number) => {
+    setEditingId(id)
+    setEditorOpen(true)
+  }
 
   return (
     <div className="party-layout">
       <div className="party-main">
-        {backup ? (
-          <>
-            <div className="filters">
-              <span className="subtle">
-                バックアップ読み込み済み：ゴブリン {backup.goblins.length} 体 /
-                PT {backup.parties.length} 件 /
-                装備 {backup.equipmentAll.length} 個
-                {backup.rawBackup.meta.exportedAt
-                  ? `（${backup.rawBackup.meta.exportedAt.slice(0, 10)} 出力）`
-                  : ''}
-              </span>
-              <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.4rem' }}>
-                <BackupDropzone compact />
-                <button className="btn ghost" onClick={clearBackup}>
-                  アンロード
-                </button>
-              </div>
-            </div>
-            {backupError && <p className="save-error">{backupError}</p>}
-            <GoblinBrowser />
-          </>
-        ) : (
+        {libraryLoading ? (
           <section className="card">
-            <h2>バックアップ JSON を読み込む</h2>
-            <p className="subtle">
-              実ゲームのセーブデータ（バックアップ JSON）からゴブリンを読み込んで
-              シミュレーション用 PT を編成します。バックアップはブラウザ内のメモリにのみ保持され、
-              ファイルや外部への送信は行いません。
-            </p>
-            <BackupDropzone />
-            {backupError && <p className="save-error">{backupError}</p>}
+            <p className="subtle">キャラクター情報を読み込み中…</p>
           </section>
+        ) : (
+          <>
+            {hasCharacters ? (
+              <>
+                <div className="filters">
+                  <span className="subtle">
+                    ローカル保存済み：ゴブリン {library.goblins.length} 体 /
+                    PT {library.parties.length} 件 /
+                    装備 {library.equipment.length} 個
+                    {library.meta?.sourceExportedAt
+                      ? `（${library.meta.sourceExportedAt.slice(0, 10)} 出力）`
+                      : library.meta?.importedAt
+                      ? `（${library.meta.importedAt.slice(0, 10)} 取込）`
+                      : ''}
+                  </span>
+                  <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.4rem' }}>
+                    <button className="btn primary" onClick={openCreate}>
+                      + 新規キャラ作成
+                    </button>
+                    <BackupDropzone compact />
+                    <button
+                      className="btn ghost"
+                      onClick={() => {
+                        if (
+                          window.confirm(
+                            'ローカル保存しているキャラクター情報を削除しますか？（プリセットは残ります）',
+                          )
+                        ) {
+                          void clearLibrary()
+                        }
+                      }}
+                    >
+                      ローカル削除
+                    </button>
+                  </div>
+                </div>
+                {libraryError && <p className="save-error">{libraryError}</p>}
+                {importBackupError && <p className="save-error">{importBackupError}</p>}
+                <GoblinBrowser onEditGoblin={openEdit} />
+              </>
+            ) : (
+              <section className="card">
+                <h2>キャラクターを準備する</h2>
+                <p className="subtle">
+                  1からキャラクターを定義するか、ゲーム本体のバックアップ JSON を取り込みます。
+                  どちらの場合もキャラクター情報は <code>tools/studio/data/character-library.json</code>{' '}
+                  にローカル保存され、以降はバックアップ無しで PT 編成・シミュレーションを利用できます。
+                </p>
+                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <button className="btn primary" onClick={openCreate}>
+                    + 新規キャラ作成
+                  </button>
+                </div>
+                <div style={{ marginTop: '1rem' }}>
+                  <BackupDropzone />
+                </div>
+                {libraryError && <p className="save-error">{libraryError}</p>}
+                {importBackupError && <p className="save-error">{importBackupError}</p>}
+              </section>
+            )}
+          </>
         )}
       </div>
       <aside className="party-side">
@@ -50,6 +106,14 @@ export function PartyPage() {
         <BackupPartyList />
         <PresetList />
       </aside>
+      <CharacterEditor
+        open={editorOpen}
+        editingId={editingId}
+        existingGoblins={library.goblins}
+        onClose={() => setEditorOpen(false)}
+        onSubmit={(g) => upsertCharacter(g)}
+        onDelete={(id) => removeCharacter(id)}
+      />
     </div>
   )
 }

--- a/tools/studio/src/pages/SimulatePage.tsx
+++ b/tools/studio/src/pages/SimulatePage.tsx
@@ -5,19 +5,24 @@ import type { DungeonSummary } from '../lib/schema'
 import {
   RETURN_POLICIES,
   runSimulationBatch,
+  runSingleExpedition,
   type ReturnPolicy,
   type SimulationResult,
+  type SingleRunResult,
 } from '../lib/runExpedition'
 import type { BackupGoblin } from '../lib/goblinMapper'
 import { usePartyStore } from '../stores/partyStore'
 import { SimulationResultView } from '../components/SimulationResultView'
+import { ExpeditionReplayView } from '../components/ExpeditionReplayView'
 
-type PartySource = 'draft' | `preset:${string}` | `backup:${number}`
+type PartySource = 'draft' | `preset:${string}` | `library:${number}`
+type RunMode = 'batch' | 'single'
 
 const TRIAL_OPTIONS = [50, 200, 500, 1000, 3000]
 
 export function SimulatePage() {
-  const { backup, draft, presets } = usePartyStore()
+  const { library, draft, presets } = usePartyStore()
+  const hasCharacters = library.goblins.length > 0
 
   const [dungeons, setDungeons] = useState<DungeonSummary[]>([])
   const [dungeonsError, setDungeonsError] = useState<string | null>(null)
@@ -28,9 +33,11 @@ export function SimulatePage() {
   const [seedMode, setSeedMode] = useState<'random' | 'fixed'>('random')
   const [fixedSeed, setFixedSeed] = useState<number>(1)
   const [partySource, setPartySource] = useState<PartySource>('draft')
+  const [runMode, setRunMode] = useState<RunMode>('batch')
   const [running, setRunning] = useState(false)
   const [progress, setProgress] = useState<{ completed: number; total: number } | null>(null)
   const [result, setResult] = useState<SimulationResult | null>(null)
+  const [singleResult, setSingleResult] = useState<SingleRunResult | null>(null)
   const [runError, setRunError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -56,7 +63,6 @@ export function SimulatePage() {
   }, [])
 
   const resolvedParty = useMemo<BackupGoblin[]>(() => {
-    if (!backup) return []
     let ids: number[] = []
     if (partySource === 'draft') {
       ids = draft.members.filter((m): m is number => m !== null)
@@ -64,53 +70,75 @@ export function SimulatePage() {
       ids =
         presets.find((p) => p.id === partySource.slice('preset:'.length))
           ?.memberIds ?? []
-    } else if (partySource.startsWith('backup:')) {
-      const partyId = Number(partySource.slice('backup:'.length))
-      ids = backup.parties.find((p) => p.id === partyId)?.memberIds ?? []
+    } else if (partySource.startsWith('library:')) {
+      const partyId = Number(partySource.slice('library:'.length))
+      ids = library.parties.find((p) => p.id === partyId)?.memberIds ?? []
     }
     return ids
-      .map((id) => backup.goblins.find((g) => g.id === id))
+      .map((id) => library.goblins.find((g) => g.id === id))
       .filter((g): g is BackupGoblin => g !== undefined)
-  }, [backup, draft, presets, partySource])
+  }, [library, draft, presets, partySource])
 
   const canRun =
     !running &&
     areaId !== '' &&
     resolvedParty.length > 0 &&
-    trials > 0 &&
-    backup !== null
+    (runMode === 'single' || trials > 0) &&
+    hasCharacters
 
   const runSimulation = useCallback(async () => {
     setRunning(true)
     setResult(null)
+    setSingleResult(null)
     setRunError(null)
-    setProgress({ completed: 0, total: trials })
     try {
-      const res = await runSimulationBatch({
-        areaId,
-        party: resolvedParty,
-        trials,
-        tier: tier as never,
-        returnPolicy,
-        seed: seedMode === 'fixed' ? fixedSeed : undefined,
-        onProgress: (completed, total) => setProgress({ completed, total }),
-      })
-      setResult(res)
+      if (runMode === 'single') {
+        const single = await runSingleExpedition({
+          areaId,
+          party: resolvedParty,
+          tier: tier as never,
+          returnPolicy,
+          seed: seedMode === 'fixed' ? fixedSeed : undefined,
+        })
+        setSingleResult(single)
+      } else {
+        setProgress({ completed: 0, total: trials })
+        const res = await runSimulationBatch({
+          areaId,
+          party: resolvedParty,
+          trials,
+          tier: tier as never,
+          returnPolicy,
+          seed: seedMode === 'fixed' ? fixedSeed : undefined,
+          onProgress: (completed, total) => setProgress({ completed, total }),
+        })
+        setResult(res)
+      }
     } catch (err) {
       setRunError(err instanceof Error ? err.message : String(err))
     } finally {
       setRunning(false)
     }
-  }, [areaId, resolvedParty, trials, tier, returnPolicy, seedMode, fixedSeed])
+  }, [
+    runMode,
+    areaId,
+    resolvedParty,
+    trials,
+    tier,
+    returnPolicy,
+    seedMode,
+    fixedSeed,
+  ])
 
-  if (!backup) {
+  if (!hasCharacters) {
     return (
       <div className="panel-stack">
         <section className="card">
           <h2>シミュレーション</h2>
           <p className="subtle">
-            シミュレーションには PT を編成する必要があります。まず{' '}
-            <Link to="/party">PT編成</Link> 画面でバックアップを読み込んでください。
+            シミュレーションにはキャラクター情報が必要です。まず{' '}
+            <Link to="/party">PT編成</Link> 画面でバックアップ JSON を取り込んでください。
+            一度取り込めばローカルに保存され、以降はバックアップ無しで利用できます。
           </p>
         </section>
       </div>
@@ -162,11 +190,25 @@ export function SimulatePage() {
             </span>
           </label>
           <label className="field">
+            <span className="field-label">実行モード</span>
+            <span className="field-input">
+              <select
+                value={runMode}
+                onChange={(e) => setRunMode(e.target.value as RunMode)}
+              >
+                <option value="batch">バッチ（統計を取る）</option>
+                <option value="single">単発（戦闘ログを見る）</option>
+              </select>
+            </span>
+          </label>
+          <label className="field">
             <span className="field-label">試行回数</span>
             <span className="field-input">
               <select
                 value={trials}
                 onChange={(e) => setTrials(Number(e.target.value))}
+                disabled={runMode === 'single'}
+                title={runMode === 'single' ? '単発モードでは1回固定です' : undefined}
               >
                 {TRIAL_OPTIONS.map((n) => (
                   <option key={n} value={n}>
@@ -206,9 +248,9 @@ export function SimulatePage() {
                 <option value="draft">
                   編集中のPT（{draft.members.filter((m) => m !== null).length}体）
                 </option>
-                {backup.parties.map((p) => (
-                  <option key={`backup-${p.id}`} value={`backup:${p.id}`}>
-                    [バックアップ] {p.name}（{p.memberIds.length}体）
+                {library.parties.map((p) => (
+                  <option key={`library-${p.id}`} value={`library:${p.id}`}>
+                    [取込PT] {p.name}（{p.memberIds.length}体）
                   </option>
                 ))}
                 {presets.map((p) => (
@@ -224,22 +266,30 @@ export function SimulatePage() {
         {dungeonsError && <p className="save-error">{dungeonsError}</p>}
         {runError && <p className="save-error">{runError}</p>}
         <div className="simulate-actions">
-          {running && progress && (
+          {running && runMode === 'batch' && progress && (
             <span className="subtle">
               実行中… {progress.completed} / {progress.total}
             </span>
+          )}
+          {running && runMode === 'single' && (
+            <span className="subtle">実行中…</span>
           )}
           <button
             className="btn primary"
             onClick={runSimulation}
             disabled={!canRun}
           >
-            {running ? '実行中…' : 'シミュレーション実行'}
+            {running
+              ? '実行中…'
+              : runMode === 'single'
+              ? '単発実行（ログ取得）'
+              : 'シミュレーション実行'}
           </button>
         </div>
       </section>
 
       {result && <SimulationResultView result={result} />}
+      {singleResult && <ExpeditionReplayView result={singleResult} />}
     </div>
   )
 }

--- a/tools/studio/src/stores/partyStore.tsx
+++ b/tools/studio/src/stores/partyStore.tsx
@@ -10,11 +10,21 @@ import {
 } from 'react'
 
 import { parseBackupFile } from '../lib/backup'
-import type { BackupExtract, BackupGoblin, BackupParty } from '../lib/goblinMapper'
-import { extractBackup } from '../lib/goblinMapper'
+import {
+  EMPTY_LIBRARY,
+  backupToLibrary,
+  buildLibraryView,
+  extractBackup,
+  isCharacterLibraryShape,
+  type BackupGoblin,
+  type BackupParty,
+  type CharacterLibrary,
+  type CharacterLibraryView,
+} from '../lib/goblinMapper'
 
 export const MAX_PARTY_MEMBERS = 6
 const PRESET_API_URL = '/api/party-presets'
+const LIBRARY_API_URL = '/api/character-library'
 const LEGACY_STORAGE_KEY = 'goblin-studio:party-presets:v1'
 
 export interface PartyPreset {
@@ -31,11 +41,13 @@ export interface PartyDraft {
 }
 
 interface PartyStoreValue {
-  backup: BackupExtract | null
-  backupError: string | null
-  backupLoading: boolean
-  loadBackup: (file: File) => Promise<void>
-  clearBackup: () => void
+  library: CharacterLibraryView
+  libraryLoading: boolean
+  libraryError: string | null
+  importBackup: (file: File) => Promise<void>
+  importBackupBusy: boolean
+  importBackupError: string | null
+  clearLibrary: () => Promise<void>
 
   draft: PartyDraft
   setDraftName: (name: string) => void
@@ -44,8 +56,11 @@ interface PartyStoreValue {
   removeMember: (index: number) => void
   clearDraft: () => void
 
-  loadBackupParty: (partyId: number) => void
-  importBackupPartyAsPreset: (partyId: number) => PartyPreset | null
+  loadLibraryParty: (partyId: number) => void
+  importLibraryPartyAsPreset: (partyId: number) => PartyPreset | null
+
+  upsertCharacter: (goblin: BackupGoblin) => Promise<void>
+  removeCharacter: (id: number) => Promise<void>
 
   presets: PartyPreset[]
   presetsLoading: boolean
@@ -65,14 +80,36 @@ const EMPTY_DRAFT: PartyDraft = {
 }
 
 export function PartyStoreProvider({ children }: { children: ReactNode }) {
-  const [backup, setBackup] = useState<BackupExtract | null>(null)
-  const [backupError, setBackupError] = useState<string | null>(null)
-  const [backupLoading, setBackupLoading] = useState(false)
+  const [library, setLibrary] = useState<CharacterLibrary>(EMPTY_LIBRARY)
+  const [libraryLoading, setLibraryLoading] = useState(true)
+  const [libraryError, setLibraryError] = useState<string | null>(null)
+  const [importBackupBusy, setImportBackupBusy] = useState(false)
+  const [importBackupError, setImportBackupError] = useState<string | null>(null)
   const [draft, setDraft] = useState<PartyDraft>(EMPTY_DRAFT)
   const [presets, setPresets] = useState<PartyPreset[]>([])
   const [presetsLoading, setPresetsLoading] = useState(true)
   const [presetsError, setPresetsError] = useState<string | null>(null)
-  const hasLoadedRef = useRef(false)
+  const presetsLoadedRef = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const fromServer = await fetchLibrary()
+        if (cancelled) return
+        setLibrary(fromServer)
+      } catch (err) {
+        if (!cancelled) {
+          setLibraryError(err instanceof Error ? err.message : String(err))
+        }
+      } finally {
+        if (!cancelled) setLibraryLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -82,7 +119,6 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
         if (cancelled) return
         const legacy = consumeLegacyLocalStorage()
         if (legacy.length > 0 && fromServer.length === 0) {
-          // 初回移行: localStorage のプリセットをファイルに昇格
           await persistPresets(legacy)
           setPresets(legacy)
         } else {
@@ -95,7 +131,7 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
       } finally {
         if (!cancelled) {
           setPresetsLoading(false)
-          hasLoadedRef.current = true
+          presetsLoadedRef.current = true
         }
       }
     })()
@@ -105,7 +141,7 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
   }, [])
 
   useEffect(() => {
-    if (!hasLoadedRef.current) return
+    if (!presetsLoadedRef.current) return
     let cancelled = false
     ;(async () => {
       try {
@@ -122,24 +158,33 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
     }
   }, [presets])
 
-  const loadBackup = useCallback(async (file: File) => {
-    setBackupLoading(true)
-    setBackupError(null)
+  const libraryView = useMemo(() => buildLibraryView(library), [library])
+
+  const importBackup = useCallback(async (file: File) => {
+    setImportBackupBusy(true)
+    setImportBackupError(null)
     try {
       const doc = await parseBackupFile(file)
       const extract = extractBackup(doc)
-      setBackup(extract)
+      const next = backupToLibrary(extract)
+      await persistLibrary(next)
+      setLibrary(next)
+      setLibraryError(null)
     } catch (err) {
-      setBackupError(err instanceof Error ? err.message : String(err))
-      setBackup(null)
+      setImportBackupError(err instanceof Error ? err.message : String(err))
     } finally {
-      setBackupLoading(false)
+      setImportBackupBusy(false)
     }
   }, [])
 
-  const clearBackup = useCallback(() => {
-    setBackup(null)
-    setBackupError(null)
+  const clearLibrary = useCallback(async () => {
+    try {
+      await deleteLibrary()
+      setLibrary(EMPTY_LIBRARY)
+      setLibraryError(null)
+    } catch (err) {
+      setLibraryError(err instanceof Error ? err.message : String(err))
+    }
   }, [])
 
   const setDraftName = useCallback((name: string) => {
@@ -182,10 +227,10 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
     setDraft({ ...EMPTY_DRAFT, members: EMPTY_DRAFT.members.slice() })
   }, [])
 
-  const loadBackupParty = useCallback((partyId: number) => {
-    setBackup((current) => {
-      const party = current?.parties.find((p) => p.id === partyId)
-      if (!party) return current
+  const loadLibraryParty = useCallback(
+    (partyId: number) => {
+      const party = library.parties.find((p) => p.id === partyId)
+      if (!party) return
       setDraft({
         name: party.name,
         members: Array.from(
@@ -193,17 +238,65 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
           (_, i) => party.memberIds[i] ?? null,
         ),
       })
-      return current
+    },
+    [library],
+  )
+
+  const upsertCharacter = useCallback(async (goblin: BackupGoblin) => {
+    let next: CharacterLibrary | null = null
+    setLibrary((prev) => {
+      const existingIndex = prev.goblins.findIndex((g) => g.id === goblin.id)
+      const goblins =
+        existingIndex >= 0
+          ? prev.goblins.map((g, i) => (i === existingIndex ? goblin : g))
+          : [...prev.goblins, goblin]
+      const meta = prev.meta ?? { importedAt: new Date().toISOString() }
+      next = { ...prev, goblins, meta }
+      return next
     })
+    if (next) {
+      try {
+        await persistLibrary(next)
+        setLibraryError(null)
+      } catch (err) {
+        setLibraryError(err instanceof Error ? err.message : String(err))
+      }
+    }
   }, [])
 
-  const importBackupPartyAsPreset = useCallback(
+  const removeCharacter = useCallback(async (id: number) => {
+    let next: CharacterLibrary | null = null
+    setLibrary((prev) => {
+      const goblins = prev.goblins.filter((g) => g.id !== id)
+      const equipment = prev.equipment.filter((e) => e.goblinId !== id)
+      const parties = prev.parties.map((p) => ({
+        ...p,
+        memberIds: p.memberIds.filter((mid) => mid !== id),
+      }))
+      next = { ...prev, goblins, equipment, parties }
+      return next
+    })
+    setDraft((prev) => ({
+      ...prev,
+      members: prev.members.map((m) => (m === id ? null : m)),
+    }))
+    if (next) {
+      try {
+        await persistLibrary(next)
+        setLibraryError(null)
+      } catch (err) {
+        setLibraryError(err instanceof Error ? err.message : String(err))
+      }
+    }
+  }, [])
+
+  const importLibraryPartyAsPreset = useCallback(
     (partyId: number): PartyPreset | null => {
-      const party = backup?.parties.find((p) => p.id === partyId)
+      const party = library.parties.find((p) => p.id === partyId)
       if (!party) return null
       const now = new Date().toISOString()
       const preset: PartyPreset = {
-        id: `preset_backup_${party.id}_${Date.now()}`,
+        id: `preset_library_${party.id}_${Date.now()}`,
         name: party.name,
         memberIds: party.memberIds.slice(),
         createdAt: now,
@@ -212,7 +305,7 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
       setPresets((prev) => [preset, ...prev])
       return preset
     },
-    [backup],
+    [library],
   )
 
   const savePreset = useCallback((): PartyPreset | null => {
@@ -278,19 +371,23 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<PartyStoreValue>(
     () => ({
-      backup,
-      backupError,
-      backupLoading,
-      loadBackup,
-      clearBackup,
+      library: libraryView,
+      libraryLoading,
+      libraryError,
+      importBackup,
+      importBackupBusy,
+      importBackupError,
+      clearLibrary,
       draft,
       setDraftName,
       setMemberAt,
       addMember,
       removeMember,
       clearDraft,
-      loadBackupParty,
-      importBackupPartyAsPreset,
+      loadLibraryParty,
+      importLibraryPartyAsPreset,
+      upsertCharacter,
+      removeCharacter,
       presets,
       presetsLoading,
       presetsError,
@@ -301,19 +398,23 @@ export function PartyStoreProvider({ children }: { children: ReactNode }) {
       renamePreset,
     }),
     [
-      backup,
-      backupError,
-      backupLoading,
-      loadBackup,
-      clearBackup,
+      libraryView,
+      libraryLoading,
+      libraryError,
+      importBackup,
+      importBackupBusy,
+      importBackupError,
+      clearLibrary,
       draft,
       setDraftName,
       setMemberAt,
       addMember,
       removeMember,
       clearDraft,
-      loadBackupParty,
-      importBackupPartyAsPreset,
+      loadLibraryParty,
+      importLibraryPartyAsPreset,
+      upsertCharacter,
+      removeCharacter,
       presets,
       presetsLoading,
       presetsError,
@@ -335,14 +436,47 @@ export function usePartyStore(): PartyStoreValue {
 }
 
 export function useGoblinById(id: number | null | undefined): BackupGoblin | null {
-  const { backup } = usePartyStore()
+  const { library } = usePartyStore()
   return useMemo(() => {
-    if (!backup || id === null || id === undefined) return null
-    return backup.goblins.find((g) => g.id === id) ?? null
-  }, [backup, id])
+    if (id === null || id === undefined) return null
+    return library.goblins.find((g) => g.id === id) ?? null
+  }, [library, id])
 }
 
 export type { BackupParty }
+
+async function fetchLibrary(): Promise<CharacterLibrary> {
+  const res = await fetch(LIBRARY_API_URL)
+  if (!res.ok) throw new Error(`キャラクター読み込み失敗: HTTP ${res.status}`)
+  const data = (await res.json()) as unknown
+  if (!isCharacterLibraryShape(data)) return EMPTY_LIBRARY
+  return {
+    goblins: data.goblins,
+    equipment: data.equipment,
+    parties: data.parties,
+    meta: (data as { meta?: CharacterLibrary['meta'] }).meta ?? null,
+  }
+}
+
+async function persistLibrary(library: CharacterLibrary): Promise<void> {
+  const res = await fetch(LIBRARY_API_URL, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(library),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error ?? `キャラクター保存失敗: HTTP ${res.status}`)
+  }
+}
+
+async function deleteLibrary(): Promise<void> {
+  const res = await fetch(LIBRARY_API_URL, { method: 'DELETE' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error ?? `キャラクター削除失敗: HTTP ${res.status}`)
+  }
+}
 
 async function fetchPresets(): Promise<PartyPreset[]> {
   const res = await fetch(PRESET_API_URL)

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -1551,3 +1551,282 @@ code {
   justify-content: flex-end;
   padding: 0.45rem 0.7rem;
 }
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 20, 20, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 4vh 1rem;
+  z-index: 50;
+}
+
+.modal-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  width: min(960px, 100%);
+  max-height: 92vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 1.2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-head h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-body {
+  padding: 1rem 1.2rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-foot {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.8rem 1.2rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.character-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.6rem 1rem;
+}
+
+.character-editor-section {
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--border);
+}
+
+.character-editor-section h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+}
+
+.character-editor-skill-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.4rem;
+}
+
+.character-editor-skill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.5rem;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-sunken);
+}
+
+.skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.75rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.skill-chip[disabled] {
+  cursor: default;
+  background: var(--surface-muted);
+  color: var(--text-sub);
+}
+
+.skill-chip.selected {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+
+.skill-chip.base {
+  background: var(--success-bg);
+  color: var(--success-fg);
+  border-color: var(--success-border);
+}
+
+.skill-chip.removable {
+  background: var(--surface-muted);
+}
+
+.character-editor-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.4rem 0.8rem;
+}
+
+.replay-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.replay-row {
+  display: flex;
+  flex-direction: column;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  font-size: 0.85rem;
+}
+
+.replay-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  cursor: pointer;
+}
+
+.replay-row.battle.win {
+  border-left: 3px solid #2e7d32;
+}
+.replay-row.battle.lose {
+  border-left: 3px solid #c62828;
+}
+.replay-row.battle.escape {
+  border-left: 3px solid #b58a00;
+}
+
+.replay-time {
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  color: var(--text-sub);
+  width: 4ch;
+  text-align: right;
+}
+
+.replay-tag {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.7rem;
+  background: var(--surface-muted);
+  color: var(--text-sub);
+  white-space: nowrap;
+}
+
+.replay-tag.battle {
+  background: var(--surface-sunken);
+  color: var(--text);
+}
+
+.replay-tag.boss {
+  background: var(--boss-bg);
+  color: var(--boss);
+  font-weight: 600;
+}
+
+.replay-tag.end {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.replay-battle-summary {
+  flex: 1;
+}
+
+.replay-battle-summary .outcome.win {
+  color: var(--success-fg);
+}
+.replay-battle-summary .outcome.lose {
+  color: var(--danger-fg);
+}
+.replay-battle-summary .outcome.escape {
+  color: var(--boss);
+}
+
+.replay-combat-log {
+  margin-top: 0.5rem;
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.replay-combat-table {
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.replay-combat-table tr.ally {
+  background: rgba(46, 125, 50, 0.04);
+}
+
+.replay-combat-table tr.enemy {
+  background: rgba(198, 40, 40, 0.04);
+}
+
+.replay-combat-table tr.turn-start td {
+  border-top: 2px solid var(--border-strong);
+}
+
+.replay-combat-table tr.critical td {
+  background: rgba(181, 138, 0, 0.12);
+}
+
+.replay-targets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.replay-targets .damage {
+  color: var(--danger-fg);
+}
+.replay-targets .heal {
+  color: var(--success-fg);
+}
+
+.replay-actor-row.r0 {
+  font-weight: 600;
+}
+
+.replay-combat-empty {
+  padding: 0.5rem;
+}
+
+.badge.danger {
+  display: inline-block;
+  padding: 0 0.3rem;
+  margin-left: 0.2rem;
+  font-size: 0.7rem;
+  border-radius: var(--radius-pill);
+  background: var(--danger-bg);
+  color: var(--danger-fg);
+  border: 1px solid var(--danger-border);
+}


### PR DESCRIPTION
## Summary

- `tools/studio` の PT プリセットをバックアップ無しで使えるよう、ゴブリン/装備/PT情報を `tools/studio/data/character-library.json` にローカル永続化（`/api/character-library` を追加）
- PT 編成画面に「新規キャラ作成」モーダルを追加し、亜種・ジョブ・Lv・個体値・追加スキルを自由に設定してキャラクターを定義可能に。ステータスは `syncGoblinDerivedStats` 等の共有ユーティリティで自動算出
- シミュレーションに「単発（戦闘ログを見る）」モードを追加し、タイムラインと各戦闘の `detailedLog` を折りたたみで閲覧できる ReplayView を実装

## 主な変更

- API: `tools/studio/src/api/dataPlugin.ts` に `/api/character-library` を追加
- ストア: `tools/studio/src/stores/partyStore.tsx` を library ベースに刷新（`upsertCharacter` / `removeCharacter` も追加）
- 新規UI: `CharacterEditor.tsx`（モーダル）/ `ExpeditionReplayView.tsx`（タイムライン+戦闘ログ）
- ロジック: `lib/customGoblin.ts`（亜種/ジョブ/スキル選択肢、`buildCustomGoblin` ファクトリ）
- 既存UI更新: `PartyPage` / `GoblinBrowser` / `BackupPartyList` / `BackupDropzone` / `SimulatePage`

## Test plan

- [ ] `npm install` 済みで `npm run dev` を起動し、`/party` を開く
- [ ] バックアップ未取込状態で「+ 新規キャラ作成」からゴブリンを作成→保存できる
- [ ] 純正ゴブリンでジョブ/Lv/個体値/追加スキルを変更し、ステータスプレビューが追従する
- [ ] 亜種ゴブリンを選ぶとジョブ欄が無効化される
- [ ] 既存キャラの「編集」「削除」が動作し、削除時にPT/プリセットからも外れる
- [ ] `tools/studio/data/character-library.json` に保存内容が出力される
- [ ] 取り込み後、ブラウザリロードでも一覧が維持される
- [ ] `/simulate` で実行モードを「単発」に切替→1回実行で `ExpeditionReplayView` が表示される
- [ ] battle/boss イベントで「ログを開く」を押すと、ターンごとの行動・ターゲット・ダメージ・残HPが見られる
- [ ] バッチモードに戻すと従来通り統計が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)