### PR TITLE
feat(skill): [10]回復能力スキル（固定値HP回復）を追加

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -18,6 +18,7 @@ import {
   hasRecoverRandomUsedSpellOnDefendSkill,
   hasSurviveLethalDamageAtHp1Skill,
   getHpRegenPercentFromSkills,
+  getHpRegenAmountFromSkills,
 } from '../../shared/data/characterSkills'
 import type { SpellDef } from '../../shared/types/Spell'
 import { CombatantManager } from './CombatantManager'
@@ -517,8 +518,8 @@ export class BattleSystem {
       for (const unit of [...allyUnits, ...enemyUnits]) {
         if (unit.currentHP <= 0) continue
         const regenPercent = getHpRegenPercentFromSkills(unit.skills)
-        if (regenPercent <= 0) continue
-        const regenAmount = Math.floor(unit.maxHP * regenPercent / 100)
+        const regenFlat = getHpRegenAmountFromSkills(unit.skills)
+        const regenAmount = Math.floor(unit.maxHP * regenPercent / 100) + regenFlat
         if (regenAmount <= 0) continue
         const before = unit.currentHP
         unit.currentHP = Math.min(unit.maxHP, unit.currentHP + regenAmount)

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -157,6 +157,10 @@ export function describeCharacterSkill(skill: CharacterSkill): string {
     return i18n.t('battle.hpRegen', { value: skill.hpRegenPercent })
   }
 
+  if (skill.hpRegenAmount !== undefined) {
+    return i18n.t('battle.hpRegenFlat', { value: skill.hpRegenAmount })
+  }
+
   if (skill.itemSlotsBonus) {
     return i18n.t('battle.itemSlotsBonus')
   }
@@ -439,6 +443,13 @@ export function hasItemSlotsBonusSkill(skills: CharacterSkill[]): boolean {
 export function getHpRegenPercentFromSkills(skills: CharacterSkill[]): number {
   return getUniqueSkillsById(skills).reduce(
     (sum, skill) => sum + (skill.hpRegenPercent ?? 0),
+    0,
+  )
+}
+
+export function getHpRegenAmountFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.hpRegenAmount ?? 0),
     0,
   )
 }

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -452,6 +452,11 @@ export const CHARACTER_SKILL_CATALOG = {
     hpRegenPercent: 20,
   },
 
+  hp_regen_flat_10: {
+    id: 'hp_regen_flat_10',
+    hpRegenAmount: 10,
+  },
+
   recovery_magic_lv1: createRecoveryMagicSkill(1),
   recovery_magic_lv2: createRecoveryMagicSkill(2),
   recovery_magic_lv3: createRecoveryMagicSkill(3),

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -660,6 +660,7 @@ const ja = {
       blizzard_taken_2_0: { name: '[2.0倍]ブリザード被ダメージ' },
       undead_trait: { name: 'アンデッド' },
       hp_regen_20: { name: '[20%]回復能力' },
+      hp_regen_flat_10: { name: '[10]回復能力' },
       weapon_melee_attack: {
         name: '[武器]近距離攻撃',
         description: '隊列の後ろに行くほど通常攻撃のダメージが低下します。',
@@ -736,6 +737,7 @@ const ja = {
     goldBonus: '[+{{value}}%]取得Gold（PT内1つのみ有効）',
     undead: '遠征終了時にHP0でも治療不要で全回復する',
     hpRegen: '[{{value}}%]毎ターン終了時に最大HPの{{value}}%を回復',
+    hpRegenFlat: '[{{value}}]毎ターン終了時にHPを{{value}}回復',
     hpRegenAction: '回復能力',
     itemSlotsBonus: 'アイテム装備可能数が増加する',
   },

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -46,6 +46,7 @@ export interface CharacterSkill {
   spellTakenMultipliers?: Partial<Record<string, number>>
   undead?: boolean
   hpRegenPercent?: number
+  hpRegenAmount?: number
   itemSlotsBonus?: boolean
   recoveryMagicLevel?: number
   mageMagicLevel?: number


### PR DESCRIPTION
## Summary
- 毎ターン終了時に固定値10でHPを回復する `hp_regen_flat_10`（[10]回復能力）スキルを追加
- `CharacterSkill` に `hpRegenAmount` フィールドを新設し、取得ヘルパー `getHpRegenAmountFromSkills` を追加
- 既存の [20%]回復能力（`hp_regen_20`）と併用された場合は `floor(maxHP * % / 100) + flat` で加算

## 変更ファイル
- `src/shared/types/CharacterSkill.ts` — `hpRegenAmount?: number` フィールド追加
- `src/shared/data/characterSkills.ts` — describe 分岐とヘルパー追加
- `src/shared/data/skillCatalog.ts` — `hp_regen_flat_10` カタログエントリ追加
- `src/core/services/BattleSystem.ts` — ターン終了時の回復処理に固定値を加算
- `src/shared/i18n/resources/ja.ts` — スキル名と説明テンプレを追加

## Test plan
- [ ] `npx tsc --noEmit` が通ることを確認（ローカルで確認済み）
- [ ] 該当スキルを持つユニットがターン終了時に固定値10回復することを戦闘で確認
- [ ] [20%]回復能力 と併用したユニットで両方加算されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)