### PR TITLE
feat(drop): studioでのアイテム/レアドロップ編集と判定ロジック改修

### DIFF
--- a/goblin_native/app/goblin/equipment.tsx
+++ b/goblin_native/app/goblin/equipment.tsx
@@ -89,7 +89,7 @@ function getDisplaySkills(eq: EquipmentInstance) {
   return EquipmentService.collectGrantedSkills([eq])
 }
 
-/** カテゴリ→定義順→称号レア度（低→高）でソート */
+/** カテゴリ→ノーマル→レア→定義順→称号レア度（低→高）でソート */
 function sortEquipment(items: EquipmentInstance[]): EquipmentInstance[] {
   const allTemplates = getEquipmentTemplates()
   const templateOrder = new Map(allTemplates.map((t, i) => [t.id, i]))
@@ -100,6 +100,8 @@ function sortEquipment(items: EquipmentInstance[]): EquipmentInstance[] {
     if (!tA || !tB) return 0
     const catDiff = CATEGORY_ORDER[tA.category] - CATEGORY_ORDER[tB.category]
     if (catDiff !== 0) return catDiff
+    const rareDiff = (tA.isRare ? 1 : 0) - (tB.isRare ? 1 : 0)
+    if (rareDiff !== 0) return rareDiff
     const orderA = templateOrder.get(a.templateId) ?? 0
     const orderB = templateOrder.get(b.templateId) ?? 0
     if (orderA !== orderB) return orderA - orderB

--- a/goblin_native/docs/drop_system.md
+++ b/goblin_native/docs/drop_system.md
@@ -224,7 +224,6 @@ droppedTemplateIds: Set<string> で遠征全体を通じて追跡
 ```typescript
 interface EquipmentDropConfig {
   templateId: string   // EquipmentTemplate.id
-  probability: number  // 0.0〜1.0（候補内の重み付けに利用）
 }
 ```
 
@@ -238,10 +237,10 @@ rareThreshold    = 100 - effectiveRare * 0.1
 当選条件: rareThreshold < luckRoll
 ```
 
-- 敵1体ごとに `luckRoll` を振り直す（ノーマルドロップとは別の抽選）。
+- 敵の `rareEquipmentDrops` の **アイテム1つごとに** `luckRoll` を振り直す（ノーマルドロップとも別の抽選）。
 - `rare` はPT倍率の `rare`、`rareDropMultiplierBoost` は `ExpeditionBoost.rareDropMultiplier`。
 - ノーマルドロップが `rare * 10` であるのに対し、レアドロップは `rare * 0.1` と影響が桁違いに小さい。レアの上振れには PT倍率の積み上げと boost 倍率の併用が必要。
-- 当選時は敵の `rareEquipmentDrops` から `probability` を重みとした加重抽選で 1 点選出する。
+- 当選したアイテムをそれぞれドロップに追加する（同じ敵から複数種ドロップ可能）。重複防止により遠征中に同じ `templateId` は 1 個まで。
 
 ### ExpeditionBoost.rareDropMultiplier
 
@@ -257,9 +256,9 @@ interface ExpeditionBoost {
 
 ### 現在の使用状況
 
-| エリア | 敵ID | 名前 | レアドロップ | 確率重み |
-|-------|------|------|------------|---------:|
-| スライムの洞窟 | S001 | スライム | `accessory_split_core`（分裂核 / `[10]回復能力` 付与） | 1 |
+| エリア | 敵ID | 名前 | レアドロップ |
+|-------|------|------|------------|
+| スライムの洞窟 | S001 | スライム | `accessory_split_core`（分裂核 / `[10]回復能力` 付与） |
 
 ※ 分裂核は `equipmentPool.json` のアクセサリ枠（rank 未設定 / 価格 0 / 称号は通常通り抽選）に追加されている。
 

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -652,9 +652,9 @@ export class ExpeditionEngine {
    *
    * レアドロップ:
    *  - 敵に `rareEquipmentDrops` が設定されているときのみ判定する。
-   *  - 敵1体ごとに `100 - effectiveRare * 0.1 < 運乱数` で当落判定。
+   *  - rareEquipmentDrops の **アイテム1つごとに** `100 - effectiveRare * 0.1 < 運乱数` で当落判定。
    *  - effectiveRare = `rare * rareDropMultiplierBoost`（boost は課金アイテム等で 2 倍化）。
-   *  - 当選時はその敵の `rareEquipmentDrops` から1点を確率重みで抽選する。
+   *  - 当選したアイテムをそれぞれドロップに追加する（同じ敵から複数種ドロップ可能）。
    *
    * 共通:
    *  - 運乱数は PT平均運値から `rollLuckValue` で算出する（敵ごとに振り直し）。
@@ -699,41 +699,27 @@ export class ExpeditionEngine {
       pendingDroppedIds.add(selected.id)
     }
 
-    // レアドロップ判定（敵1体ごとに、敵固有の rareEquipmentDrops から1点）
+    // レアドロップ判定（rareEquipmentDrops のアイテム1つごとに当落判定）
     for (const enemy of enemies) {
       if (!enemy.rareEquipmentDrops || enemy.rareEquipmentDrops.length === 0) continue
 
-      const luckRoll = rollLuckValue(partyLuckAverage, this.rng)
-      if (!(rareThreshold < luckRoll)) continue
+      for (const drop of enemy.rareEquipmentDrops) {
+        if (
+          expeditionDroppedIds.has(drop.templateId) ||
+          pendingDroppedIds.has(drop.templateId) ||
+          getEquipmentTemplate(drop.templateId) === undefined
+        ) continue
 
-      const rareCandidates = enemy.rareEquipmentDrops.filter(
-        (drop) =>
-          !expeditionDroppedIds.has(drop.templateId) &&
-          !pendingDroppedIds.has(drop.templateId) &&
-          getEquipmentTemplate(drop.templateId) !== undefined
-      )
-      if (rareCandidates.length === 0) continue
+        const luckRoll = rollLuckValue(partyLuckAverage, this.rng)
+        if (!(rareThreshold < luckRoll)) continue
 
-      const totalWeight = rareCandidates.reduce((sum, drop) => sum + Math.max(0, drop.probability), 0)
-      if (totalWeight <= 0) continue
-
-      let pick = this.rng() * totalWeight
-      let selectedDrop = rareCandidates[rareCandidates.length - 1]
-      for (const drop of rareCandidates) {
-        const weight = Math.max(0, drop.probability)
-        if (pick < weight) {
-          selectedDrop = drop
-          break
-        }
-        pick -= weight
+        const title = EquipmentTitleService.rollTitle(titleMultiplier, this.rng)
+        drops.push({
+          templateId: drop.templateId,
+          titleId: title.titleId !== 'none' ? title.titleId : undefined,
+        })
+        pendingDroppedIds.add(drop.templateId)
       }
-
-      const title = EquipmentTitleService.rollTitle(titleMultiplier, this.rng)
-      drops.push({
-        templateId: selectedDrop.templateId,
-        titleId: title.titleId !== 'none' ? title.titleId : undefined,
-      })
-      pendingDroppedIds.add(selectedDrop.templateId)
     }
 
     for (const templateId of pendingDroppedIds) {

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -443,7 +443,7 @@ describe('rollTreasureDrops', () => {
 
     it('rareEquipmentDrops が設定された敵からレアドロップが発生する', () => {
       const enemy = createDummyEnemy({
-        rareEquipmentDrops: [{ templateId: 'sword_royal', probability: 1.0 }],
+        rareEquipmentDrops: [{ templateId: 'sword_royal' }],
       })
 
       let found = false
@@ -463,7 +463,7 @@ describe('rollTreasureDrops', () => {
       // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank5) はノーマルでは出ない
       const enemy = createDummyEnemy({
         level: 1,
-        rareEquipmentDrops: [{ templateId: 'sword_kaiser', probability: 1.0 }],
+        rareEquipmentDrops: [{ templateId: 'sword_kaiser' }],
       })
 
       let rareDrops = 0
@@ -481,7 +481,7 @@ describe('rollTreasureDrops', () => {
       // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank5) はノーマルでは出ない
       const enemy = createDummyEnemy({
         level: 1,
-        rareEquipmentDrops: [{ templateId: 'sword_kaiser', probability: 1.0 }],
+        rareEquipmentDrops: [{ templateId: 'sword_kaiser' }],
       })
 
       const iterations = 2000
@@ -511,7 +511,7 @@ describe('rollTreasureDrops', () => {
 
     it('レアドロップにも称号が付与される', () => {
       const enemy = createDummyEnemy({
-        rareEquipmentDrops: [{ templateId: 'sword_royal', probability: 1.0 }],
+        rareEquipmentDrops: [{ templateId: 'sword_royal' }],
       })
 
       let foundTitle = false
@@ -529,7 +529,7 @@ describe('rollTreasureDrops', () => {
 
     it('レアドロップも遠征中の重複防止に登録される', () => {
       const enemy = createDummyEnemy({
-        rareEquipmentDrops: [{ templateId: 'sword_royal', probability: 1.0 }],
+        rareEquipmentDrops: [{ templateId: 'sword_royal' }],
       })
       const droppedIds = new Set<string>()
 

--- a/goblin_native/src/shared/data/enemy/goblin_village_3.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_3.json
@@ -175,7 +175,12 @@
         "vitality": 12,
         "agility": 8,
         "luck": 6
-      }
+      },
+      "rareEquipmentDrops": [
+        {
+          "templateId": "accessory_human_slayer"
+        }
+      ]
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/enemy/slime_cave.json
+++ b/goblin_native/src/shared/data/enemy/slime_cave.json
@@ -26,8 +26,7 @@
       },
       "rareEquipmentDrops": [
         {
-          "templateId": "accessory_split_core",
-          "probability": 1
+          "templateId": "accessory_split_core"
         }
       ]
     },
@@ -60,7 +59,12 @@
         "vitality": 1,
         "agility": 8,
         "luck": 3
-      }
+      },
+      "rareEquipmentDrops": [
+        {
+          "templateId": "accessory_locuk_medal"
+        }
+      ]
     }
   ],
   "patterns": [

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -347,12 +347,12 @@
           "value": 16
         }
       ],
-      "range": "melee",
-      "price": 5,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_1"
       ],
+      "range": "melee",
+      "price": 5,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -370,12 +370,12 @@
           "value": 24
         }
       ],
-      "range": "melee",
-      "price": 15,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_2"
       ],
+      "range": "melee",
+      "price": 15,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -393,12 +393,12 @@
           "value": 32
         }
       ],
-      "range": "melee",
-      "price": 30,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_3"
       ],
+      "range": "melee",
+      "price": 30,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -416,12 +416,12 @@
           "value": 40
         }
       ],
-      "range": "melee",
-      "price": 60,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_4"
       ],
+      "range": "melee",
+      "price": 60,
+      "unlockRank": 1,
       "rank": 1
     },
     {
@@ -439,12 +439,12 @@
           "value": 56
         }
       ],
-      "range": "melee",
-      "price": 100,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_5"
       ],
+      "range": "melee",
+      "price": 100,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -462,12 +462,12 @@
           "value": 80
         }
       ],
-      "range": "melee",
-      "price": 500,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "attack_count_up_6"
       ],
+      "range": "melee",
+      "price": 500,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -485,12 +485,12 @@
           "value": 104
         }
       ],
-      "range": "melee",
-      "price": 2500,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "attack_count_up_7"
       ],
+      "range": "melee",
+      "price": 2500,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -508,12 +508,12 @@
           "value": 152
         }
       ],
-      "range": "melee",
-      "price": 12500,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "attack_count_up_8"
       ],
+      "range": "melee",
+      "price": 12500,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -531,12 +531,12 @@
           "value": 208
         }
       ],
-      "range": "melee",
-      "price": 60000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "attack_count_up_9"
       ],
+      "range": "melee",
+      "price": 60000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -554,11 +554,11 @@
           "value": 304
         }
       ],
-      "range": "melee",
-      "price": 240000,
       "grantedSkillIds": [
         "attack_count_up_10"
       ],
+      "range": "melee",
+      "price": 240000,
       "rank": 7
     },
     {
@@ -576,11 +576,11 @@
           "value": 400
         }
       ],
-      "range": "melee",
-      "price": 720000,
       "grantedSkillIds": [
         "attack_count_up_11"
       ],
+      "range": "melee",
+      "price": 720000,
       "rank": 8
     },
     {
@@ -862,11 +862,11 @@
           "value": 5
         }
       ],
-      "price": 5,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "physical_reduction_1"
       ],
+      "price": 5,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -883,11 +883,11 @@
           "value": 8
         }
       ],
-      "price": 15,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "physical_reduction_2"
       ],
+      "price": 15,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -904,11 +904,11 @@
           "value": 10
         }
       ],
-      "price": 30,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "physical_reduction_3"
       ],
+      "price": 30,
+      "unlockRank": 1,
       "rank": 1
     },
     {
@@ -929,11 +929,11 @@
           "value": 15
         }
       ],
-      "price": 100,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "physical_reduction_6"
       ],
+      "price": 100,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -954,11 +954,11 @@
           "value": 22
         }
       ],
-      "price": 500,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "physical_reduction_7"
       ],
+      "price": 500,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -979,11 +979,11 @@
           "value": 30
         }
       ],
-      "price": 2500,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "physical_reduction_8"
       ],
+      "price": 2500,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -1004,11 +1004,11 @@
           "value": 40
         }
       ],
-      "price": 12500,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "physical_reduction_9"
       ],
+      "price": 12500,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -1029,11 +1029,11 @@
           "value": 60
         }
       ],
-      "price": 60000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "physical_reduction_10"
       ],
+      "price": 60000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -1054,10 +1054,10 @@
           "value": 80
         }
       ],
-      "price": 240000,
       "grantedSkillIds": [
         "physical_reduction_11"
       ],
+      "price": 240000,
       "rank": 7
     },
     {
@@ -1078,10 +1078,10 @@
           "value": 120
         }
       ],
-      "price": 720000,
       "grantedSkillIds": [
         "physical_reduction_12"
       ],
+      "price": 720000,
       "rank": 8
     },
     {
@@ -1149,13 +1149,13 @@
           "value": 8
         }
       ],
-      "price": 80,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_20",
         "breath_reduction_6"
       ],
+      "price": 80,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -1180,13 +1180,13 @@
           "value": 12
         }
       ],
-      "price": 400,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_30",
         "breath_reduction_7"
       ],
+      "price": 400,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -1211,13 +1211,13 @@
           "value": 16
         }
       ],
-      "price": 2000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_40",
         "breath_reduction_8"
       ],
+      "price": 2000,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -1242,13 +1242,13 @@
           "value": 20
         }
       ],
-      "price": 10000,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_50",
         "breath_reduction_9"
       ],
+      "price": 10000,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -1273,13 +1273,13 @@
           "value": 28
         }
       ],
-      "price": 50000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_60",
         "breath_reduction_10"
       ],
+      "price": 50000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -1304,12 +1304,12 @@
           "value": 36
         }
       ],
-      "price": 200000,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_70",
         "breath_reduction_11"
       ],
+      "price": 200000,
       "rank": 7
     },
     {
@@ -1334,12 +1334,12 @@
           "value": 48
         }
       ],
-      "price": 600000,
       "grantedSkillIds": [
         "breath_damage_4_5",
         "evasion_up_80",
         "breath_reduction_12"
       ],
+      "price": 600000,
       "rank": 8
     },
     {
@@ -1363,12 +1363,12 @@
           "value": 0.8
         }
       ],
-      "price": 5,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_1",
         "critical_rate_up_10"
       ],
+      "price": 5,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -1389,12 +1389,12 @@
           "value": 0.5
         }
       ],
-      "price": 15,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_2",
         "critical_rate_up_10"
       ],
+      "price": 15,
+      "unlockRank": 1,
       "rank": 0
     },
     {
@@ -1415,12 +1415,12 @@
           "value": 0.5
         }
       ],
-      "price": 30,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_3",
         "critical_rate_up_10"
       ],
+      "price": 30,
+      "unlockRank": 1,
       "rank": 1
     },
     {
@@ -1441,12 +1441,12 @@
           "value": 0.5
         }
       ],
-      "price": 2000,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "attack_count_up_4",
         "critical_rate_up_10"
       ],
+      "price": 2000,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -1467,12 +1467,12 @@
           "value": 0.4
         }
       ],
-      "price": 10000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "attack_count_up_5",
         "critical_rate_up_10"
       ],
+      "price": 10000,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -1493,12 +1493,12 @@
           "value": 0.3
         }
       ],
-      "price": 50000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "attack_count_up_6",
         "critical_rate_up_10"
       ],
+      "price": 50000,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -1519,12 +1519,12 @@
           "value": 0.2
         }
       ],
-      "price": 250000,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "attack_count_up_7",
         "critical_rate_up_10"
       ],
+      "price": 250000,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -1545,12 +1545,12 @@
           "value": 0.2
         }
       ],
-      "price": 1250000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "attack_count_up_8",
         "critical_rate_up_10"
       ],
+      "price": 1250000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -1571,11 +1571,11 @@
           "value": 0.1
         }
       ],
-      "price": 2500000,
       "grantedSkillIds": [
         "attack_count_up_9",
         "critical_rate_up_10"
       ],
+      "price": 2500000,
       "rank": 7
     },
     {
@@ -1596,11 +1596,11 @@
           "value": 0.1
         }
       ],
-      "price": 5000000,
       "grantedSkillIds": [
         "attack_count_up_10",
         "critical_rate_up_10"
       ],
+      "price": 5000000,
       "rank": 8
     },
     {
@@ -1652,11 +1652,11 @@
           "value": 20
         }
       ],
-      "price": 200,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "spell_damage_10"
       ],
+      "price": 200,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -1673,11 +1673,11 @@
           "value": 30
         }
       ],
-      "price": 1000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "spell_damage_11"
       ],
+      "price": 1000,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -1694,11 +1694,11 @@
           "value": 40
         }
       ],
-      "price": 5000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "spell_damage_12"
       ],
+      "price": 5000,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -1715,11 +1715,11 @@
           "value": 50
         }
       ],
-      "price": 25000,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "spell_damage_13"
       ],
+      "price": 25000,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -1736,11 +1736,11 @@
           "value": 60
         }
       ],
-      "price": 125000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "spell_damage_14"
       ],
+      "price": 125000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -1757,10 +1757,10 @@
           "value": 80
         }
       ],
-      "price": 500000,
       "grantedSkillIds": [
         "spell_damage_15"
       ],
+      "price": 500000,
       "rank": 7
     },
     {
@@ -1777,10 +1777,10 @@
           "value": 110
         }
       ],
-      "price": 1500000,
       "grantedSkillIds": [
         "spell_damage_16"
       ],
+      "price": 1500000,
       "rank": 8
     },
     {
@@ -1832,11 +1832,11 @@
           "value": 20
         }
       ],
-      "price": 200,
-      "unlockRank": 1,
       "grantedSkillIds": [
         "magic_heal_to_hp_6"
       ],
+      "price": 200,
+      "unlockRank": 1,
       "rank": 2
     },
     {
@@ -1853,11 +1853,11 @@
           "value": 30
         }
       ],
-      "price": 1000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "magic_heal_to_hp_7"
       ],
+      "price": 1000,
+      "unlockRank": 2,
       "rank": 3
     },
     {
@@ -1874,11 +1874,11 @@
           "value": 45
         }
       ],
-      "price": 5000,
-      "unlockRank": 2,
       "grantedSkillIds": [
         "magic_heal_to_hp_8"
       ],
+      "price": 5000,
+      "unlockRank": 2,
       "rank": 4
     },
     {
@@ -1895,11 +1895,11 @@
           "value": 60
         }
       ],
-      "price": 25000,
-      "unlockRank": 3,
       "grantedSkillIds": [
         "magic_heal_to_hp_9"
       ],
+      "price": 25000,
+      "unlockRank": 3,
       "rank": 5
     },
     {
@@ -1916,11 +1916,11 @@
           "value": 120
         }
       ],
-      "price": 125000,
-      "unlockRank": 5,
       "grantedSkillIds": [
         "magic_heal_to_hp_10"
       ],
+      "price": 125000,
+      "unlockRank": 5,
       "rank": 6
     },
     {
@@ -1937,10 +1937,10 @@
           "value": 180
         }
       ],
-      "price": 500000,
       "grantedSkillIds": [
         "magic_heal_to_hp_11"
       ],
+      "price": 500000,
       "rank": 7
     },
     {
@@ -1957,10 +1957,10 @@
           "value": 240
         }
       ],
-      "price": 1500000,
       "grantedSkillIds": [
         "magic_heal_to_hp_12"
       ],
+      "price": 1500000,
       "rank": 8
     },
     {
@@ -1971,7 +1971,57 @@
       "grantedSkillIds": [
         "hp_regen_flat_10"
       ],
-      "price": 0
+      "price": 12500,
+      "isRare": true
+    },
+    {
+      "id": "accessory_luck_medal",
+      "name": "ラッキーメダル",
+      "category": "accessory",
+      "statBonuses": [
+        {
+          "stat": "def_flat",
+          "value": 3
+        }
+      ],
+      "grantedSkillIds": [
+        "exp_bonus_50"
+      ],
+      "price": 12500,
+      "isRare": true
+    },
+    {
+      "id": "claw_beast_slayer",
+      "name": "魔獣の爪",
+      "category": "weapon",
+      "subCategory": "claw",
+      "statBonuses": [
+        {
+          "stat": "atk_flat",
+          "value": 5
+        },
+        {
+          "stat": "accuracy_flat",
+          "value": 20
+        }
+      ],
+      "grantedSkillIds": [
+        "beast_slayer_1_5"
+      ],
+      "range": "melee",
+      "price": 12500,
+      "isRare": true
+    },
+    {
+      "id": "accessory_human_slayer",
+      "name": "人間に対する殺意",
+      "category": "accessory",
+      "statBonuses": [],
+      "grantedSkillIds": [
+        "human_slayer_1_5"
+      ],
+      "price": 15000,
+      "isRare": true
     }
   ]
 }

--- a/goblin_native/src/shared/types/Enemy.ts
+++ b/goblin_native/src/shared/types/Enemy.ts
@@ -6,7 +6,6 @@ import type { BattleActionPolicy } from './Battle'
 
 export interface EquipmentDropConfig {
   templateId: string   // EquipmentTemplate.id
-  probability: number  // 0.0〜1.0（敵個別レアドロップの抽選確率）
 }
 
 export interface Enemy {

--- a/goblin_native/src/shared/types/Equipment.ts
+++ b/goblin_native/src/shared/types/Equipment.ts
@@ -60,6 +60,7 @@ export interface EquipmentTemplate {
   price: number
   unlockRank?: number  // 店売り解放に必要な拠点ランク（未設定=店売りなし）
   rank?: number  // アイテムランク（敵レベル→ランク抽選時の対象。未設定=敵ドロップ対象外）
+  isRare?: boolean  // レアアイテム判定（true なら装備一覧で同カテゴリ内のレア枠に並ぶ）
 }
 
 /**

--- a/tools/studio/src/App.tsx
+++ b/tools/studio/src/App.tsx
@@ -8,6 +8,7 @@ import { StoryListPage } from './pages/StoryListPage'
 import { StoryDetailPage } from './pages/StoryDetailPage'
 import { GoblinDataPage } from './pages/GoblinDataPage'
 import { SkillCatalogPage } from './pages/SkillCatalogPage'
+import { EquipmentPoolPage } from './pages/EquipmentPoolPage'
 import { DungeonUnlockFlowPage } from './pages/DungeonUnlockFlowPage'
 import { PartyStoreProvider } from './stores/partyStore'
 
@@ -24,6 +25,7 @@ export function App() {
             <Link to="/unlock-flow">解放図</Link>
             <Link to="/stories">ストーリー</Link>
             <Link to="/goblins">ゴブリン</Link>
+            <Link to="/equipment">アイテム</Link>
             <Link to="/skills">Skill</Link>
             <Link to="/party">PT編成</Link>
             <Link to="/simulate">シミュレーション</Link>
@@ -38,6 +40,7 @@ export function App() {
             <Route path="/stories/new" element={<StoryDetailPage />} />
             <Route path="/stories/:storyId" element={<StoryDetailPage />} />
             <Route path="/goblins" element={<GoblinDataPage />} />
+            <Route path="/equipment" element={<EquipmentPoolPage />} />
             <Route path="/skills" element={<SkillCatalogPage />} />
             <Route path="/party" element={<PartyPage />} />
             <Route path="/simulate" element={<SimulatePage />} />

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -121,6 +121,7 @@ export function dataApiPlugin(options: Options): Plugin {
   const racesFile = path.join(options.appSrc, 'shared', 'data', 'races.ts')
   const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
   const variantsFile = path.join(options.appSrc, 'shared', 'data', 'goblinVariants.ts')
+  const equipmentPoolFile = path.join(options.appSrc, 'shared', 'data', 'equipmentPool.json')
   const presetsFile = path.join(options.dataDir, 'party-presets.json')
   const libraryFile = path.join(options.dataDir, 'character-library.json')
 
@@ -242,6 +243,23 @@ export function dataApiPlugin(options: Options): Plugin {
           const message = err instanceof Error ? err.message : 'Unknown error'
           const status = message.startsWith('NOT_FOUND') ? 404 : 500
           return json(res, status, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/equipment-pool', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            return json(res, 200, await readJson(equipmentPoolFile))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            await writeEquipmentPool(equipmentPoolFile, body)
+            return json(res, 200, { ok: true })
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          return json(res, 500, { error: message })
         }
       })
 
@@ -511,6 +529,41 @@ async function deleteStory(storyFile: string, storyId: string) {
   }
   await writeJson(storyFile, { stories: nextStories })
   return { ok: true }
+}
+
+async function writeEquipmentPool(filePath: string, body: unknown): Promise<void> {
+  if (!body || typeof body !== 'object') {
+    throw new Error('Body must be an object')
+  }
+  const record = body as Record<string, unknown>
+  if (typeof record.version !== 'string' || !Array.isArray(record.templates)) {
+    throw new Error('equipment pool must contain version (string) and templates (array)')
+  }
+  const ids = new Set<string>()
+  for (const entry of record.templates as unknown[]) {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('Each template entry must be an object')
+    }
+    const e = entry as Record<string, unknown>
+    if (typeof e._comment === 'string') continue
+    if (typeof e.id !== 'string' || e.id === '') {
+      throw new Error('Template entry missing id')
+    }
+    if (ids.has(e.id)) {
+      throw new Error(`Duplicate template id: ${e.id}`)
+    }
+    ids.add(e.id)
+    if (typeof e.name !== 'string' || typeof e.category !== 'string') {
+      throw new Error(`Template ${e.id} missing required fields (name/category)`)
+    }
+    if (!Array.isArray(e.statBonuses)) {
+      throw new Error(`Template ${e.id} statBonuses must be an array`)
+    }
+    if (typeof e.price !== 'number') {
+      throw new Error(`Template ${e.id} price must be a number`)
+    }
+  }
+  await writeJson(filePath, body)
 }
 
 async function readJson(filePath: string): Promise<any> {

--- a/tools/studio/src/components/EnemyEditor.tsx
+++ b/tools/studio/src/components/EnemyEditor.tsx
@@ -18,6 +18,7 @@ import {
   TextField,
 } from './fields'
 import { EnemySkillListEditor } from './SkillEditors'
+import { RareEquipmentDropsEditor } from './RareEquipmentDropsEditor'
 
 type Enemy = EnemyDatabase['enemies'][number]
 const raceEntries = Object.entries(races).sort((a, b) => a[1].label.localeCompare(b[1].label, 'ja'))
@@ -317,10 +318,21 @@ function EnemyForm({
         value={(enemy as any).factorDrops}
         onChange={(v) => onChange((prev) => ({ ...prev, factorDrops: v }) as Enemy)}
       />
-      <ExtraJsonSection
-        label="equipmentDrops"
-        value={(enemy as any).equipmentDrops}
-        onChange={(v) => onChange((prev) => ({ ...prev, equipmentDrops: v }) as Enemy)}
+      <RareEquipmentDropsEditor
+        rareEquipmentDrops={
+          (enemy as Enemy & { rareEquipmentDrops?: Array<{ templateId: string }> }).rareEquipmentDrops
+        }
+        onChange={(rareEquipmentDrops) =>
+          onChange((prev) => {
+            const next = { ...prev } as Enemy & { rareEquipmentDrops?: Array<{ templateId: string }> }
+            if (!rareEquipmentDrops || rareEquipmentDrops.length === 0) {
+              delete next.rareEquipmentDrops
+            } else {
+              next.rareEquipmentDrops = rareEquipmentDrops
+            }
+            return next as Enemy
+          })
+        }
       />
     </aside>
   )

--- a/tools/studio/src/components/EquipmentTemplateForm.tsx
+++ b/tools/studio/src/components/EquipmentTemplateForm.tsx
@@ -1,0 +1,266 @@
+import type {
+  EquipmentCategory,
+  EquipmentStat,
+  EquipmentStatBonus,
+  EquipmentTemplate,
+  WeaponRange,
+  WeaponSubCategory,
+} from '../lib/schema'
+import {
+  FieldGroup,
+  FieldRow,
+  NumberField,
+  OptionalNumberField,
+  TextField,
+} from './fields'
+import { SkillIdListEditor } from './SkillEditors'
+
+const CATEGORIES: EquipmentCategory[] = [
+  'weapon',
+  'armor',
+  'shield',
+  'gauntlet',
+  'wand',
+  'rod',
+  'accessory',
+]
+
+const SUB_CATEGORIES: WeaponSubCategory[] = [
+  'sword',
+  'axe',
+  'spear',
+  'bow',
+  'staff',
+  'claw',
+]
+
+const RANGES: WeaponRange[] = ['melee', 'ranged']
+
+const STATS: EquipmentStat[] = [
+  'hp_flat',
+  'atk_flat',
+  'def_flat',
+  'magic_atk_flat',
+  'magic_def_flat',
+  'attackCount_flat',
+  'accuracy_flat',
+  'evasion_flat',
+  'magicHeal_flat',
+  'hp_percent',
+  'atk_percent',
+  'def_percent',
+  'critical_rate_percent',
+  'damage_reduction',
+]
+
+export function EquipmentTemplateForm({
+  template,
+  onChange,
+  onDelete,
+}: {
+  template: EquipmentTemplate
+  onChange: (updater: (prev: EquipmentTemplate) => EquipmentTemplate) => void
+  onDelete: () => void
+}) {
+  const set = <K extends keyof EquipmentTemplate>(key: K, value: EquipmentTemplate[K]) =>
+    onChange((prev) => ({ ...prev, [key]: value }))
+
+  const setOptional = <K extends keyof EquipmentTemplate>(key: K, value: EquipmentTemplate[K] | undefined) =>
+    onChange((prev) => {
+      const next = { ...prev }
+      if (value === undefined) {
+        delete next[key]
+      } else {
+        next[key] = value as EquipmentTemplate[K]
+      }
+      return next
+    })
+
+  const updateStatBonuses = (statBonuses: EquipmentStatBonus[]) => set('statBonuses', statBonuses)
+
+  return (
+    <aside className="card enemy-detail">
+      <div className="section-head">
+        <h3>
+          {template.name} <span className="subtle">/ <code>{template.id}</code></span>
+        </h3>
+        <button
+          className="btn ghost small danger"
+          onClick={() => {
+            if (window.confirm(`「${template.name}」(${template.id}) を削除しますか？`)) {
+              onDelete()
+            }
+          }}
+        >
+          削除
+        </button>
+      </div>
+
+      <FieldGroup columns={1}>
+        <TextField label="id" value={template.id} onChange={(v) => set('id', v)} />
+        <TextField label="name" value={template.name} onChange={(v) => set('name', v)} />
+      </FieldGroup>
+
+      <h4>カテゴリ</h4>
+      <FieldGroup columns={3}>
+        <label className="field">
+          <span className="field-label">category</span>
+          <span className="field-input">
+            <select
+              value={template.category}
+              onChange={(e) => set('category', e.target.value as EquipmentCategory)}
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </span>
+        </label>
+        <label className="field">
+          <span className="field-label">subCategory</span>
+          <span className="field-input">
+            <select
+              value={template.subCategory ?? ''}
+              onChange={(e) =>
+                setOptional('subCategory', e.target.value === '' ? undefined : (e.target.value as WeaponSubCategory))
+              }
+            >
+              <option value="">(未設定)</option>
+              {SUB_CATEGORIES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </span>
+        </label>
+        <label className="field">
+          <span className="field-label">range</span>
+          <span className="field-input">
+            <select
+              value={template.range ?? ''}
+              onChange={(e) =>
+                setOptional('range', e.target.value === '' ? undefined : (e.target.value as WeaponRange))
+              }
+            >
+              <option value="">(未設定)</option>
+              {RANGES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </span>
+        </label>
+      </FieldGroup>
+
+      <h4>価格・ランク</h4>
+      <FieldGroup columns={3}>
+        <NumberField
+          label="price"
+          value={template.price}
+          min={0}
+          onChange={(v) => set('price', v)}
+        />
+        <OptionalNumberField
+          label="unlockRank (店売り)"
+          value={template.unlockRank}
+          min={0}
+          onChange={(v) => setOptional('unlockRank', v)}
+        />
+        <OptionalNumberField
+          label="rank (敵ドロップ)"
+          value={template.rank}
+          min={0}
+          onChange={(v) => setOptional('rank', v)}
+        />
+      </FieldGroup>
+      <label className="field">
+        <span className="field-input">
+          <input
+            type="checkbox"
+            checked={template.isRare === true}
+            onChange={(e) => setOptional('isRare', e.target.checked ? true : undefined)}
+          />
+          <span style={{ marginLeft: '0.4rem' }}>
+            レアアイテム (装備一覧で同カテゴリ内のレア枠に並びます)
+          </span>
+        </span>
+      </label>
+
+      <h4>statBonuses</h4>
+      <StatBonusListEditor bonuses={template.statBonuses} onChange={updateStatBonuses} />
+
+      <h4>付与スキル (skillId)</h4>
+      <SkillIdListEditor
+        skillIds={template.grantedSkillIds ?? []}
+        onChange={(skillIds) =>
+          setOptional('grantedSkillIds', skillIds.length > 0 ? skillIds : undefined)
+        }
+      />
+    </aside>
+  )
+}
+
+function StatBonusListEditor({
+  bonuses,
+  onChange,
+}: {
+  bonuses: EquipmentStatBonus[]
+  onChange: (next: EquipmentStatBonus[]) => void
+}) {
+  const updateAt = (index: number, updater: (prev: EquipmentStatBonus) => EquipmentStatBonus) => {
+    onChange(bonuses.map((b, i) => (i === index ? updater(b) : b)))
+  }
+  const removeAt = (index: number) => {
+    onChange(bonuses.filter((_, i) => i !== index))
+  }
+  return (
+    <div className="story-block-list">
+      {bonuses.map((bonus, index) => (
+        <div key={index} className="story-block">
+          <div className="story-block-head">
+            <strong>{bonus.stat}</strong>
+            <div className="pattern-actions">
+              <button className="icon-btn danger" onClick={() => removeAt(index)}>
+                ×
+              </button>
+            </div>
+          </div>
+          <FieldRow>
+            <label className="field field-size-md">
+              <span className="field-label">stat</span>
+              <span className="field-input">
+                <select
+                  value={bonus.stat}
+                  onChange={(e) => updateAt(index, (prev) => ({ ...prev, stat: e.target.value as EquipmentStat }))}
+                >
+                  {STATS.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
+            <NumberField
+              size="sm"
+              label="value"
+              value={bonus.value}
+              step={0.1}
+              onChange={(v) => updateAt(index, (prev) => ({ ...prev, value: v }))}
+            />
+          </FieldRow>
+        </div>
+      ))}
+      <button
+        className="btn ghost small"
+        onClick={() => onChange([...bonuses, { stat: 'atk_flat', value: 0 }])}
+      >
+        + statBonus を追加
+      </button>
+    </div>
+  )
+}

--- a/tools/studio/src/components/RareEquipmentDropsEditor.tsx
+++ b/tools/studio/src/components/RareEquipmentDropsEditor.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  EquipmentPoolSchema,
+  isEquipmentTemplate,
+  type EquipmentTemplate,
+} from '../lib/schema'
+
+interface RareDropEntry {
+  templateId: string
+}
+
+let cachedPool: EquipmentTemplate[] | null = null
+let cachedPoolPromise: Promise<EquipmentTemplate[]> | null = null
+
+async function loadEquipmentTemplates(): Promise<EquipmentTemplate[]> {
+  if (cachedPool) return cachedPool
+  if (cachedPoolPromise) return cachedPoolPromise
+  cachedPoolPromise = (async () => {
+    const res = await fetch('/api/equipment-pool')
+    if (!res.ok) throw new Error(`equipment-pool 取得失敗: HTTP ${res.status}`)
+    const raw = await res.json()
+    const parsed = EquipmentPoolSchema.parse(raw)
+    const templates = parsed.templates.filter(isEquipmentTemplate)
+    cachedPool = templates
+    return templates
+  })()
+  try {
+    return await cachedPoolPromise
+  } finally {
+    cachedPoolPromise = null
+  }
+}
+
+export function invalidateEquipmentPoolCache() {
+  cachedPool = null
+}
+
+export function RareEquipmentDropsEditor({
+  rareEquipmentDrops,
+  onChange,
+}: {
+  rareEquipmentDrops: RareDropEntry[] | undefined
+  onChange: (next: RareDropEntry[] | undefined) => void
+}) {
+  const entries = rareEquipmentDrops ?? []
+  const [templates, setTemplates] = useState<EquipmentTemplate[] | null>(cachedPool)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (templates) return
+    loadEquipmentTemplates()
+      .then((list) => {
+        if (cancelled) return
+        setTemplates(list)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [templates])
+
+  const templateMap = useMemo(() => {
+    const map = new Map<string, EquipmentTemplate>()
+    for (const t of templates ?? []) map.set(t.id, t)
+    return map
+  }, [templates])
+
+  const rareTemplates = useMemo(
+    () => (templates ?? []).filter((t) => t.isRare === true),
+    [templates],
+  )
+
+  const updateAt = (index: number, templateId: string) => {
+    onChange(entries.map((e, i) => (i === index ? { templateId } : e)))
+  }
+  const removeAt = (index: number) => {
+    const next = entries.filter((_, i) => i !== index)
+    onChange(next.length > 0 ? next : undefined)
+  }
+  const addEntry = () => {
+    onChange([...entries, { templateId: '' }])
+  }
+
+  return (
+    <section className="card">
+      <div className="section-head">
+        <h4>レアドロップ (rareEquipmentDrops)</h4>
+        <button className="btn ghost small" onClick={addEntry}>
+          + 追加
+        </button>
+      </div>
+      <p className="subtle">
+        登録したアイテム1つごとに運値ベースの当落判定が走ります（確率指定なし）。
+        同じ敵から複数種のレアアイテムがドロップする可能性があります。
+        セレクトには <strong>isRare=true のアイテムのみ</strong> 表示されます（アイテム管理画面のチェックでON可）。
+      </p>
+      {loadError && <p className="save-error">{loadError}</p>}
+      {!templates && !loadError && <p className="subtle">アイテム一覧を読み込み中…</p>}
+      {templates && (
+        <div className="story-block-list">
+          {entries.map((entry, index) => {
+            const template = templateMap.get(entry.templateId)
+            return (
+              <div key={index} className="story-block">
+                <div className="story-block-head">
+                  <strong>
+                    {template ? `${template.name}` : entry.templateId || '(未設定)'}
+                  </strong>
+                  <div className="pattern-actions">
+                    <button className="icon-btn danger" onClick={() => removeAt(index)}>
+                      ×
+                    </button>
+                  </div>
+                </div>
+                <TemplateSelect
+                  value={entry.templateId}
+                  templates={rareTemplates}
+                  onChange={(value) => updateAt(index, value)}
+                />
+                {template && (
+                  <p className="subtle">
+                    <code>{template.id}</code> · {template.category}
+                    {template.subCategory ? ` / ${template.subCategory}` : ''}
+                    {template.rank !== undefined ? ` · rank ${template.rank}` : ''}
+                  </p>
+                )}
+                {!template && entry.templateId && (
+                  <p className="save-error">
+                    equipmentPool に存在しない templateId です: {entry.templateId}
+                  </p>
+                )}
+              </div>
+            )
+          })}
+          {entries.length === 0 && <p className="subtle">未設定</p>}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function TemplateSelect({
+  value,
+  templates,
+  onChange,
+}: {
+  value: string
+  templates: EquipmentTemplate[]
+  onChange: (value: string) => void
+}) {
+  const [query, setQuery] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<string>('')
+
+  const options = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return templates
+      .filter((t) => (categoryFilter ? t.category === categoryFilter : true))
+      .filter((t) => {
+        if (q === '') return true
+        return (
+          t.id.toLowerCase().includes(q) ||
+          t.name.toLowerCase().includes(q) ||
+          (t.subCategory ?? '').toLowerCase().includes(q)
+        )
+      })
+      .sort((a, b) => a.id.localeCompare(b.id))
+  }, [templates, query, categoryFilter])
+
+  const categories = useMemo(() => {
+    const set = new Set<string>()
+    for (const t of templates) set.add(t.category)
+    return Array.from(set).sort()
+  }, [templates])
+
+  return (
+    <div className="rare-drop-select">
+      <div className="rare-drop-select-toolbar">
+        <input
+          type="search"
+          placeholder="id / name で絞り込み"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
+          <option value="">全カテゴリ</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <select value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">(未設定)</option>
+        {value && !options.some((t) => t.id === value) && (
+          <option value={value}>{value} (絞り込み外)</option>
+        )}
+        {options.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.name} / {t.id} ({t.category}
+            {t.subCategory ? `:${t.subCategory}` : ''})
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -83,6 +83,98 @@ export const EnemyDatabaseSchema = z.object({
   patterns: z.array(EnemyPatternSchema),
 })
 
+export const EquipmentCategorySchema = z.enum([
+  'weapon',
+  'armor',
+  'shield',
+  'gauntlet',
+  'wand',
+  'rod',
+  'accessory',
+])
+
+export const WeaponSubCategorySchema = z.enum([
+  'sword',
+  'axe',
+  'spear',
+  'bow',
+  'staff',
+  'claw',
+])
+
+export const WeaponRangeSchema = z.enum(['melee', 'ranged'])
+
+export const EquipmentStatSchema = z.enum([
+  'hp_flat',
+  'atk_flat',
+  'def_flat',
+  'magic_atk_flat',
+  'magic_def_flat',
+  'attackCount_flat',
+  'accuracy_flat',
+  'evasion_flat',
+  'magicHeal_flat',
+  'hp_percent',
+  'atk_percent',
+  'def_percent',
+  'critical_rate_percent',
+  'damage_reduction',
+])
+
+export const EquipmentStatBonusSchema = z.object({
+  stat: EquipmentStatSchema,
+  value: z.number(),
+  sourceCategory: EquipmentCategorySchema.optional(),
+  sourceSubCategory: WeaponSubCategorySchema.optional(),
+})
+
+export const EquipmentTemplateSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    category: EquipmentCategorySchema,
+    subCategory: WeaponSubCategorySchema.optional(),
+    statBonuses: z.array(EquipmentStatBonusSchema),
+    grantedSkillIds: z.array(z.string()).optional(),
+    grantedSkills: z.array(z.object({ id: z.string() }).passthrough()).optional(),
+    range: WeaponRangeSchema.optional(),
+    price: z.number().nonnegative(),
+    unlockRank: z.number().int().nonnegative().optional(),
+    rank: z.number().int().nonnegative().optional(),
+    isRare: z.boolean().optional(),
+  })
+  .passthrough()
+
+export const EquipmentPoolCommentSchema = z
+  .object({ _comment: z.string() })
+  .passthrough()
+
+export const EquipmentPoolEntrySchema = z.union([
+  EquipmentTemplateSchema,
+  EquipmentPoolCommentSchema,
+])
+
+export const EquipmentPoolSchema = z.object({
+  version: z.string(),
+  templates: z.array(EquipmentPoolEntrySchema),
+})
+
+export type EquipmentCategory = z.infer<typeof EquipmentCategorySchema>
+export type WeaponSubCategory = z.infer<typeof WeaponSubCategorySchema>
+export type WeaponRange = z.infer<typeof WeaponRangeSchema>
+export type EquipmentStat = z.infer<typeof EquipmentStatSchema>
+export type EquipmentStatBonus = z.infer<typeof EquipmentStatBonusSchema>
+export type EquipmentTemplate = z.infer<typeof EquipmentTemplateSchema>
+export type EquipmentPoolComment = z.infer<typeof EquipmentPoolCommentSchema>
+export type EquipmentPoolEntry = z.infer<typeof EquipmentPoolEntrySchema>
+export type EquipmentPool = z.infer<typeof EquipmentPoolSchema>
+
+export function isEquipmentTemplate(
+  entry: EquipmentPoolEntry,
+): entry is EquipmentTemplate {
+  return typeof (entry as { id?: unknown }).id === 'string'
+}
+
 export const StoryUnlockConditionSchema = z
   .object({
     type: z.literal('dungeon_cleared'),

--- a/tools/studio/src/pages/EquipmentPoolPage.tsx
+++ b/tools/studio/src/pages/EquipmentPoolPage.tsx
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  EquipmentPoolSchema,
+  isEquipmentTemplate,
+  type EquipmentPool,
+  type EquipmentPoolEntry,
+  type EquipmentTemplate,
+} from '../lib/schema'
+import { EquipmentTemplateForm } from '../components/EquipmentTemplateForm'
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'error'; message: string }
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+type KeyedTemplate = EquipmentTemplate & { _key: number }
+type KeyedEntry = EquipmentPoolEntry | KeyedTemplate
+interface KeyedPool {
+  version: string
+  templates: KeyedEntry[]
+}
+
+const ALL_CATEGORIES = ['weapon', 'armor', 'shield', 'gauntlet', 'wand', 'rod', 'accessory'] as const
+
+let keySeed = 0
+const nextKey = () => ++keySeed
+
+function isKeyedTemplate(entry: KeyedEntry): entry is KeyedTemplate {
+  return isEquipmentTemplate(entry) && typeof (entry as { _key?: unknown })._key === 'number'
+}
+
+function attachKeys(pool: EquipmentPool): KeyedPool {
+  return {
+    version: pool.version,
+    templates: pool.templates.map((entry) =>
+      isEquipmentTemplate(entry) ? { ...entry, _key: nextKey() } : entry,
+    ),
+  }
+}
+
+function stripKeys(pool: KeyedPool): EquipmentPool {
+  return {
+    version: pool.version,
+    templates: pool.templates.map((entry) => {
+      if (!isKeyedTemplate(entry)) return entry
+      const { _key, ...rest } = entry
+      return rest as EquipmentTemplate
+    }),
+  }
+}
+
+export function EquipmentPoolPage() {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [pool, setPool] = useState<KeyedPool | null>(null)
+  const originalRef = useRef<string | null>(null)
+  const [selectedKey, setSelectedKey] = useState<number | null>(null)
+  const [query, setQuery] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoadState({ kind: 'loading' })
+    ;(async () => {
+      try {
+        const res = await fetch('/api/equipment-pool')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const raw = await res.json()
+        const parsed = EquipmentPoolSchema.safeParse(raw)
+        if (!parsed.success) {
+          throw new Error(
+            `equipment-pool 検証失敗: ${parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(' / ')}`,
+          )
+        }
+        if (cancelled) return
+        const keyed = attachKeys(parsed.data)
+        originalRef.current = JSON.stringify(stripKeys(keyed))
+        setPool(keyed)
+        const firstTemplate = keyed.templates.find(isKeyedTemplate)
+        setSelectedKey(firstTemplate?._key ?? null)
+        setLoadState({ kind: 'ready' })
+      } catch (err) {
+        if (!cancelled) {
+          setLoadState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = useMemo(() => {
+    if (!pool || originalRef.current === null) return false
+    return JSON.stringify(stripKeys(pool)) !== originalRef.current
+  }, [pool])
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  const updateTemplate = useCallback(
+    (key: number, updater: (prev: EquipmentTemplate) => EquipmentTemplate) => {
+      setPool((prev) => {
+        if (!prev) return prev
+        const nextTemplates = prev.templates.map((entry) => {
+          if (!isKeyedTemplate(entry) || entry._key !== key) return entry
+          const { _key, ...rest } = entry
+          const updated = updater(rest as EquipmentTemplate)
+          return { ...updated, _key }
+        })
+        return { ...prev, templates: nextTemplates }
+      })
+      setSaveState({ kind: 'idle' })
+    },
+    [],
+  )
+
+  const addTemplate = useCallback(() => {
+    setPool((prev) => {
+      if (!prev) return prev
+      const nextId = generateUniqueId(prev.templates)
+      const newTemplate: KeyedTemplate = {
+        id: nextId,
+        name: '新規アイテム',
+        category: 'accessory',
+        statBonuses: [],
+        price: 0,
+        _key: nextKey(),
+      }
+      setSelectedKey(newTemplate._key)
+      return { ...prev, templates: [...prev.templates, newTemplate] }
+    })
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const deleteTemplate = useCallback((key: number) => {
+    setPool((prev) => {
+      if (!prev) return prev
+      const nextTemplates = prev.templates.filter(
+        (entry) => !isKeyedTemplate(entry) || entry._key !== key,
+      )
+      return { ...prev, templates: nextTemplates }
+    })
+    setSaveState({ kind: 'idle' })
+    setSelectedKey((current) => (current === key ? null : current))
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!pool) return
+    const stripped = stripKeys(pool)
+    const parsed = EquipmentPoolSchema.safeParse(stripped)
+    if (!parsed.success) {
+      setSaveState({
+        kind: 'error',
+        message: `検証失敗: ${parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(' / ')}`,
+      })
+      return
+    }
+    const ids = new Set<string>()
+    for (const entry of stripped.templates) {
+      if (!isEquipmentTemplate(entry)) continue
+      if (entry.id === '') {
+        setSaveState({ kind: 'error', message: '空の id があります' })
+        return
+      }
+      if (ids.has(entry.id)) {
+        setSaveState({ kind: 'error', message: `id 重複: ${entry.id}` })
+        return
+      }
+      ids.add(entry.id)
+    }
+    setSaveState({ kind: 'saving' })
+    try {
+      const res = await fetch('/api/equipment-pool', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(stripped),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      originalRef.current = JSON.stringify(stripped)
+      setSaveState({ kind: 'success' })
+    } catch (err) {
+      setSaveState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [pool])
+
+  const revert = useCallback(() => {
+    if (originalRef.current === null) return
+    try {
+      const original = JSON.parse(originalRef.current) as EquipmentPool
+      setPool(attachKeys(original))
+      setSaveState({ kind: 'idle' })
+    } catch {
+      // noop
+    }
+  }, [])
+
+  const filtered = useMemo(() => {
+    if (!pool) return [] as KeyedTemplate[]
+    const q = query.trim().toLowerCase()
+    return pool.templates.filter(isKeyedTemplate).filter((t) => {
+      if (categoryFilter && t.category !== categoryFilter) return false
+      if (q === '') return true
+      return (
+        t.id.toLowerCase().includes(q) ||
+        t.name.toLowerCase().includes(q) ||
+        (t.subCategory ?? '').toLowerCase().includes(q)
+      )
+    })
+  }, [pool, query, categoryFilter])
+
+  const selected = useMemo(() => {
+    if (!pool || selectedKey === null) return null
+    return (pool.templates.find(
+      (entry) => isKeyedTemplate(entry) && entry._key === selectedKey,
+    ) as KeyedTemplate | undefined) ?? null
+  }, [pool, selectedKey])
+
+  if (loadState.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {loadState.message}</p>
+  }
+  if (!pool) return null
+
+  return (
+    <div className="detail">
+      <div className="detail-head">
+        <div>
+          <h2>アイテム管理</h2>
+          <p className="subtle">
+            equipmentPool.json · version {pool.version} ·
+            {' '}
+            {countTemplates(pool.templates)} アイテム
+          </p>
+        </div>
+        <SaveBar isDirty={isDirty} saveState={saveState} onSave={save} onRevert={revert} />
+      </div>
+
+      <div className="enemy-layout">
+        <div className="enemy-list">
+          <div className="equipment-toolbar">
+            <input
+              type="search"
+              placeholder="id / name / subCategory で絞り込み"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="search-input"
+            />
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+              className="search-input"
+            >
+              <option value="">全カテゴリ</option>
+              {ALL_CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <button className="btn primary small" onClick={addTemplate}>
+              + 新規追加
+            </button>
+          </div>
+          <table className="enemy-table">
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>name</th>
+                <th>category</th>
+                <th>sub</th>
+                <th className="num">rank</th>
+                <th className="num">price</th>
+                <th>レア</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((t) => (
+                <tr
+                  key={t._key}
+                  className={selectedKey === t._key ? 'selected' : ''}
+                  onClick={() => setSelectedKey(t._key)}
+                >
+                  <td><code>{t.id || '(未設定)'}</code></td>
+                  <td>{t.name}</td>
+                  <td>{t.category}</td>
+                  <td>{t.subCategory ?? ''}</td>
+                  <td className="num">{t.rank ?? ''}</td>
+                  <td className="num">{t.price}</td>
+                  <td>{t.isRare ? '★' : ''}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="subtle">該当するアイテムがありません</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        {selected && (
+          <EquipmentTemplateForm
+            template={selected}
+            onChange={(updater) => updateTemplate(selected._key, updater)}
+            onDelete={() => deleteTemplate(selected._key)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function countTemplates(entries: KeyedEntry[]): number {
+  return entries.filter(isKeyedTemplate).length
+}
+
+function generateUniqueId(entries: KeyedEntry[]): string {
+  const existing = new Set(
+    entries.filter(isKeyedTemplate).map((e) => e.id),
+  )
+  let n = 1
+  while (existing.has(`new_item_${n}`)) n++
+  return `new_item_${n}`
+}
+
+function SaveBar({
+  isDirty,
+  saveState,
+  onSave,
+  onRevert,
+}: {
+  isDirty: boolean
+  saveState: SaveState
+  onSave: () => void
+  onRevert: () => void
+}) {
+  return (
+    <div className="save-bar">
+      {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+      {saveState.kind === 'success' && !isDirty && <span className="saved">保存しました</span>}
+      {saveState.kind === 'error' && <span className="save-error">{saveState.message}</span>}
+      <button className="btn ghost" onClick={onRevert} disabled={!isDirty || saveState.kind === 'saving'}>
+        取り消し
+      </button>
+      <button className="btn primary" onClick={onSave} disabled={!isDirty || saveState.kind === 'saving'}>
+        保存
+      </button>
+    </div>
+  )
+}

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -1275,6 +1275,34 @@ code {
   flex: 1;
 }
 
+.equipment-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.equipment-toolbar .search-input {
+  flex: 1;
+}
+
+.rare-drop-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.rare-drop-select-toolbar {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.rare-drop-select-toolbar input,
+.rare-drop-select-toolbar select {
+  flex: 1;
+  min-width: 0;
+}
+
 .sortable {
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
## Summary
- tools/studio に「アイテム」ページを追加し、equipmentPool.json を CRUD 編集できるように
- アイテムに `isRare` フラグを追加。装備変更画面ではカテゴリ内で **ノーマル → レア** の並び順に
- 敵のレアドロップ UI を JSON エディタから「アイテム選択 UI」に置き換え（`isRare=true` のみ候補化）
- `EquipmentDropConfig` から `probability` を削除し、レアドロップは **設定アイテム1つごとに当落判定**（同じ敵から複数種ドロップ可）
- ホブゴブリン（goblin_village_3）に「人間に対する殺意」のレアドロップを設定

## 背景・補足
- レアドロップは運値ベース（`100 - rare * 0.1 < luckRoll`）で判定されるため、確率重みは不要と判断し削除
- アイテム編集 UI は内部 `_key` で選択を管理しているので、id を編集中でもフォームが消えない
- `_comment` 行（カテゴリ見出し）は保持される

## Test plan
- [ ] `npx tsc --noEmit` (goblin_native): pass
- [ ] `npx tsc -p tsconfig.app.json --noEmit` (tools/studio): pass
- [ ] `npx jest TreasureDrop`: 27 tests pass
- [ ] tools/studio で起動 → /equipment でアイテム CRUD が動く
- [ ] tools/studio の敵編集 → レアドロップに isRare アイテムだけが表示される
- [ ] 装備変更画面で同カテゴリ内のノーマル/レア順並びを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)