### PR TITLE
feat(battle): 呪文選択AIをHP状況/優先度ベースに改修

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -132,6 +132,15 @@ const SPELL_DAMAGE_OPTIONS: DamageOptions = {
 const CLERIC_MAGIC_SPELL_IDS = new Set(RECOVERY_MAGIC_SPELL_TABLE.map(entry => entry.spellId))
 const ATTACK_UP_PHYSICAL_DAMAGE_MULTIPLIER = 1.6
 const TWO_COLUMN_ATTACK_DAMAGE_MULTIPLIER = 0.5
+const HEALTHY_HP_RATIO_THRESHOLD = 0.8
+const LOW_HP_RATIO_THRESHOLD = 0.79
+const CLERIC_BARRIER_SPELL_PRIORITY = ['shield_barrier', 'magic_barrier'] as const
+const CLERIC_SINGLE_HEAL_SPELL_PRIORITY = ['full_heal', 'heal_plus', 'heal'] as const
+
+interface UsableSpellCharge {
+  charge: SpellCharge
+  def: SpellDef
+}
 
 /** レベル帯ごとの魔法追加ダメージ制限倍率 */
 const SPELL_BONUS_LEVEL_LIMIT_BY_LEVEL: { maxLevel: number; multiplier: number }[] = [
@@ -925,15 +934,75 @@ export class BattleSystem {
     sourceGroup: BattleUnit[],
     rng: () => number,
   ): SpellDef | null {
-    for (const sc of unit.spellCharges) {
-      if (sc.remaining > 0) {
-        const def = SPELL_DEFS[sc.spellId]
-        if (!def || !this.canUseSpell(def, targetGroup, sourceGroup)) continue
-        const useRate = sc.category === 'cleric'
-          ? unit.battleActionPolicy.clericMagicRate
-          : unit.battleActionPolicy.mageMagicRate
-        if (shouldRunRate(useRate, rng)) return def
-      }
+    const usableCharges = this.getUsableSpellCharges(unit, targetGroup, sourceGroup)
+    const clericCandidates = usableCharges.filter(({ charge }) => charge.category === 'cleric')
+    if (clericCandidates.length > 0 && shouldRunRate(unit.battleActionPolicy.clericMagicRate, rng)) {
+      const spell = this.decideClericSpellAction(clericCandidates, sourceGroup)
+      if (spell) return spell
+    }
+
+    const mageCandidates = usableCharges.filter(({ charge }) => charge.category === 'mage')
+    if (mageCandidates.length > 0 && shouldRunRate(unit.battleActionPolicy.mageMagicRate, rng)) {
+      return this.decideMageSpellAction(mageCandidates, rng)
+    }
+
+    return null
+  }
+
+  private getUsableSpellCharges(
+    unit: BattleUnit,
+    targetGroup: BattleUnit[],
+    sourceGroup: BattleUnit[],
+  ): UsableSpellCharge[] {
+    return unit.spellCharges
+      .filter(charge => charge.remaining > 0)
+      .map(charge => ({ charge, def: SPELL_DEFS[charge.spellId] }))
+      .filter((entry): entry is UsableSpellCharge => Boolean(entry.def) && this.canUseSpell(entry.def, targetGroup, sourceGroup))
+  }
+
+  private decideMageSpellAction(
+    candidates: UsableSpellCharge[],
+    rng: () => number,
+  ): SpellDef | null {
+    if (candidates.length === 0) return null
+    return candidates[Math.floor(rng() * candidates.length)].def
+  }
+
+  private decideClericSpellAction(
+    candidates: UsableSpellCharge[],
+    sourceGroup: BattleUnit[],
+  ): SpellDef | null {
+    if (candidates.length === 0) return null
+
+    const aliveAllies = sourceGroup.filter(unit => unit.currentHP > 0 && unit.maxHP > 0)
+    if (aliveAllies.length === 0) return null
+
+    const allAlliesHealthy = aliveAllies.every(unit => unit.currentHP / unit.maxHP > HEALTHY_HP_RATIO_THRESHOLD)
+    if (allAlliesHealthy) {
+      return this.findUsableSpellByPriority(candidates, CLERIC_BARRIER_SPELL_PRIORITY)
+    }
+
+    const lowHpAllies = aliveAllies.filter(unit => unit.currentHP / unit.maxHP <= LOW_HP_RATIO_THRESHOLD)
+    if (lowHpAllies.length >= 2) {
+      const partyHeal = candidates.find(({ def }) => def.id === 'party_heal')
+      if (partyHeal) return partyHeal.def
+    }
+
+    const healTarget = this.selectLowestHpRatioAlly(sourceGroup)[0]
+    if (!healTarget) return null
+
+    return this.findUsableSpellByPriority(candidates, CLERIC_SINGLE_HEAL_SPELL_PRIORITY)
+      ?? candidates.find(({ def }) => def.id === 'party_heal')?.def
+      ?? null
+  }
+
+  private findUsableSpellByPriority(
+    candidates: UsableSpellCharge[],
+    priority: readonly string[],
+  ): SpellDef | null {
+    for (const spellId of priority) {
+      const found = candidates.find(({ def }) => def.id === spellId)
+      if (found) return found.def
     }
     return null
   }

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -1804,6 +1804,107 @@ describe('spell charges', () => {
     expect(spellLogs).toHaveLength(1)
   })
 
+  it('魔法使い魔法は使用可能な習得呪文からランダムに選ぶ', () => {
+    const caster = createTestEnemy({
+      id: 'RANDOM_MAGE',
+      name: 'ランダム術師',
+      level: 13,
+      hp: 999,
+      atk: 1,
+      magicAtk: 100,
+      def: 1,
+      agility: 100,
+      attackCount: 0,
+      spells: [{ spellId: 'magic_arrow' }, { spellId: 'fireball' }],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 0, mageMagicRate: 100 },
+    })
+    const target = createTestGoblin({
+      stats: { hp: 999, atk: 1, agility: 1, def: 10, attackCount: 0, accuracy: 20, evasion: 15 },
+    })
+    const rngValues = [0.5, 0.5, 0.99, 0.5, 0.5, 0.5]
+    let rngIndex = 0
+    const rng = () => rngValues[rngIndex++] ?? 0.5
+
+    const result = new BattleSystem().executeBattle([target], [target.stats.hp], [[caster]], rng, 1)
+
+    expect(result.detailedLog.some(log => log.actorId === 'RANDOM_MAGE' && log.action === 'ファイヤーボール')).toBe(true)
+    expect(result.detailedLog.some(log => log.actorId === 'RANDOM_MAGE' && log.action === 'マジックアロー')).toBe(false)
+  })
+
+  it('僧侶魔法は全員のHPが80%超ならバリアを優先する', () => {
+    const cleric = createTestGoblin({
+      id: 1,
+      stats: { hp: 300, atk: 1, agility: 100, def: 10, attackCount: 0, accuracy: 999, evasion: 0 },
+      spells: [{ spellId: 'shield_barrier' }, { spellId: 'magic_barrier' }, { spellId: 'heal' }],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 100, mageMagicRate: 0 },
+    })
+    const enemy = createTestEnemy({ hp: 999, atk: 1, def: 1, agility: 1, attackCount: 0 })
+
+    const result = new BattleSystem().executeBattle([cleric], [270], [[enemy]], () => 0.5, 1)
+
+    expect(result.detailedLog.some(log => log.actorId === '1' && log.action === 'シールドバリア')).toBe(true)
+    expect(result.detailedLog.some(log => log.actorId === '1' && log.action === 'ヒール')).toBe(false)
+  })
+
+  it('僧侶魔法は79%以下の味方が複数いる場合にパーティヒールを優先する', () => {
+    const wounded = createTestGoblin({
+      id: 1,
+      stats: { hp: 300, atk: 1, agility: 1, def: 10, attackCount: 0, accuracy: 999, evasion: 0 },
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 0, mageMagicRate: 0 },
+    })
+    const cleric = createTestGoblin({
+      id: 2,
+      stats: { hp: 300, atk: 1, agility: 100, def: 10, attackCount: 0, accuracy: 999, evasion: 0, magicHeal: 30 },
+      spells: [{ spellId: 'heal' }, { spellId: 'party_heal' }],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 100, mageMagicRate: 0 },
+    })
+    const enemy = createTestEnemy({ hp: 999, atk: 1, def: 1, agility: 1, attackCount: 0 })
+
+    const result = new BattleSystem().executeBattle([wounded, cleric], [200, 200], [[enemy]], () => 0.5, 1)
+
+    expect(result.detailedLog.some(log => log.actorId === '2' && log.action === 'パーティヒール')).toBe(true)
+    expect(result.detailedLog.some(log => log.actorId === '2' && log.action === 'ヒール')).toBe(false)
+  })
+
+  it('僧侶魔法はパーティヒールがない場合に重症の味方へフルヒールを使う', () => {
+    const wounded = createTestGoblin({
+      id: 1,
+      stats: { hp: 300, atk: 1, agility: 1, def: 10, attackCount: 0, accuracy: 999, evasion: 0 },
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 0, mageMagicRate: 0 },
+    })
+    const cleric = createTestGoblin({
+      id: 2,
+      stats: { hp: 300, atk: 1, agility: 100, def: 10, attackCount: 0, accuracy: 999, evasion: 0, magicHeal: 30 },
+      spells: [{ spellId: 'heal' }, { spellId: 'heal_plus' }, { spellId: 'full_heal' }],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 100, mageMagicRate: 0 },
+    })
+    const enemy = createTestEnemy({ hp: 999, atk: 1, def: 1, agility: 1, attackCount: 0 })
+
+    const result = new BattleSystem().executeBattle([wounded, cleric], [120, 200], [[enemy]], () => 0.5, 1)
+
+    expect(result.detailedLog.some(log => log.actorId === '2' && log.action === 'フルヒール')).toBe(true)
+  })
+
+  it('僧侶魔法は単体回復でヒールプラスをヒールより優先する', () => {
+    const wounded = createTestGoblin({
+      id: 1,
+      stats: { hp: 300, atk: 1, agility: 1, def: 10, attackCount: 0, accuracy: 999, evasion: 0 },
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 0, mageMagicRate: 0 },
+    })
+    const cleric = createTestGoblin({
+      id: 2,
+      stats: { hp: 300, atk: 1, agility: 100, def: 10, attackCount: 0, accuracy: 999, evasion: 0, magicHeal: 30 },
+      spells: [{ spellId: 'heal' }, { spellId: 'heal_plus' }],
+      battleActionPolicy: { attackRate: 0, clericMagicRate: 100, mageMagicRate: 0 },
+    })
+    const enemy = createTestEnemy({ hp: 999, atk: 1, def: 1, agility: 1, attackCount: 0 })
+
+    const result = new BattleSystem().executeBattle([wounded, cleric], [210, 300], [[enemy]], () => 0.5, 1)
+
+    expect(result.detailedLog.some(log => log.actorId === '2' && log.action === 'ヒールプラス')).toBe(true)
+    expect(result.detailedLog.some(log => log.actorId === '2' && log.action === 'ヒール')).toBe(false)
+  })
+
   it('魔法支援持ちは味方のダメージ魔法に追撃する', () => {
     const caster = createTestGoblin({
       id: 1,


### PR DESCRIPTION
## Summary
- 僧侶呪文の選択をHP状況に応じた優先度ロジックへ刷新（全員HP80%超→バリア / 79%以下が複数→パーティヒール / それ以外→最低HP味方への単体回復で full_heal > heal_plus > heal）
- 魔法使い呪文は使用可能な習得呪文からランダムに選択
- 呪文選択ロジックを `getUsableSpellCharges` / `decideClericSpellAction` / `decideMageSpellAction` に分割し、見通しを改善
- 上記挙動を担保するユニットテストを5件追加

## Test plan
- [ ] `npm test -- CombatStats` で追加した5ケースが通ること
- [ ] `npx tsc --noEmit` で型エラーが出ないこと
- [ ] 戦闘シミュレーションで僧侶/魔法使いの選択挙動に違和感が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)