### PR TITLE
feat(balance): 敵経験値をLv×3×種族係数の固定計算式に統一

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -27,6 +27,7 @@ import { normalizePartyRewardMultipliers, DUNGEON_TIER_SCALING, getDungeonTierAr
 import { getGoldBonusPercentFromSkills } from '../../shared/data/characterSkills'
 import { getGoblinBaseAttributesAtLevel } from '../../shared/utils/goblinHp'
 import { getEffectiveStats } from '../../shared/utils/goblinStats'
+import { calculateEnemyExp } from '../../shared/utils/enemyExp'
 
 export class ExpeditionEngine {
   private rng: () => number
@@ -139,7 +140,7 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies) : 0
+            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies, false) : 0
 
             events.push({
               type: "battle",
@@ -202,7 +203,7 @@ export class ExpeditionEngine {
             const pattern = this.selectEnemyPattern(enemyDatabase.patterns, currentFloor, false)
             const enemies = this.applyTierScaling(this.getEnemiesFromPattern(pattern, enemyDatabase.enemies), tierScaling)
             const combat = this.resolveCombat(partyState, enemies, area)
-            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies) : 0
+            const xp = combat.outcome === 'win' ? this.calculateEnemyXp(enemies, false) : 0
 
             events.push({
               type: "battle",
@@ -274,7 +275,7 @@ export class ExpeditionEngine {
         const bossEnemies = this.applyTierScaling(this.getEnemiesFromPattern(bossPattern, enemyDatabase.enemies), tierScaling)
 
         const bossCombat = this.resolveCombat(partyState, bossEnemies, area, true)
-        const bossXp = bossCombat.outcome === 'win' ? this.calculateEnemyXp(bossEnemies) : 0
+        const bossXp = bossCombat.outcome === 'win' ? this.calculateEnemyXp(bossEnemies, true) : 0
 
         // 規定時間の終端でボス戦を行う（最後の秒で戦闘開始）
         const bossTime = adjustedDuration
@@ -471,7 +472,6 @@ export class ExpeditionEngine {
         attackCount: Math.max(1, Math.floor(enemy.attackCount * countScale)),
         accuracy: Math.round(enemy.accuracy * statScale),
         evasion: this.scaleDefensiveStat(enemy.evasion, scaling.evasionScale),
-        exp: Math.floor(enemy.exp * statScale),
         gold: Math.floor(enemy.gold * goldScale),
       }))
     )
@@ -518,8 +518,11 @@ export class ExpeditionEngine {
     )
   }
 
-  private calculateEnemyXp(enemies2D: Enemy[][]): number {
-    return enemies2D.flat().reduce((sum, enemy) => sum + enemy.exp, 0)
+  private calculateEnemyXp(enemies2D: Enemy[][], isBoss: boolean): number {
+    return enemies2D.flat().reduce(
+      (sum, enemy) => sum + calculateEnemyExp(enemy.level, enemy.raceTags, isBoss),
+      0
+    )
   }
 
   private createEnemySnap(enemies2D: Enemy[][], isBoss = false): EnemySnap {

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -131,19 +131,18 @@ describe('ExpeditionEngine dungeon tier scaling', () => {
   it('称号ごとの表と同じ法則で主要ステータスをスケールする', () => {
     const engine = new ExpeditionEngine(1)
     const expected = [
-      { level: 28, exp: 200, gold: 2800, atk: 340, accuracy: 284, attackCount: 7, evasion: 1800, magicDef: 8000 },
-      { level: 45, exp: 316, gold: 5560, atk: 537, accuracy: 449, attackCount: 8, evasion: 2844, magicDef: 12640 },
-      { level: 61, exp: 420, gold: 8520, atk: 714, accuracy: 596, attackCount: 10, evasion: 3780, magicDef: 16800 },
-      { level: 83, exp: 550, gold: 12769, atk: 935, accuracy: 781, attackCount: 11, evasion: 4950, magicDef: 22000 },
-      { level: 109, exp: 700, gold: 18334, atk: 1190, accuracy: 994, attackCount: 13, evasion: 12600, magicDef: 56000 },
-      { level: 164, exp: 1000, gold: 31304, atk: 1700, accuracy: 1420, attackCount: 15, evasion: 18000, magicDef: 80000 },
+      { level: 28, gold: 2800, atk: 340, accuracy: 284, attackCount: 7, evasion: 1800, magicDef: 8000 },
+      { level: 45, gold: 5560, atk: 537, accuracy: 449, attackCount: 8, evasion: 2844, magicDef: 12640 },
+      { level: 61, gold: 8520, atk: 714, accuracy: 596, attackCount: 10, evasion: 3780, magicDef: 16800 },
+      { level: 83, gold: 12769, atk: 935, accuracy: 781, attackCount: 11, evasion: 4950, magicDef: 22000 },
+      { level: 109, gold: 18334, atk: 1190, accuracy: 994, attackCount: 13, evasion: 12600, magicDef: 56000 },
+      { level: 164, gold: 31304, atk: 1700, accuracy: 1420, attackCount: 15, evasion: 18000, magicDef: 80000 },
     ]
 
     DUNGEON_TIER_SCALING.forEach((scaling, index) => {
       const [[scaled]] = (engine as any).applyTierScaling([[baseEnemy]], scaling)
       expect({
         level: scaled.level,
-        exp: scaled.exp,
         gold: scaled.gold,
         atk: scaled.atk,
         accuracy: scaled.accuracy,
@@ -201,61 +200,50 @@ describe('ExpeditionEngine dungeon tier scaling', () => {
 })
 
 describe('ExpeditionEngine enemy XP rewards', () => {
-  it('敵ごとのexp合計を戦闘経験値として扱う', () => {
-    const engine = new ExpeditionEngine(1)
-    const enemies: Enemy[][] = [
-      [
-        {
-          id: 'slime-a',
-          name: 'スライムA',
-          raceTags: ['slime'],
-          level: 1,
-          hp: 4,
-          baseAttributes: { power: 2, wisdom: 2, spirit: 2, vitality: 2, agility: 6, luck: 2 },
-          atk: 2,
-          def: 1,
-          attackCount: 1,
-          accuracy: 70,
-          evasion: 9,
-          exp: 1,
-          gold: 1,
-        },
-        {
-          id: 'slime-b',
-          name: 'スライムB',
-          raceTags: ['slime'],
-          level: 1,
-          hp: 4,
-          baseAttributes: { power: 2, wisdom: 2, spirit: 2, vitality: 2, agility: 6, luck: 2 },
-          atk: 2,
-          def: 1,
-          attackCount: 1,
-          accuracy: 70,
-          evasion: 9,
-          exp: 1,
-          gold: 1,
-        },
-      ],
-      [
-        {
-          id: 'boss-slime',
-          name: 'ボススライム',
-          raceTags: ['slime'],
-          level: 3,
-          hp: 20,
-          baseAttributes: { power: 3, wisdom: 3, spirit: 3, vitality: 3, agility: 8, luck: 3 },
-          atk: 3,
-          def: 2,
-          attackCount: 1,
-          accuracy: 100,
-          evasion: 11,
-          exp: 5,
-          gold: 5,
-        },
-      ],
-    ]
+  const engine = new ExpeditionEngine(1)
+  const enemies: Enemy[][] = [
+    [
+      {
+        id: 'slime-a',
+        name: 'スライムA',
+        raceTags: ['slime'],
+        level: 5,
+        hp: 4,
+        baseAttributes: { power: 2, wisdom: 2, spirit: 2, vitality: 2, agility: 6, luck: 2 },
+        atk: 2,
+        def: 1,
+        attackCount: 1,
+        accuracy: 70,
+        evasion: 9,
+        gold: 1,
+      },
+      {
+        id: 'human-a',
+        name: '人間兵士',
+        raceTags: ['human'],
+        level: 5,
+        hp: 4,
+        baseAttributes: { power: 2, wisdom: 2, spirit: 2, vitality: 2, agility: 6, luck: 2 },
+        atk: 2,
+        def: 1,
+        attackCount: 1,
+        accuracy: 70,
+        evasion: 9,
+        gold: 1,
+      },
+    ],
+  ]
 
-    expect((engine as any).calculateEnemyXp(enemies)).toBe(7)
+  it('通常戦闘ではLv×3×種族係数で経験値を算出する', () => {
+    // slime(beast) Lv5 → 5*3*1.0 = 15
+    // human Lv5 → 5*3*1.15 = 17.25 → 17
+    expect((engine as any).calculateEnemyXp(enemies, false)).toBe(32)
+  })
+
+  it('ボス戦ではボス係数1.5が乗算される', () => {
+    // slime(beast) Lv5 ボス → 5*3*1.0*1.5 = 22.5 → 23
+    // human Lv5 ボス → 5*3*1.15*1.5 = 25.875 → 26
+    expect((engine as any).calculateEnemyXp(enemies, true)).toBe(49)
   })
 })
 

--- a/goblin_native/src/shared/types/Enemy.ts
+++ b/goblin_native/src/shared/types/Enemy.ts
@@ -28,7 +28,7 @@ export interface Enemy {
   penetrationResistancePercent?: number // 貫通耐性
   criticalResistancePercent?: number    // 必殺耐性
   magicResistancePercent?: number       // 魔法耐性
-  exp: number
+  exp?: number  // 互換用に残す。実際の経験値は calculateEnemyExp で算出する。
   gold: number
   factorDrops?: FactorDropConfig[]      // この敵を倒すと得られる可能性のある因子
   rareEquipmentDrops?: EquipmentDropConfig[] // この敵固有のレアドロップ候補（運乱数によるレア抽選で当選した場合に1点抽選）

--- a/goblin_native/src/shared/utils/__tests__/enemyExp.test.ts
+++ b/goblin_native/src/shared/utils/__tests__/enemyExp.test.ts
@@ -1,0 +1,47 @@
+import { calculateEnemyExp, getRaceExpCoefficient } from '../enemyExp'
+
+describe('getRaceExpCoefficient', () => {
+  it('魔獣系 (beast) は 1.0 を返す', () => {
+    expect(getRaceExpCoefficient(['orc'])).toBe(1.0)
+    expect(getRaceExpCoefficient(['wolf'])).toBe(1.0)
+    expect(getRaceExpCoefficient(['slime'])).toBe(1.0)
+  })
+
+  it('人間系 (human) は 1.15 を返す (implies 経由を含む)', () => {
+    expect(getRaceExpCoefficient(['human'])).toBe(1.15)
+    expect(getRaceExpCoefficient(['dwarf'])).toBe(1.15)
+    expect(getRaceExpCoefficient(['elf'])).toBe(1.15)
+    expect(getRaceExpCoefficient(['hobbit'])).toBe(1.15)
+  })
+
+  it('構築物 (construct) は 1.2 を返す', () => {
+    expect(getRaceExpCoefficient(['construct'])).toBe(1.2)
+  })
+
+  it('未定義 / 中立種族はデフォルトの 1.0 を返す', () => {
+    expect(getRaceExpCoefficient(['dragon'])).toBe(1.0)
+    expect(getRaceExpCoefficient(['undead'])).toBe(1.0)
+    expect(getRaceExpCoefficient(['demon_race'])).toBe(1.0)
+  })
+
+  it('複数タグでは最大係数を採用する', () => {
+    expect(getRaceExpCoefficient(['orc', 'human'])).toBe(1.15)
+  })
+})
+
+describe('calculateEnemyExp', () => {
+  it('魔獣の通常戦闘は Lv * 3 * 1.0', () => {
+    expect(calculateEnemyExp(10, ['orc'], false)).toBe(30)
+    expect(calculateEnemyExp(20, ['slime'], false)).toBe(60)
+  })
+
+  it('人間の通常戦闘は Lv * 3 * 1.15', () => {
+    expect(calculateEnemyExp(10, ['human'], false)).toBe(35) // 34.5 → 35
+    expect(calculateEnemyExp(20, ['dwarf'], false)).toBe(69) // 69
+  })
+
+  it('ボス係数 1.5 を乗算する', () => {
+    expect(calculateEnemyExp(10, ['orc'], true)).toBe(45) // 30*1.5
+    expect(calculateEnemyExp(10, ['human'], true)).toBe(52) // 34.5*1.5 = 51.75 → 52
+  })
+})

--- a/goblin_native/src/shared/utils/enemyExp.ts
+++ b/goblin_native/src/shared/utils/enemyExp.ts
@@ -1,0 +1,51 @@
+import { races } from '../data/races'
+
+const RACE_EXP_COEFFICIENTS: Record<string, number> = {
+  human: 1.15,
+  beast: 1.0,
+  construct: 1.2,
+}
+
+const DEFAULT_RACE_EXP_COEFFICIENT = 1.0
+
+const BOSS_EXP_COEFFICIENT = 1.5
+
+const LEVEL_EXP_BASE = 3
+
+function expandRaceTags(raceTags: readonly string[]): Set<string> {
+  const expanded = new Set<string>()
+  const visit = (tag: string) => {
+    if (expanded.has(tag)) return
+    expanded.add(tag)
+    const race = races[tag]
+    if (!race) return
+    for (const implied of race.implies ?? []) {
+      visit(implied)
+    }
+  }
+  for (const tag of raceTags) visit(tag)
+  return expanded
+}
+
+export function getRaceExpCoefficient(raceTags: readonly string[]): number {
+  const expanded = expandRaceTags(raceTags)
+  let coefficient = DEFAULT_RACE_EXP_COEFFICIENT
+  for (const tag of expanded) {
+    const value = RACE_EXP_COEFFICIENTS[tag]
+    if (value !== undefined && value > coefficient) {
+      coefficient = value
+    }
+  }
+  return coefficient
+}
+
+export function calculateEnemyExp(
+  level: number,
+  raceTags: readonly string[],
+  isBoss: boolean
+): number {
+  const base = level * LEVEL_EXP_BASE
+  const raceCoefficient = getRaceExpCoefficient(raceTags)
+  const bossCoefficient = isBoss ? BOSS_EXP_COEFFICIENT : 1
+  return Math.round(base * raceCoefficient * bossCoefficient)
+}


### PR DESCRIPTION
## Summary
- 敵経験値を JSON の個別 exp 値ではなく `Lv × 3 × 種族係数 × ボス係数` の固定式で算出するよう変更
- 種族係数: 人間 1.15 / 構築物 1.2 / それ以外 1.0（races の implies 経由でも判定）、ボス係数 1.5
- `applyTierScaling` から exp 出力を削除（scaled level から自動算出されるため不要）。`Enemy.exp` 型は互換のため optional に

## 背景
旧来は JSON の `exp` フィールドで個別設定しており、辺境の村の防衛砲台 (Lv25 construct) が exp:200 と突出するなどバランスがバラついていた。Lv と種族から固定式で算出することでステージ間の一貫性を確保する。

## 変更点
- `src/shared/utils/enemyExp.ts` 新規（`calculateEnemyExp`, `getRaceExpCoefficient`）
- `ExpeditionEngine.calculateEnemyXp(enemies, isBoss)` を新計算式ベースに変更（呼び出し3箇所も更新）
- `Enemy.exp` を optional に（JSON 側のフィールドは当面残置）

## Test plan
- [x] `npx tsc --noEmit` が通ること
- [x] `npx jest` 全367テスト通過
- [ ] 実機で遠征を回し、通常戦闘 / ボス戦の獲得 EXP が新計算式と整合することを確認
- [ ] 辺境の村でボス砲台撃破時の EXP が旧来 (200) より下がっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)