### PR TITLE
feat(shop): 金のドングリ（消費型課金/ゲーム内入手）を追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -7,6 +7,7 @@ import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useExpeditionFlow, type ExpeditionHistoryDisplay } from '@/presentation/hooks/useExpeditionFlow'
+import { getGoldenAcornCount } from '@/presentation/stores/usePurchaseStore'
 import { useCurrentTime } from '@/presentation/hooks/useCurrentTime'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
@@ -325,10 +326,11 @@ export default function FormationScreen() {
       })
     }
 
-    const doBulkLaunch = async () => {
+    const doBulkLaunch = async (useGoldenAcorn: boolean) => {
       setIsBulkLaunching(true)
       try {
-        const result = await startBulkExpedition(inputs)
+        const inputsWithFlag = inputs.map((input) => ({ ...input, useGoldenAcorn }))
+        const result = await startBulkExpedition(inputsWithFlag)
         const allSkipped = [...skippedReasons, ...result.skippedReasons]
 
         if (result.startedCount === 0) {
@@ -351,6 +353,31 @@ export default function FormationScreen() {
       return
     }
 
+    const promptGoldenAcornBulk = (onChoose: (useAcorn: boolean) => void) => {
+      const acornCount = getGoldenAcornCount()
+      // 全PT分のドングリを保有している場合のみ選択肢を出す
+      if (acornCount < inputs.length) {
+        onChoose(false)
+        return
+      }
+      Alert.alert(
+        t('ui.formation.index.goldenAcornBulkPromptTitle'),
+        t('ui.formation.index.goldenAcornBulkPromptBody', {
+          count: inputs.length,
+          remaining: acornCount,
+        }),
+        [
+          { text: t('ui.common.cancel'), style: 'cancel' },
+          { text: t('ui.formation.index.goldenAcornBulkStartWithout'), onPress: () => onChoose(false) },
+          { text: t('ui.formation.index.goldenAcornBulkUseAndStart'), onPress: () => onChoose(true) },
+        ],
+      )
+    }
+
+    const launchWithGoldenAcornPrompt = () => {
+      promptGoldenAcornBulk((useAcorn) => void doBulkLaunch(useAcorn))
+    }
+
     const maxPendingGoblins = rank * 5
     const remainingPendingSlots = Math.max(0, maxPendingGoblins - pendingGoblins.length)
     if (inputs.length > remainingPendingSlots) {
@@ -359,13 +386,13 @@ export default function FormationScreen() {
         t('ui.formation.index.pendingOverflowBody', { count: inputs.length }),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.common.launch'), onPress: () => void doBulkLaunch() },
+          { text: t('ui.formation.common.launch'), onPress: launchWithGoldenAcornPrompt },
         ],
       )
       return
     }
 
-    void doBulkLaunch()
+    launchWithGoldenAcornPrompt()
   }, [dungeons, parties, pendingGoblins.length, rank, startBulkExpedition, t])
 
   const canBulkLaunch = useMemo(() => {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -7,6 +7,7 @@ import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
+import { getGoldenAcornCount } from '@/presentation/stores/usePurchaseStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getPartyEffectiveStats } from '@/shared/utils/goblinStats'
 import { getGoldBonusPercentFromSkills } from '@/shared/data/characterSkills'
@@ -282,13 +283,14 @@ export default function ExpeditionPreparationScreen() {
       return
     }
 
-    const doStartExpedition = async () => {
+    const doStartExpedition = async (useGoldenAcorn: boolean) => {
       try {
         await startExpedition({
           party,
           dungeon: selectedDungeon,
           returnPolicy: selectedReturnPolicy,
           tier: selectedTier,
+          useGoldenAcorn,
         })
 
         router.dismissAll()
@@ -298,6 +300,27 @@ export default function ExpeditionPreparationScreen() {
       }
     }
 
+    const promptGoldenAcorn = (onChoose: (useAcorn: boolean) => void) => {
+      const acornCount = getGoldenAcornCount()
+      if (acornCount <= 0) {
+        onChoose(false)
+        return
+      }
+      Alert.alert(
+        t('ui.formation.preparation.goldenAcornPromptTitle'),
+        t('ui.formation.preparation.goldenAcornPromptBody', { count: acornCount }),
+        [
+          { text: t('ui.common.cancel'), style: 'cancel' },
+          { text: t('ui.formation.preparation.goldenAcornStartWithout'), onPress: () => onChoose(false) },
+          { text: t('ui.formation.preparation.goldenAcornUseAndStart'), onPress: () => onChoose(true) },
+        ],
+      )
+    }
+
+    const launchWithGoldenAcornPrompt = () => {
+      promptGoldenAcorn((useAcorn) => void doStartExpedition(useAcorn))
+    }
+
     const maxPendingGoblins = rank * 5
     if (pendingGoblins.length >= maxPendingGoblins) {
       Alert.alert(
@@ -305,13 +328,13 @@ export default function ExpeditionPreparationScreen() {
         t('ui.formation.preparation.pendingOverflowBody'),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.common.launch'), onPress: () => void doStartExpedition() },
+          { text: t('ui.formation.common.launch'), onPress: launchWithGoldenAcornPrompt },
         ],
       )
       return
     }
 
-    void doStartExpedition()
+    launchWithGoldenAcornPrompt()
   }, [
     pendingGoblins.length,
     party,

--- a/goblin_native/app/shop.tsx
+++ b/goblin_native/app/shop.tsx
@@ -97,7 +97,10 @@ export default function ShopScreen() {
   }
 
   // 補間パラメータを取得
-  const getDescriptionParams = (descriptionKey: string): Record<string, number | string> | undefined => {
+  const getDescriptionParams = (
+    descriptionKey: string,
+    productInfo?: PurchaseProduct,
+  ): Record<string, number | string> | undefined => {
     switch (descriptionKey) {
       case 'shop.goblinCapacityExpansion.description':
         return { count: GOBLIN_CAPACITY_EXPANSION }
@@ -114,6 +117,9 @@ export default function ShopScreen() {
           goldMultiplier: MONTHLY_PASS_GOLD_MULTIPLIER,
           speedPercent: Math.round((1 - MONTHLY_PASS_SPEED_MULTIPLIER) * 100),
         }
+      case 'shop.goldenAcorn.description':
+      case 'shop.goldenAcorn.descriptionDiscount':
+        return productInfo?.consumableQuantity ? { count: productInfo.consumableQuantity } : undefined
       default:
         return undefined
     }
@@ -124,7 +130,7 @@ export default function ShopScreen() {
     const packageId = pkg.identifier
     const productInfo = PURCHASE_PRODUCTS.find(p => p.packageId === packageId)
     const entitlementId = productInfo?.entitlementId || packageId
-    const descriptionParams = productInfo ? getDescriptionParams(productInfo.descriptionKey) : undefined
+    const descriptionParams = productInfo ? getDescriptionParams(productInfo.descriptionKey, productInfo) : undefined
 
     return {
       iconName: productInfo?.iconName || 'star',

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -64,6 +64,12 @@ export class ExpeditionEngine {
     const rareDropMultiplierBoost = expeditionBoost?.rareDropMultiplier && expeditionBoost.rareDropMultiplier > 0
       ? expeditionBoost.rareDropMultiplier
       : 1
+    const goldMultiplierBoost = expeditionBoost?.goldMultiplier && expeditionBoost.goldMultiplier > 0
+      ? expeditionBoost.goldMultiplier
+      : 1
+    const titleMultiplierBoost = expeditionBoost?.titleMultiplier && expeditionBoost.titleMultiplier > 0
+      ? expeditionBoost.titleMultiplier
+      : 1
     const tier = request.tier ?? 0
     const tierScaling = DUNGEON_TIER_SCALING[tier] ?? DUNGEON_TIER_SCALING[0]
     // ダンジョンIDからエリアIDにマッピング
@@ -167,7 +173,8 @@ export class ExpeditionEngine {
               droppedTemplateIds,
               partyLuckAverage,
               normalizedRewardMultipliers,
-              rareDropMultiplierBoost
+              rareDropMultiplierBoost,
+              titleMultiplierBoost
             )
             if (treasureDrops.length > 0) {
               events.push({
@@ -229,7 +236,8 @@ export class ExpeditionEngine {
               droppedTemplateIds,
               partyLuckAverage,
               normalizedRewardMultipliers,
-              rareDropMultiplierBoost
+              rareDropMultiplierBoost,
+              titleMultiplierBoost
             )
             if (defaultTreasure.length > 0) {
               events.push({
@@ -299,7 +307,8 @@ export class ExpeditionEngine {
             droppedTemplateIds,
             partyLuckAverage,
             normalizedRewardMultipliers,
-            rareDropMultiplierBoost
+            rareDropMultiplierBoost,
+            titleMultiplierBoost
           )
           if (bossTreasure.length > 0) {
             events.push({
@@ -334,7 +343,7 @@ export class ExpeditionEngine {
       (max, member) => Math.max(max, getGoldBonusPercentFromSkills(member.skills)),
       0,
     )
-    const summary = this.calculateRewardSummary(events, partyState, normalizedRewardMultipliers, partyGoldBonusPercent)
+    const summary = this.calculateRewardSummary(events, partyState, normalizedRewardMultipliers, partyGoldBonusPercent, goldMultiplierBoost)
     console.log('ExpeditionEngine: Expedition complete', summary)
 
     return {
@@ -669,9 +678,11 @@ export class ExpeditionEngine {
     droppedIds: Set<string>,
     partyLuckAverage: number,
     rewardMultipliers?: PartyRewardMultipliers,
-    rareDropMultiplierBoost: number = 1
+    rareDropMultiplierBoost: number = 1,
+    titleMultiplierBoost: number = 1
   ): TreasureDrop[] {
     const { title: titleMultiplier, rare: rareMultiplier } = normalizePartyRewardMultipliers(rewardMultipliers)
+    const effectiveTitleMultiplier = titleMultiplier * (titleMultiplierBoost > 0 ? titleMultiplierBoost : 1)
     const drops: TreasureDrop[] = []
     const expeditionDroppedIds = new Set(droppedIds)
     const pendingDroppedIds = new Set<string>()
@@ -694,7 +705,7 @@ export class ExpeditionEngine {
       const index = Math.floor(this.rng() * candidates.length)
       const selected = candidates[index]
 
-      const title = EquipmentTitleService.rollTitle(titleMultiplier, this.rng)
+      const title = EquipmentTitleService.rollTitle(effectiveTitleMultiplier, this.rng)
       drops.push({
         templateId: selected.id,
         titleId: title.titleId !== 'none' ? title.titleId : undefined,
@@ -716,7 +727,7 @@ export class ExpeditionEngine {
         const luckRoll = rollLuckValue(partyLuckAverage, this.rng)
         if (!(rareThreshold < luckRoll)) continue
 
-        const title = EquipmentTitleService.rollTitle(titleMultiplier, this.rng)
+        const title = EquipmentTitleService.rollTitle(effectiveTitleMultiplier, this.rng)
         drops.push({
           templateId: drop.templateId,
           titleId: title.titleId !== 'none' ? title.titleId : undefined,
@@ -737,9 +748,11 @@ export class ExpeditionEngine {
     partyState: PartyState[],
     rewardMultipliers?: PartyRewardMultipliers,
     goldBonusPercent: number = 0,
+    goldMultiplierBoost: number = 1,
   ): RewardSummary {
     const { gold: goldMultiplier } = normalizePartyRewardMultipliers(rewardMultipliers)
     const skillGoldMultiplier = 1 + goldBonusPercent / 100
+    const effectiveGoldBoost = goldMultiplierBoost > 0 ? goldMultiplierBoost : 1
     let xpGained = 0
     let baseGoldGained = 0
     let maxFloorReached = 1
@@ -770,8 +783,8 @@ export class ExpeditionEngine {
       successReasons.has(event.reason)
     )
 
-    const goldGained = Math.floor(baseGoldGained * goldMultiplier * skillGoldMultiplier)
-    const totalGoldMultiplier = goldMultiplier * skillGoldMultiplier
+    const goldGained = Math.floor(baseGoldGained * goldMultiplier * skillGoldMultiplier * effectiveGoldBoost)
+    const totalGoldMultiplier = goldMultiplier * skillGoldMultiplier * effectiveGoldBoost
 
     return {
       success,

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -62,6 +62,70 @@ describe('ExpeditionEngine reward multipliers', () => {
     expect(summary.goldGained).toBe(52)
   })
 
+  it('goldMultiplierBoost を gold 報酬に乗算する（金のドングリ相当）', () => {
+    const engine = new ExpeditionEngine(1)
+    const events: TimelineEvent[] = [
+      { type: 'move_start', at: 0, floor: 1 },
+      {
+        type: 'battle',
+        at: 10,
+        floor: 1,
+        enemy: { id: 'e1', name: '敵1', lvl: 1, count: 1, gold: 100 },
+        combat: { rounds: 1, outcome: 'win', allyHPDelta: [0], enemyDefeated: 1 },
+        xp: 5,
+      },
+      { type: 'return', at: 30, reason: 'completed' },
+    ]
+    const partyState: PartyState[] = [
+      {
+        id: '1',
+        name: 'テスト',
+        race: 'ゴブリン',
+        currentHP: 10,
+        maxHP: 10,
+        baseHP: 10,
+        atk: 5,
+        magicAtk: 0,
+        def: 5,
+        magicDef: 0,
+        agility: 5,
+        luck: 5,
+        attackCount: 1,
+        accuracy: 10,
+        evasion: 5,
+        magicHeal: 5,
+        isKO: false,
+        isDead: false,
+        mods: [],
+        skills: [],
+        factors: [],
+        level: 1,
+        avatar: 'test.png',
+      },
+    ]
+
+    // boost なし: 100 gold
+    const baseline = (engine as any).calculateRewardSummary(
+      events,
+      partyState,
+      DEFAULT_PARTY_REWARD_MULTIPLIERS,
+      0,
+      1,
+    )
+    expect(baseline.goldGained).toBe(100)
+
+    // boost = 2.0 → 200 gold
+    const boosted = (engine as any).calculateRewardSummary(
+      events,
+      partyState,
+      DEFAULT_PARTY_REWARD_MULTIPLIERS,
+      0,
+      2.0,
+    )
+    expect(boosted.goldGained).toBe(200)
+    expect(boosted.goldMultiplier).toBeCloseTo(2.0)
+  })
+
   it('敗北した戦闘の経験値を報酬合計に含めない', () => {
     const engine = new ExpeditionEngine(1)
     const events: TimelineEvent[] = [

--- a/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/StartExpeditionUseCase.ts
@@ -1,4 +1,5 @@
 import type {
+  ExpeditionBoost,
   ExpeditionMeta,
   ExpeditionRequest,
   Goblin,
@@ -25,7 +26,10 @@ export class StartExpeditionUseCase {
     this.equipmentRepository = equipmentRepository
   }
 
-  public async execute(request: ExpeditionRequest): Promise<ExpeditionMeta> {
+  public async execute(
+    request: ExpeditionRequest,
+    expeditionBoost?: ExpeditionBoost,
+  ): Promise<ExpeditionMeta> {
     const partyId = Number.parseInt(request.partyId, 10)
     if (Number.isNaN(partyId)) {
       throw new Error('パーティIDが不正です')
@@ -60,6 +64,7 @@ export class StartExpeditionUseCase {
       request,
       departingGoblins,
       rewardMultipliers: normalizePartyRewardMultipliers(party.rewardMultipliers),
+      expeditionBoost,
     }
   }
 

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -3,6 +3,7 @@ import { Alert } from 'react-native'
 import type {
   Dungeon,
   DungeonTier,
+  ExpeditionBoost,
   ExpeditionReplay,
   ExpeditionRequest,
   ExpeditionRecord,
@@ -18,7 +19,14 @@ import { useBaseStore, getBaseStateRepository } from '../stores/useBaseStore'
 import { useDungeonStore } from '../stores/useDungeonStore'
 import { SQLiteEquipmentRepository } from '../../infrastructure/repositories/SQLiteEquipmentRepository'
 import { useDebugSettingsStore } from '../stores/useDebugSettingsStore'
-import { getSpeedMultiplier } from '../stores/usePurchaseStore'
+import { getSpeedMultiplier, usePurchaseStore } from '../stores/usePurchaseStore'
+import {
+  TICKET_TYPES,
+  GOLDEN_ACORN_SPEED_MULTIPLIER,
+  GOLDEN_ACORN_GOLD_MULTIPLIER,
+  GOLDEN_ACORN_RARE_MULTIPLIER,
+  GOLDEN_ACORN_TITLE_MULTIPLIER,
+} from '../../shared/constants/purchases'
 import { useStoryStore } from '../stores/useStoryStore'
 import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
@@ -38,10 +46,18 @@ interface StartExpeditionInput {
   dungeon: Dungeon
   returnPolicy: ExpeditionRequest['returnPolicy']
   tier?: DungeonTier
+  /** 出発時に金のドングリを消費するか */
+  useGoldenAcorn?: boolean
 }
 
 interface StartExpeditionResult {
   record: ExpeditionRecord
+}
+
+const GOLDEN_ACORN_BOOST: ExpeditionBoost = {
+  goldMultiplier: GOLDEN_ACORN_GOLD_MULTIPLIER,
+  rareDropMultiplier: GOLDEN_ACORN_RARE_MULTIPLIER,
+  titleMultiplier: GOLDEN_ACORN_TITLE_MULTIPLIER,
 }
 
 export interface ExpeditionHistoryDisplay {
@@ -166,6 +182,7 @@ export const useExpeditionFlow = ({
     dungeon: Dungeon,
     returnPolicy: ExpeditionRequest['returnPolicy'],
     partyExpeditionTimeMultiplier: number = 1,
+    goldenAcornUsed: boolean = false,
   ): number => {
     if (instantDungeonExploration) {
       return 1
@@ -184,7 +201,10 @@ export const useExpeditionFlow = ({
     }
     const multiplier = multiplierMap[returnPolicy] ?? 1.0
     const speedMultiplier = getSpeedMultiplier()
-    return Math.floor(baseTime * multiplier * speedMultiplier * partyExpeditionTimeMultiplier)
+    const goldenAcornSpeed = goldenAcornUsed ? GOLDEN_ACORN_SPEED_MULTIPLIER : 1
+    return Math.floor(
+      baseTime * multiplier * speedMultiplier * partyExpeditionTimeMultiplier * goldenAcornSpeed,
+    )
   }, [instantDungeonExploration])
 
   const formatTime = useCallback((date: Date) => {
@@ -224,11 +244,31 @@ export const useExpeditionFlow = ({
   }, [])
 
   const startExpedition = useCallback(
-    async ({ party, dungeon, returnPolicy, tier }: StartExpeditionInput): Promise<StartExpeditionResult> => {
+    async ({ party, dungeon, returnPolicy, tier, useGoldenAcorn = false }: StartExpeditionInput): Promise<StartExpeditionResult> => {
       setIsProcessing(true)
+      const debugInstantAcorn = useDebugSettingsStore.getState().instantGoldenAcorn
+      let acornConsumed = false
       try {
+        if (useGoldenAcorn) {
+          if (debugInstantAcorn) {
+            // デバッグ時は消費せずに効果のみ適用
+            acornConsumed = false
+          } else {
+            const success = await usePurchaseStore.getState().useTicket(TICKET_TYPES.GOLDEN_ACORN)
+            if (!success) {
+              throw new Error('金のドングリの残数が不足しています')
+            }
+            acornConsumed = true
+          }
+        }
+
         const partyExpeditionTimeMultiplier = await getPartyExpeditionTimeMultiplier(party)
-        const durationSec = estimateExplorationTime(dungeon, returnPolicy, partyExpeditionTimeMultiplier)
+        const durationSec = estimateExplorationTime(
+          dungeon,
+          returnPolicy,
+          partyExpeditionTimeMultiplier,
+          useGoldenAcorn,
+        )
         const request: ExpeditionRequest = {
           partyId: party.id.toString(),
           areaId: dungeon.id,
@@ -238,7 +278,8 @@ export const useExpeditionFlow = ({
           durationSec,
         }
 
-        const expeditionMeta = await startExpeditionUseCase.execute(request)
+        const boost = useGoldenAcorn ? GOLDEN_ACORN_BOOST : undefined
+        const expeditionMeta = await startExpeditionUseCase.execute(request, boost)
         const startTime = new Date()
         const returnTime = new Date(startTime.getTime() + durationSec * 1000)
         const expeditionId = `exp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
@@ -271,6 +312,16 @@ export const useExpeditionFlow = ({
         }
 
         return { record }
+      } catch (error) {
+        // UseCase 失敗時に消費したドングリを戻す
+        if (acornConsumed) {
+          try {
+            await usePurchaseStore.getState().addTickets(TICKET_TYPES.GOLDEN_ACORN, 1)
+          } catch (rollbackError) {
+            console.warn('[useExpeditionFlow] Failed to rollback golden acorn', rollbackError)
+          }
+        }
+        throw error
       } finally {
         setIsProcessing(false)
       }
@@ -288,11 +339,34 @@ export const useExpeditionFlow = ({
       setIsProcessing(true)
       const records: ExpeditionRecord[] = []
       const skippedReasons: string[] = []
+      const debugInstantAcorn = useDebugSettingsStore.getState().instantGoldenAcorn
+      let acornsConsumed = 0
 
       try {
-        for (const { party, dungeon, returnPolicy, tier } of inputs) {
+        for (const { party, dungeon, returnPolicy, tier, useGoldenAcorn = false } of inputs) {
+          let acornAppliedForThisInput = false
+          if (useGoldenAcorn) {
+            if (debugInstantAcorn) {
+              acornAppliedForThisInput = true
+            } else {
+              const success = await usePurchaseStore.getState().useTicket(TICKET_TYPES.GOLDEN_ACORN)
+              if (success) {
+                acornsConsumed++
+                acornAppliedForThisInput = true
+              } else {
+                skippedReasons.push(`${party.name}: 金のドングリの残数が不足`)
+                continue
+              }
+            }
+          }
+
           const partyExpeditionTimeMultiplier = await getPartyExpeditionTimeMultiplier(party)
-          const durationSec = estimateExplorationTime(dungeon, returnPolicy, partyExpeditionTimeMultiplier)
+          const durationSec = estimateExplorationTime(
+            dungeon,
+            returnPolicy,
+            partyExpeditionTimeMultiplier,
+            acornAppliedForThisInput,
+          )
           const request: ExpeditionRequest = {
             partyId: party.id.toString(),
             areaId: dungeon.id,
@@ -303,7 +377,8 @@ export const useExpeditionFlow = ({
           }
 
           try {
-            const expeditionMeta = await startExpeditionUseCase.execute(request)
+            const boost = acornAppliedForThisInput ? GOLDEN_ACORN_BOOST : undefined
+            const expeditionMeta = await startExpeditionUseCase.execute(request, boost)
             const startTime = new Date()
             const returnTime = new Date(startTime.getTime() + durationSec * 1000)
             const expeditionId = `exp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
@@ -324,6 +399,15 @@ export const useExpeditionFlow = ({
             })
           } catch (error) {
             skippedReasons.push(`${party.name}: ${(error as Error).message}`)
+            // UseCase 失敗時はそのパーティ分のドングリを戻す
+            if (acornAppliedForThisInput && !debugInstantAcorn) {
+              try {
+                await usePurchaseStore.getState().addTickets(TICKET_TYPES.GOLDEN_ACORN, 1)
+                acornsConsumed--
+              } catch (rollbackError) {
+                console.warn('[useExpeditionFlow] Failed to rollback golden acorn (bulk)', rollbackError)
+              }
+            }
           }
         }
 
@@ -344,6 +428,10 @@ export const useExpeditionFlow = ({
 
         return { startedCount: records.length, skippedReasons }
       } finally {
+        // 参考用カウンタは利用しないが、消費数を上位で見たい場合に備えてログのみ出す
+        if (acornsConsumed > 0) {
+          console.log(`[useExpeditionFlow] Golden acorn consumed (bulk): ${acornsConsumed}`)
+        }
         setIsProcessing(false)
       }
     },

--- a/goblin_native/src/presentation/stores/useDebugSettingsStore.ts
+++ b/goblin_native/src/presentation/stores/useDebugSettingsStore.ts
@@ -6,16 +6,25 @@ const STORAGE_KEY = 'debug-settings'
 interface DebugSettingsState {
   isLoading: boolean
   instantDungeonExploration: boolean
+  instantGoldenAcorn: boolean
 }
 
 interface DebugSettingsActions {
   initialize: () => Promise<void>
   setInstantDungeonExploration: (enabled: boolean) => Promise<void>
+  setInstantGoldenAcorn: (enabled: boolean) => Promise<void>
 }
 
-export const useDebugSettingsStore = create<DebugSettingsState & DebugSettingsActions>()((set) => ({
+type PersistedSettings = Partial<Pick<DebugSettingsState, 'instantDungeonExploration' | 'instantGoldenAcorn'>>
+
+const persist = async (settings: PersistedSettings): Promise<void> => {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}
+
+export const useDebugSettingsStore = create<DebugSettingsState & DebugSettingsActions>()((set, get) => ({
   isLoading: true,
   instantDungeonExploration: false,
+  instantGoldenAcorn: false,
 
   initialize: async () => {
     try {
@@ -25,9 +34,10 @@ export const useDebugSettingsStore = create<DebugSettingsState & DebugSettingsAc
         return
       }
 
-      const parsed = JSON.parse(raw) as Partial<Pick<DebugSettingsState, 'instantDungeonExploration'>>
+      const parsed = JSON.parse(raw) as PersistedSettings
       set({
         instantDungeonExploration: parsed.instantDungeonExploration ?? false,
+        instantGoldenAcorn: parsed.instantGoldenAcorn ?? false,
         isLoading: false,
       })
     } catch {
@@ -36,10 +46,18 @@ export const useDebugSettingsStore = create<DebugSettingsState & DebugSettingsAc
   },
 
   setInstantDungeonExploration: async (enabled: boolean) => {
-    await AsyncStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ instantDungeonExploration: enabled }),
-    )
     set({ instantDungeonExploration: enabled })
+    await persist({
+      instantDungeonExploration: enabled,
+      instantGoldenAcorn: get().instantGoldenAcorn,
+    })
+  },
+
+  setInstantGoldenAcorn: async (enabled: boolean) => {
+    set({ instantGoldenAcorn: enabled })
+    await persist({
+      instantDungeonExploration: get().instantDungeonExploration,
+      instantGoldenAcorn: enabled,
+    })
   },
 }))

--- a/goblin_native/src/presentation/stores/usePurchaseStore.ts
+++ b/goblin_native/src/presentation/stores/usePurchaseStore.ts
@@ -3,6 +3,7 @@ import Purchases, { CustomerInfo, PurchasesPackage } from 'react-native-purchase
 import {
   REVENUECAT_API_KEY,
   ENTITLEMENT_IDS,
+  PURCHASE_PRODUCTS,
   TICKET_TYPES,
   SPEED_HALF_MULTIPLIER,
   SPEED_TWO_THIRDS_MULTIPLIER,
@@ -138,6 +139,20 @@ export const usePurchaseStore = create<PurchaseState & PurchaseActions>()((set, 
         customerInfo,
         entitlements: newEntitlements,
       })
+
+      // Consumable（チケット系）の場合は購入個数を tickets テーブルへ加算
+      const productInfo = PURCHASE_PRODUCTS.find(p => p.packageId === pkg.identifier)
+      if (productInfo?.section === 'ticket' && productInfo.consumableQuantity && productInfo.consumableQuantity > 0) {
+        try {
+          await get().addTickets(
+            productInfo.entitlementId as TicketType,
+            productInfo.consumableQuantity,
+          )
+          console.log(`[Purchase] Granted ${productInfo.consumableQuantity} ${productInfo.entitlementId}`)
+        } catch (grantError) {
+          console.error('[Purchase] Failed to grant consumable tickets:', grantError)
+        }
+      }
 
       console.log('[Purchase] Purchase successful! Active entitlements:', Array.from(newEntitlements))
 
@@ -291,4 +306,8 @@ export const getSpeedTicketCount = (): number => {
 
 export const getBoostTicketCount = (): number => {
   return usePurchaseStore.getState().getTicketCount(TICKET_TYPES.BOOST)
+}
+
+export const getGoldenAcornCount = (): number => {
+  return usePurchaseStore.getState().getTicketCount(TICKET_TYPES.GOLDEN_ACORN)
 }

--- a/goblin_native/src/shared/constants/purchases.ts
+++ b/goblin_native/src/shared/constants/purchases.ts
@@ -52,6 +52,7 @@ export const MONTHLY_PASS_SPEED_MULTIPLIER = 0.8    // 遠征時間倍率（0.8 
 export const TICKET_TYPES = {
   SPEED: 'speed_ticket',
   BOOST: 'boost_ticket',
+  GOLDEN_ACORN: 'golden_acorn',
 } as const
 
 export type TicketType = typeof TICKET_TYPES[keyof typeof TICKET_TYPES]
@@ -59,6 +60,12 @@ export type TicketType = typeof TICKET_TYPES[keyof typeof TICKET_TYPES]
 // チケット効果
 export const SPEED_TICKET_MULTIPLIER = 0.5    // 遠征時間倍率（0.5 = 50%短縮）
 export const BOOST_TICKET_MULTIPLIER = 2.0    // ドロップ率・経験値倍率
+
+// 金のドングリ効果（出撃時に1個消費する Consumable）
+export const GOLDEN_ACORN_SPEED_MULTIPLIER = 0.5   // 探索時間 1/2
+export const GOLDEN_ACORN_GOLD_MULTIPLIER = 2.0    // Gold 倍率 2倍
+export const GOLDEN_ACORN_RARE_MULTIPLIER = 2.0    // レアドロップ倍率 2倍
+export const GOLDEN_ACORN_TITLE_MULTIPLIER = 2.0   // 称号倍率 2倍
 
 // 商品情報（UI表示用 + Package ID → Entitlement ID マッピング）
 export interface PurchaseProduct {
@@ -69,6 +76,11 @@ export interface PurchaseProduct {
   iconName: string         // アイコン名
   section: 'one_time' | 'subscription' | 'ticket'  // 表示セクション
   requiresEntitlement?: string  // この商品を購入するために必要な前提Entitlement
+  /**
+   * Consumable 商品で1回購入したときに付与されるチケット数。
+   * section='ticket' のときに必須。purchasePackage 成功時、entitlementId をキーに tickets テーブルへ加算される。
+   */
+  consumableQuantity?: number
 }
 
 export const PURCHASE_PRODUCTS: PurchaseProduct[] = [
@@ -155,6 +167,7 @@ export const PURCHASE_PRODUCTS: PurchaseProduct[] = [
     descriptionKey: 'shop.speedTicket.description',
     iconName: 'zap',
     section: 'ticket',
+    consumableQuantity: 5,
   },
   {
     packageId: 'boost_ticket_5',
@@ -163,6 +176,44 @@ export const PURCHASE_PRODUCTS: PurchaseProduct[] = [
     descriptionKey: 'shop.boostTicket.description',
     iconName: 'trending-up',
     section: 'ticket',
+    consumableQuantity: 5,
+  },
+  // 金のドングリ（バンドルが大きいほど割安）
+  {
+    packageId: 'golden_acorn_50',
+    entitlementId: TICKET_TYPES.GOLDEN_ACORN,
+    nameKey: 'shop.goldenAcorn.name50',
+    descriptionKey: 'shop.goldenAcorn.description',
+    iconName: 'gift',
+    section: 'ticket',
+    consumableQuantity: 50,
+  },
+  {
+    packageId: 'golden_acorn_100',
+    entitlementId: TICKET_TYPES.GOLDEN_ACORN,
+    nameKey: 'shop.goldenAcorn.name100',
+    descriptionKey: 'shop.goldenAcorn.descriptionDiscount',
+    iconName: 'gift',
+    section: 'ticket',
+    consumableQuantity: 100,
+  },
+  {
+    packageId: 'golden_acorn_200',
+    entitlementId: TICKET_TYPES.GOLDEN_ACORN,
+    nameKey: 'shop.goldenAcorn.name200',
+    descriptionKey: 'shop.goldenAcorn.descriptionDiscount',
+    iconName: 'gift',
+    section: 'ticket',
+    consumableQuantity: 200,
+  },
+  {
+    packageId: 'golden_acorn_500',
+    entitlementId: TICKET_TYPES.GOLDEN_ACORN,
+    nameKey: 'shop.goldenAcorn.name500',
+    descriptionKey: 'shop.goldenAcorn.descriptionDiscount',
+    iconName: 'gift',
+    section: 'ticket',
+    consumableQuantity: 500,
   },
 ]
 

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -300,6 +300,10 @@ const en = {
         abortConfirmTitle: 'Confirm Return',
         abortConfirmBody: 'End the expedition early.\nGold and items will be lost.\nExperience and HP status will be kept.',
         abortConfirmOk: 'Return',
+        goldenAcornBulkPromptTitle: 'Use Golden Acorns?',
+        goldenAcornBulkPromptBody: 'Spend {{count}} acorns to halve travel time and double Gold, rare drops, and titles for each party.\n{{remaining}} remaining',
+        goldenAcornBulkUseAndStart: 'Use for All & Dispatch',
+        goldenAcornBulkStartWithout: 'Dispatch Without',
       },
       preparation: {
         title: 'Expedition Prep',
@@ -336,6 +340,10 @@ const en = {
         startFailedTitle: 'Expedition failed',
         startFailedBody: 'An error occurred when starting the expedition',
         pendingOverflowBody: 'Pending slots are full. If a goblin is added after a successful expedition, it may be discarded. Dispatch anyway?',
+        goldenAcornPromptTitle: 'Use a Golden Acorn?',
+        goldenAcornPromptBody: 'Halves travel time and doubles Gold, rare drops, and titles.\n{{count}} remaining',
+        goldenAcornUseAndStart: 'Use and Dispatch',
+        goldenAcornStartWithout: 'Dispatch Without',
       },
       edit: {
         title: 'Edit Members',
@@ -808,6 +816,14 @@ const en = {
     boostTicket: {
       name: 'Boost Ticket x5',
       description: '5 tickets that double drop rate and EXP',
+    },
+    goldenAcorn: {
+      name50: 'Golden Acorn x50',
+      name100: 'Golden Acorn x100 (Discount)',
+      name200: 'Golden Acorn x200 (Better Deal)',
+      name500: 'Golden Acorn x500 (Best Deal)',
+      description: '{{count}} pack. Consume one before an expedition: travel time 1/2, Gold/rare/title 2x.',
+      descriptionDiscount: '{{count}} pack at a better per-acorn price. Travel time 1/2, Gold/rare/title 2x.',
     },
   },
 } as const

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -300,6 +300,10 @@ const ja = {
         abortConfirmTitle: '帰還確認',
         abortConfirmBody: '遠征を途中で終了します。\nGold・アイテムは持ち帰れません。\n経験値とHP状態は維持されます。',
         abortConfirmOk: '帰還する',
+        goldenAcornBulkPromptTitle: '金のドングリを使う？',
+        goldenAcornBulkPromptBody: '{{count}}PT分（{{count}}個）を消費し、各PTの探索時間 1/2、Gold・レア・称号 2倍 で出撃します。\n残り {{remaining}} 個',
+        goldenAcornBulkUseAndStart: '全PTで使用して出撃',
+        goldenAcornBulkStartWithout: '使わずに出撃',
       },
       preparation: {
         title: '冒険準備',
@@ -336,6 +340,10 @@ const ja = {
         startFailedTitle: '遠征に失敗しました',
         startFailedBody: '遠征開始時にエラーが発生しました',
         pendingOverflowBody: '待機枠がいっぱいです。遠征に成功してゴブリンが追加された場合、受け取れず破棄される可能性があります。出撃しますか？',
+        goldenAcornPromptTitle: '金のドングリを使う？',
+        goldenAcornPromptBody: '探索時間 1/2、Gold・レア・称号倍率がすべて 2倍 になります。\n残り {{count}} 個',
+        goldenAcornUseAndStart: '使用して出発',
+        goldenAcornStartWithout: '使わずに出発',
       },
       edit: {
         title: 'メンバー編集',
@@ -848,6 +856,14 @@ const ja = {
     boostTicket: {
       name: 'ブーストチケット×5',
       description: 'ドロップ率・経験値が2倍になるチケット5枚',
+    },
+    goldenAcorn: {
+      name50: '金のドングリ ×50',
+      name100: '金のドングリ ×100（お得）',
+      name200: '金のドングリ ×200（さらにお得）',
+      name500: '金のドングリ ×500（最もお得）',
+      description: '{{count}}個セット。出発時に1個消費すると、探索時間1/2・Gold/レア/称号倍率がすべて2倍に。',
+      descriptionDiscount: '{{count}}個セット。1個あたりの単価がお得！ 探索時間1/2、Gold/レア/称号倍率がすべて2倍。',
     },
   },
 } as const

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -61,14 +61,17 @@ export type TimelineEvent =
   | { type: "return"; at: number; reason: ExpeditionEndReason }
 
 /**
- * 出撃時に消費する課金/補助アイテムによるブースト設定。
- * 現状はレアドロップの確率倍率のみ用意。今後「探索時間1/2」「称号付与倍率2倍」を追加予定。
+ * 出撃時に消費する課金/補助アイテム（金のドングリ等）によるブースト設定。
+ * 探索時間の短縮は ExpeditionRequest.durationSec 計算時点で適用するため、ここでは扱わない。
  *
- * - rareDropMultiplier: 1 を基準に乗算する倍率。レアドロップ判定にのみ適用される。
- *   未指定または 1 の場合はブーストなし。
+ * - rareDropMultiplier: レアドロップ判定の倍率（1 で無効）
+ * - goldMultiplier: 戦闘で得られる Gold の倍率（1 で無効）
+ * - titleMultiplier: 装備に付与される称号の倍率（1 で無効）
  */
 export interface ExpeditionBoost {
   rareDropMultiplier?: number
+  goldMultiplier?: number
+  titleMultiplier?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- 出発時に1個消費すると探索時間1/2・Gold/レア/称号倍率2倍で遠征できる Consumable「金のドングリ」を追加。
- RevenueCat 商品は 50/100/200/500 個の4バンドル（量が多いほど割安）に分割し、`PurchaseProduct.consumableQuantity` を見て購入成功時に tickets テーブルへ自動加算する仕組みを共通化（既存 speed/boost ticket も同フローに乗る）。
- 単発出撃 (`preparation.tsx`) では残数 ≥ 1 で「使用して出発／使わずに出発／キャンセル」、一括出撃 (`formation/index.tsx`) では残数 ≥ 出撃PT数のときに同等の Alert を出して全PTで1個ずつ消費。

## 主な変更点
- `ExpeditionBoost` に `goldMultiplier` / `titleMultiplier` を追加。`ExpeditionEngine.calculateRewardSummary` / `rollTreasureDrops` に boost を伝播。
- `estimateExplorationTime` に `goldenAcornUsed` を追加し、0.5 倍を従来の倍率に乗算。
- `useExpeditionFlow` の `startExpedition` / `startBulkExpedition` でドングリの消費・失敗時ロールバックを実装。
- デバッグフラグ `instantGoldenAcorn`（消費せず効果適用）を `useDebugSettingsStore` に追加。
- i18n: `shop.goldenAcorn` を `name50/100/200/500 + description/descriptionDiscount` に再構成。preparation/index に確認 Alert 文言を追加。
- テスト: `goldMultiplierBoost = 2.0` で gold 報酬が 2 倍になるケースを追加。

## ストア側の作業（コード外）
- App Store Connect / Google Play / RevenueCat ダッシュボードに4バンドルを Consumable として登録。
  - `golden_acorn_50` / `golden_acorn_100` / `golden_acorn_200` / `golden_acorn_500`
  - 単価が `50 → 500` で割安になるよう価格を設定（例: 100% / 95% / 90% / 80%）。
- Entitlement / Ticket type は4種共通で `golden_acorn`。

## Test plan
- [ ] `npx tsc --noEmit` 通過 ✅
- [ ] `npx jest` 全 369 テスト通過 ✅
- [ ] 単発出撃: 残数 0 / 1 / 複数 で Alert の出方を実機確認
- [ ] 一括出撃: 残数 < PT数 / 残数 ≥ PT数 で Alert の出方を実機確認
- [ ] 金のドングリ使用ON/OFFで探索時間・Gold/レア/称号がそれぞれ期待通り変動すること
- [ ] 緊急帰還しても消費分が戻らないこと
- [ ] デバッグフラグ `instantGoldenAcorn=true` で残数を消費せず効果適用されること
- [ ] RevenueCat テストモードで4バンドルそれぞれ購入し、tickets テーブルに正しい個数加算されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)