### PR TITLE
feat(story): 全ストーリーの読了報酬に金のドングリ5個を設定し残数バッジを追加

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -10,6 +10,7 @@ import StoryIcon from '../../assets/tab/tab_story.svg'
 import SettingIcon from '../../assets/tab/tab_setting.svg'
 import { CurrentTimeBadge } from '@/presentation/components/CurrentTimeBadge'
 import { GoldBadge } from '@/presentation/components/GoldBadge'
+import { GoldenAcornBadge } from '@/presentation/components/GoldenAcornBadge'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
 
 interface TabIconProps {
@@ -107,6 +108,7 @@ export default function TabLayout() {
       />
     </Tabs>
     <CurrentTimeBadge bottom={baseHeight + safeAreaPadding + 8} />
+    <GoldenAcornBadge bottom={baseHeight + safeAreaPadding + 8} />
     <GoldBadge bottom={baseHeight + safeAreaPadding + 8} />
     </View>
   )

--- a/goblin_native/src/presentation/components/GoldenAcornBadge.tsx
+++ b/goblin_native/src/presentation/components/GoldenAcornBadge.tsx
@@ -1,0 +1,46 @@
+import { memo } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { usePurchaseStore } from '@/presentation/stores/usePurchaseStore'
+import { TICKET_TYPES } from '@/shared/constants/purchases'
+
+interface GoldenAcornBadgeProps {
+  bottom: number
+}
+
+export const GoldenAcornBadge = memo(function GoldenAcornBadge({ bottom }: GoldenAcornBadgeProps) {
+  const { t } = useTranslation()
+  const count = usePurchaseStore((state) => {
+    const ticket = state.tickets.find(tk => tk.ticketType === TICKET_TYPES.GOLDEN_ACORN)
+    return ticket?.quantity ?? 0
+  })
+
+  return (
+    <View style={styles.wrapper} pointerEvents="none">
+      <View style={[styles.badge, { bottom }]}>
+        <Text style={styles.text}>{t('ui.common.goldenAcornBadge', { count })}</Text>
+      </View>
+    </View>
+  )
+})
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+  },
+  badge: {
+    position: 'absolute',
+    backgroundColor: 'rgba(120, 53, 15, 0.85)',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  text: {
+    fontSize: 11,
+    color: '#FEF3C7',
+  },
+})

--- a/goblin_native/src/presentation/stores/useStoryStore.ts
+++ b/goblin_native/src/presentation/stores/useStoryStore.ts
@@ -1,8 +1,10 @@
 import { create } from 'zustand'
 import { SQLiteStoryProgressRepository } from '../../infrastructure/repositories/SQLiteStoryProgressRepository'
 import { storiesData } from '../../shared/data/story'
+import { TICKET_TYPES } from '../../shared/constants/purchases'
 import type { Story } from '../../shared/types/Story'
 import type { StoryProgressState } from '../../shared/types/StoryProgress'
+import { usePurchaseStore } from './usePurchaseStore'
 
 const repository = SQLiteStoryProgressRepository.getInstance()
 
@@ -87,7 +89,23 @@ export const useStoryStore = create<StoryStoreState & StoryStoreActions>()((set,
     },
 
     markStoryRead: async (storyId: string) => {
+      // 既読への遷移時のみ報酬を付与（再読での重複付与を防ぐ）
+      const wasUnread = !get().progress[storyId]?.read
       await repository.markRead(storyId)
+      if (wasUnread) {
+        const story = storiesData.find(s => s.id === storyId)
+        if (story) {
+          for (const reward of story.rewards) {
+            if (reward.type === 'golden_acorn' && typeof reward.value === 'number' && reward.value > 0) {
+              try {
+                await usePurchaseStore.getState().addTickets(TICKET_TYPES.GOLDEN_ACORN, reward.value)
+              } catch (error) {
+                console.error('[Story] Failed to grant golden acorn reward:', error)
+              }
+            }
+          }
+        }
+      }
       await refresh()
     },
   }

--- a/goblin_native/src/shared/data/story/stories.json
+++ b/goblin_native/src/shared/data/story/stories.json
@@ -6,7 +6,7 @@
       "category": "main",
       "order": 0,
       "unlockCondition": null,
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "prologue_1",
@@ -24,7 +24,7 @@
       "category": "main",
       "order": 1,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "slime_cave" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_slime_cave_1",
@@ -38,7 +38,7 @@
       "category": "main",
       "order": 2,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "forest_outskirts" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_forest_1",
@@ -52,7 +52,7 @@
       "category": "main",
       "order": 3,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "goblin_village_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_goblin_village_1",
@@ -66,7 +66,7 @@
       "category": "main",
       "order": 4,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "undead_ruins_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_ruins_1",
@@ -80,7 +80,7 @@
       "category": "main",
       "order": 5,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "road_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_road_1",
@@ -94,7 +94,7 @@
       "category": "main",
       "order": 6,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "orc_camp_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_orc_camp_1",
@@ -108,7 +108,7 @@
       "category": "main",
       "order": 7,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "human_village" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_village_1",
@@ -122,7 +122,7 @@
       "category": "main",
       "order": 8,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "wolf_grassland_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_wolf_grassland_1",
@@ -136,7 +136,7 @@
       "category": "main",
       "order": 9,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "lizardman_swamp_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_lizardman_swamp_1",
@@ -150,7 +150,7 @@
       "category": "main",
       "order": 10,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "subjugation_force_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_subjugation_1",
@@ -164,7 +164,7 @@
       "category": "main",
       "order": 11,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "spider_forest_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_spider_forest_1",
@@ -178,7 +178,7 @@
       "category": "main",
       "order": 12,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "dead_grave_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_dead_grave_1",
@@ -192,7 +192,7 @@
       "category": "main",
       "order": 13,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "harpy_cliff_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_harpy_cliff_1",
@@ -206,7 +206,7 @@
       "category": "main",
       "order": 14,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "human_fortress_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_fortress_1",
@@ -220,7 +220,7 @@
       "category": "main",
       "order": 15,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "vampire_castle_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_vampire_1",
@@ -234,7 +234,7 @@
       "category": "main",
       "order": 16,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "royal_capital_2" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_after_royal_capital_2_1",
@@ -248,7 +248,7 @@
       "category": "main",
       "order": 17,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "royal_capital_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "story_ending_1",
@@ -266,7 +266,7 @@
       "category": "side",
       "order": 100,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "orc_fortress_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_orc_fortress_1",
@@ -280,7 +280,7 @@
       "category": "side",
       "order": 101,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "hobbit_hills_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_hobbit_hills_1",
@@ -294,7 +294,7 @@
       "category": "side",
       "order": 102,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "dwarf_mine_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_dwarf_mine_1",
@@ -308,7 +308,7 @@
       "category": "side",
       "order": 103,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "elf_forest_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_elf_forest_1",
@@ -322,7 +322,7 @@
       "category": "side",
       "order": 104,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "lizardman_swamp_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_lizardman_swamp_1",
@@ -336,7 +336,7 @@
       "category": "side",
       "order": 105,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "troll_canyon_3" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_troll_canyon_1",
@@ -350,7 +350,7 @@
       "category": "side",
       "order": 106,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "minotaur_labyrinth_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_minotaur_1",
@@ -364,7 +364,7 @@
       "category": "side",
       "order": 107,
       "unlockCondition": { "type": "dungeon_cleared", "dungeonId": "harpy_cliff_1" },
-      "rewards": [],
+      "rewards": [{ "type": "golden_acorn", "value": 5 }],
       "chapters": [
         {
           "id": "side_harpy_cliff_1",

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -12,6 +12,7 @@ const en = {
       settings: 'Settings',
       goldSuffix: 'G',
       levelShort: 'Lv.',
+      goldenAcornBadge: 'Acorn {{count}}',
     },
     tabs: {
       story: 'Story',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -12,6 +12,7 @@ const ja = {
       settings: '設定',
       goldSuffix: 'G',
       levelShort: 'Lv.',
+      goldenAcornBadge: 'ﾄﾞﾝｸﾞﾘ {{count}}',
     },
     tabs: {
       story: '物語',

--- a/goblin_native/src/shared/types/Story.ts
+++ b/goblin_native/src/shared/types/Story.ts
@@ -6,7 +6,7 @@ export type StoryUnlockCondition = {
 }
 
 export type StoryReward = {
-  type: 'gold' | 'goblin' | 'equipment'
+  type: 'gold' | 'goblin' | 'equipment' | 'golden_acorn'
   value: number | string
 }
 


### PR DESCRIPTION
## Summary
- 全ストーリー（全26件）の読了報酬として金のドングリ 5個を設定
- `StoryReward.type` に `'golden_acorn'` を追加し、`useStoryStore.markStoryRead` で未読→既読への遷移時のみ報酬を付与（再読での重複付与を防止）
- 画面下部に `GoldenAcornBadge` を新設し、`CurrentTimeBadge`（左）／`GoldenAcornBadge`（中央）／`GoldBadge`（右）として残数を常時表示

## 変更ファイル
- `src/shared/types/Story.ts` — `StoryReward.type` に `'golden_acorn'` を追加
- `src/shared/data/story/stories.json` — 全 26 件の `rewards` に `{ type: 'golden_acorn', value: 5 }` を設定
- `src/presentation/stores/useStoryStore.ts` — 読了遷移時のみ `usePurchaseStore.addTickets(GOLDEN_ACORN, value)` を呼び出し
- `src/presentation/components/GoldenAcornBadge.tsx` — 新規（中央寄せの残数バッジ）
- `app/(tabs)/_layout.tsx` — `GoldenAcornBadge` を配置
- `src/shared/i18n/resources/{ja,en}.ts` — `ui.common.goldenAcornBadge` を追加

## Test plan
- [ ] 未読ストーリーを最後まで読み「読了」をタップして金のドングリ残数が +5 されること
- [ ] 既読ストーリーを再度開いても残数が増えないこと
- [ ] スキップで読了した場合も +5 されること
- [ ] 画面下部のタブバー上に時刻 / ドングリ残数 / Gold が並んで常時表示されること
- [ ] 言語切替（ja/en）でラベルが切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)