### PR TITLE
feat(start): 起動直後からスタート画面を表示し初期化完了後に遷移

### DIFF
--- a/goblin_native/app/_layout.tsx
+++ b/goblin_native/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { View, ActivityIndicator, Text, StyleSheet, Pressable, Platform, AppState } from 'react-native'
 import { Stack, router } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
@@ -26,8 +26,11 @@ export default function RootLayout() {
   const { t } = useTranslation()
   const { ready, error, reloadKey, resetAndReinitialize, reloadAfterImport } = useDatabaseInit()
   const [storesReady, setStoresReady] = useState(false)
+  const [showLaunchStartScreen, setShowLaunchStartScreen] = useState(true)
+  const [launchStartRequested, setLaunchStartRequested] = useState(false)
   const tutorialStep = useTutorialStore(state => state.step)
   const tutorialLoading = useTutorialStore(state => state.isLoading)
+  const startupReady = ready && storesReady && !tutorialLoading
 
   useEffect(() => {
     if (!ready) {
@@ -81,6 +84,25 @@ export default function RootLayout() {
     return () => subscription.remove()
   }, [])
 
+  const handleLaunchStart = useCallback(() => {
+    setLaunchStartRequested(true)
+  }, [])
+
+  useEffect(() => {
+    if (!launchStartRequested || !startupReady) return
+
+    const enterGame = async () => {
+      if (tutorialStep === 'not_started') {
+        await useTutorialStore.getState().advanceTo('read_prologue')
+        router.replace('/(tabs)/story')
+      }
+      setShowLaunchStartScreen(false)
+      setLaunchStartRequested(false)
+    }
+
+    void enterGame()
+  }, [launchStartRequested, startupReady, tutorialStep])
+
   if (error) {
     return (
       <SafeAreaProvider>
@@ -91,6 +113,20 @@ export default function RootLayout() {
           </Pressable>
         </View>
       </SafeAreaProvider>
+    )
+  }
+
+  if (showLaunchStartScreen) {
+    return (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <StartScreen
+            onStart={handleLaunchStart}
+            starting={launchStartRequested}
+          />
+          <StatusBar style="light" />
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
     )
   }
 
@@ -109,7 +145,13 @@ export default function RootLayout() {
     return (
       <GestureHandlerRootView style={{ flex: 1 }}>
         <SafeAreaProvider>
-          <StartScreen onStart={() => router.replace('/(tabs)/story')} />
+          <StartScreen
+            onStart={() => {
+              void useTutorialStore.getState().advanceTo('read_prologue').then(() => {
+                router.replace('/(tabs)/story')
+              })
+            }}
+          />
           <StatusBar style="light" />
         </SafeAreaProvider>
       </GestureHandlerRootView>

--- a/goblin_native/src/presentation/components/StartScreen.tsx
+++ b/goblin_native/src/presentation/components/StartScreen.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   View,
   Text,
@@ -9,28 +8,20 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
-import { useTutorialStore } from '../stores/useTutorialStore'
 
 const startBackgroundImage = require('../../../assets/images/start-background.png')
 
 interface StartScreenProps {
   onStart?: () => void
+  starting?: boolean
 }
 
-export function StartScreen({ onStart }: StartScreenProps) {
+export function StartScreen({ onStart, starting = false }: StartScreenProps) {
   const { t } = useTranslation()
-  const advanceTo = useTutorialStore(state => state.advanceTo)
-  const [starting, setStarting] = useState(false)
 
-  const handleStart = async () => {
+  const handleStart = () => {
     if (starting) return
-    setStarting(true)
-    try {
-      await advanceTo('read_prologue')
-      onStart?.()
-    } finally {
-      setStarting(false)
-    }
+    onStart?.()
   }
 
   return (
@@ -40,7 +31,6 @@ export function StartScreen({ onStart }: StartScreenProps) {
       resizeMode="cover"
     >
       <View style={styles.topScrim} />
-      <View style={styles.bottomScrim} />
       <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
         <View style={styles.content}>
           <View style={styles.header}>
@@ -49,22 +39,24 @@ export function StartScreen({ onStart }: StartScreenProps) {
           </View>
 
           <View style={styles.footer}>
-            <Pressable
-              style={({ pressed }) => [
-                styles.startButton,
-                pressed && styles.startButtonPressed,
-                starting && styles.startButtonDisabled,
-              ]}
-              onPress={handleStart}
-              disabled={starting}
-            >
-              {starting ? (
-                <ActivityIndicator color="#1F2937" />
-              ) : (
-                <Text style={styles.startButtonText}>{t('ui.start.beginButton')}</Text>
-              )}
-            </Pressable>
-            <Text style={styles.tagline}>{t('ui.start.tagline')}</Text>
+            <View style={styles.buttonScrim}>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.startButton,
+                  pressed && styles.startButtonPressed,
+                  starting && styles.startButtonDisabled,
+                ]}
+                onPress={handleStart}
+                disabled={starting}
+              >
+                {starting ? (
+                  <ActivityIndicator color="#1F2937" />
+                ) : (
+                  <Text style={styles.startButtonText}>{t('ui.start.beginButton')}</Text>
+                )}
+              </Pressable>
+              <Text style={styles.tagline}>{t('ui.start.tagline')}</Text>
+            </View>
           </View>
         </View>
       </SafeAreaView>
@@ -93,14 +85,6 @@ const styles = StyleSheet.create({
     height: 230,
     backgroundColor: 'rgba(6, 12, 24, 0.28)',
   },
-  bottomScrim: {
-    position: 'absolute',
-    right: 0,
-    bottom: 0,
-    left: 0,
-    height: 300,
-    backgroundColor: 'rgba(3, 8, 18, 0.56)',
-  },
   header: {
     alignItems: 'center',
     marginTop: 48,
@@ -127,6 +111,12 @@ const styles = StyleSheet.create({
   footer: {
     alignItems: 'center',
     paddingBottom: 26,
+  },
+  buttonScrim: {
+    width: '100%',
+    borderRadius: 22,
+    backgroundColor: 'rgba(3, 8, 18, 0.34)',
+    padding: 10,
   },
   startButton: {
     width: '100%',


### PR DESCRIPTION
## Summary
- 起動直後にスプラッシュ/初期化画面ではなく `StartScreen` を最初に描画するように変更
- 「はじめる」押下後に DB・stores・チュートリアル初期化の完了を待ってから次画面へ遷移
- `StartScreen` はボタン背後にスクリム枠を追加し、`starting` 状態を親 (`_layout.tsx`) から制御するよう整理

## Test plan
- [ ] 初回起動時、スプラッシュ → スタート画面が表示されること
- [ ] 「はじめる」ボタン押下時にローディング表示 (ActivityIndicator) が出ること
- [ ] 初期化完了後にチュートリアル開始 (`/(tabs)/story`) へ遷移すること
- [ ] チュートリアル完了済みのユーザーは通常のホーム画面へ遷移すること
- [ ] アプリをバックグラウンド→復帰した際の挙動に異常がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)