### PR TITLE
feat(goblin): 始祖ゴブリンを訓練対象外にしテストを更新

### DIFF
--- a/goblin_native/src/shared/data/__tests__/goblinJobs.test.ts
+++ b/goblin_native/src/shared/data/__tests__/goblinJobs.test.ts
@@ -36,9 +36,12 @@ function createGoblin(overrides: Partial<Goblin> = {}): Goblin {
 describe('goblinJobs', () => {
   it('純ゴブリンのみ訓練対象になる', () => {
     expect(canTrainGoblin(createGoblin({ race: 'ゴブリン' }))).toBe(true)
-    expect(canTrainGoblin(createGoblin({ race: '始祖ゴブリン', raceId: 'founder' }))).toBe(true)
     expect(canTrainGoblin(createGoblin({ race: 'スライムゴブリン' }))).toBe(false)
     expect(canTrainGoblin(createGoblin({ race: 'ウルフゴブリン' }))).toBe(false)
+  })
+
+  it('始祖ゴブリンは訓練対象にならない', () => {
+    expect(canTrainGoblin(createGoblin({ id: 0, race: '始祖ゴブリン', raceId: 'founder' }))).toBe(false)
   })
 
   it('ジョブ変更時に種族スキルとジョブスキルを再構成し、その他のスキルは保持する', () => {

--- a/goblin_native/src/shared/data/goblinJobs.ts
+++ b/goblin_native/src/shared/data/goblinJobs.ts
@@ -5,6 +5,7 @@ import { syncGoblinDerivedStats } from '../utils/goblinStats'
 import { getGoblinBaseAttributes } from '../utils/goblinHp'
 import { getCharacterSkill, type CharacterSkillId } from './skillCatalog'
 import { isBaseGoblinRaceId, normalizeGoblinRaceId } from '../types/Race'
+import { isProtectedGoblin } from '../utils/goblinProtection'
 import {
   getGoblinJobDescription,
   getGoblinJobLabel,
@@ -223,7 +224,7 @@ export function isPureGoblin(goblin: Goblin): boolean {
 }
 
 export function canTrainGoblin(goblin: Goblin): boolean {
-  return isPureGoblin(goblin)
+  return isPureGoblin(goblin) && !isProtectedGoblin(goblin)
 }
 
 export function getGoblinJobSkills(job: GoblinJob, level: number): CharacterSkill[] {


### PR DESCRIPTION
## Summary
- `canTrainGoblin` を保護対象ゴブリン（始祖ゴブリン含む）が訓練対象外となるよう修正
- 関連テストを始祖ゴブリンが訓練不可である挙動に合わせて更新

## Test plan
- [ ] `npm test -- goblinJobs` がパスすること
- [ ] `npx tsc --noEmit` が通ること
- [ ] 始祖ゴブリン「マルク」が訓練不可になっていることを実機で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)