### PR TITLE
feat(formation): 編成画面のレア度/称号倍率にPTスキル補正を反映

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -15,7 +15,11 @@ import { useTutorialStore } from '@/presentation/stores/useTutorialStore'
 import { useTutorialTarget } from '@/presentation/hooks/useTutorialTarget'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getPartyEffectiveStats } from '@/shared/utils/goblinStats'
-import { getGoldBonusPercentFromSkills } from '@/shared/data/characterSkills'
+import {
+  getGoldBonusPercentFromSkills,
+  getPartyRareMultiplierFromSkills,
+  getPartyTitleMultiplierFromSkills,
+} from '@/shared/data/characterSkills'
 import { normalizePartyRewardMultipliers } from '@/shared/types'
 import type { Party, Goblin, Dungeon, DungeonTier, ExpeditionRequest, ExpeditionRecord } from '@/shared/types'
 
@@ -101,11 +105,19 @@ const PartyCard = memo(function PartyCard({
       (max, member) => Math.max(max, getGoldBonusPercentFromSkills(member.skills)),
       0,
     )
+    const skillRareMultiplier = members.reduce(
+      (product, member) => product * getPartyRareMultiplierFromSkills(member.skills),
+      1,
+    )
+    const skillTitleMultiplier = members.reduce(
+      (product, member) => product * getPartyTitleMultiplierFromSkills(member.skills),
+      1,
+    )
     const goldMultiplier = multipliers.gold * (1 + maxGoldBonusPercent / 100)
     return t('ui.formation.index.rewardText', {
       gold: formatMultiplier(goldMultiplier),
-      rare: formatMultiplier(multipliers.rare),
-      title: formatMultiplier(multipliers.title),
+      rare: formatMultiplier(multipliers.rare * skillRareMultiplier),
+      title: formatMultiplier(multipliers.title * skillTitleMultiplier),
     })
   }, [party.rewardMultipliers, members, t])
 

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -12,7 +12,11 @@ import { useExpeditionFlow } from '@/presentation/hooks/useExpeditionFlow'
 import { getGoldenAcornCount } from '@/presentation/stores/usePurchaseStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getPartyEffectiveStats } from '@/shared/utils/goblinStats'
-import { getGoldBonusPercentFromSkills } from '@/shared/data/characterSkills'
+import {
+  getGoldBonusPercentFromSkills,
+  getPartyRareMultiplierFromSkills,
+  getPartyTitleMultiplierFromSkills,
+} from '@/shared/data/characterSkills'
 import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '@/shared/types'
 import type { ExpeditionRequest, Goblin, Dungeon, Party, DungeonTier } from '@/shared/types'
 import { getDungeonDescription, getDungeonName, getReturnPolicyLabel } from '@/shared/i18n/entityLocalization'
@@ -187,11 +191,19 @@ export default function ExpeditionPreparationScreen() {
       (max, member) => Math.max(max, getGoldBonusPercentFromSkills(member.skills)),
       0,
     )
+    const skillRareMultiplier = partyMembers.reduce(
+      (product, member) => product * getPartyRareMultiplierFromSkills(member.skills),
+      1,
+    )
+    const skillTitleMultiplier = partyMembers.reduce(
+      (product, member) => product * getPartyTitleMultiplierFromSkills(member.skills),
+      1,
+    )
     const goldMultiplier = multipliers.gold * (1 + maxGoldBonusPercent / 100)
     return t('ui.formation.preparation.rewardText', {
       gold: formatMultiplier(goldMultiplier),
-      rare: formatMultiplier(multipliers.rare),
-      title: formatMultiplier(multipliers.title),
+      rare: formatMultiplier(multipliers.rare * skillRareMultiplier),
+      title: formatMultiplier(multipliers.title * skillTitleMultiplier),
     })
   }, [party, partyMembers, t])
 


### PR DESCRIPTION
## Summary
- 編成一覧 (`app/(tabs)/formation/index.tsx`) と遠征準備画面 (`app/(tabs)/formation/preparation.tsx`) で、PTメンバーの `getPartyRareMultiplierFromSkills` / `getPartyTitleMultiplierFromSkills` をレア度倍率・称号倍率の表示に乗算するよう変更
- 直近導入したPT報酬倍率系スキル（異常固体マルク等）の効果を、報酬テキストに正しく反映するための表示修正

## Test plan
- [ ] `npx tsc --noEmit` で型エラーがないこと
- [ ] 編成一覧でPT報酬倍率系スキル持ちを含む/含まないPTのレア度/称号倍率表示が期待どおりであること
- [ ] 遠征準備画面でも同様にレア度/称号倍率の倍率表示が反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)