### PR TITLE
feat(skill): 純ゴブリン誕生時の継承・発現スキル抽選システムを追加

### DIFF
--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -15,6 +15,27 @@ import type { Goblin } from '@/shared/types'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import { isProtectedGoblin } from '@/shared/utils/goblinProtection'
+import { getFactorImage } from '@/shared/utils/factorImages'
+import { getFactor } from '@/shared/data/factors'
+import { getDefaultSkillsForRace } from '@/shared/data/raceSkills'
+import { getUniqueSkillsById } from '@/shared/data/characterSkills'
+import { GOBLIN_JOB_SKILL_IDS } from '@/shared/data/goblinJobs'
+import { EQUIPMENT_GRANTED_SKILL_IDS } from '@/shared/data/equipmentPoolLoader'
+import { getFactorName, getSkillLabel } from '@/shared/i18n/entityLocalization'
+
+function getCardUniqueSkills(goblin: Goblin) {
+  const raceSkillIds = new Set(
+    getDefaultSkillsForRace(goblin.raceId ?? goblin.race).map((skill) => skill.id),
+  )
+
+  return getUniqueSkillsById(goblin.skills).filter(
+    (skill) => (
+      !raceSkillIds.has(skill.id) &&
+      !GOBLIN_JOB_SKILL_IDS.has(skill.id) &&
+      !EQUIPMENT_GRANTED_SKILL_IDS.has(skill.id)
+    ),
+  )
+}
 
 export default function GoblinListScreen() {
   const { t } = useTranslation()
@@ -276,6 +297,12 @@ export default function GoblinListScreen() {
         </View>
         {pendingGoblins.map((goblin) => {
           const effectiveStats = getEffectiveStats(goblin)
+          const factorIds = goblin.factors ?? []
+          const visibleFactorIds = factorIds.slice(0, 2)
+          const extraFactorCount = Math.max(0, factorIds.length - visibleFactorIds.length)
+          const uniqueSkills = getCardUniqueSkills(goblin)
+          const visibleSkills = uniqueSkills.slice(0, 3)
+          const extraSkillCount = Math.max(0, uniqueSkills.length - visibleSkills.length)
           return (
             <View key={goblin.id} style={styles.pendingCard}>
               <View style={styles.pendingRow}>
@@ -290,6 +317,40 @@ export default function GoblinListScreen() {
                     <Text style={styles.pendingStats}>
                       HP{effectiveStats.hp} / A{effectiveStats.atk} / D{effectiveStats.def} / 命{effectiveStats.accuracy}
                     </Text>
+                    {(factorIds.length > 0 || uniqueSkills.length > 0) && (
+                      <View style={styles.pendingTraitRows}>
+                        {factorIds.length > 0 && (
+                          <View style={styles.pendingTraitRow}>
+                            {visibleFactorIds.map((factorId, index) => {
+                              const FactorIcon = getFactorImage(factorId)
+                              return (
+                                <View key={`${factorId}-${index}`} style={styles.pendingFactorChip}>
+                                  <FactorIcon width={13} height={13} />
+                                  <Text style={styles.pendingFactorChipText} numberOfLines={1}>
+                                    {getFactorName(getFactor(factorId) ?? { id: factorId, name: factorId })}
+                                  </Text>
+                                </View>
+                              )
+                            })}
+                            {extraFactorCount > 0 && (
+                              <Text style={styles.pendingMoreChip}>+{extraFactorCount}</Text>
+                            )}
+                          </View>
+                        )}
+                        {uniqueSkills.length > 0 && (
+                          <View style={styles.pendingTraitRow}>
+                            {visibleSkills.map((skill) => (
+                              <Text key={skill.id} style={styles.pendingSkillChip} numberOfLines={1}>
+                                {getSkillLabel(skill)}
+                              </Text>
+                            ))}
+                            {extraSkillCount > 0 && (
+                              <Text style={styles.pendingMoreChip}>+{extraSkillCount}</Text>
+                            )}
+                          </View>
+                        )}
+                      </View>
+                    )}
                   </View>
                 </TouchableOpacity>
                 {hasCapacity && (
@@ -548,6 +609,7 @@ const styles = StyleSheet.create({
   },
   pendingInfo: {
     flex: 1,
+    minWidth: 0,
   },
   pendingName: {
     fontSize: 14,
@@ -558,6 +620,50 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: '#6B7280',
     marginTop: 1,
+  },
+  pendingTraitRows: {
+    marginTop: 4,
+    gap: 3,
+  },
+  pendingTraitRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 3,
+  },
+  pendingFactorChip: {
+    maxWidth: 104,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    backgroundColor: '#EEF2FF',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  pendingFactorChipText: {
+    flexShrink: 1,
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#4338CA',
+  },
+  pendingSkillChip: {
+    maxWidth: 128,
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#065F46',
+    backgroundColor: '#ECFDF5',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  pendingMoreChip: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#6B7280',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
   },
   addButton: {
     backgroundColor: '#374151',

--- a/goblin_native/src/core/services/BirthSkillService.ts
+++ b/goblin_native/src/core/services/BirthSkillService.ts
@@ -1,0 +1,63 @@
+import { getCharacterSkill } from '../../shared/data/skillCatalog'
+import {
+  factorSkillInheritanceRules,
+  pureGoblinSkillManifestationRules,
+  PURE_GOBLIN_BIRTH_SKILL_SLOT_MAX,
+  type BirthSkillLotteryEntry,
+} from '../../shared/data/skillBirthRules'
+import type { CharacterSkill } from '../../shared/types/CharacterSkill'
+
+interface RollPureGoblinBirthSkillsOptions {
+  inheritedFactorIds: string[]
+  baseRank?: number
+  existingSkillIds?: Iterable<string>
+  rng: () => number
+}
+
+export class BirthSkillService {
+  static rollPureGoblinBirthSkills({
+    inheritedFactorIds,
+    baseRank,
+    existingSkillIds = [],
+    rng,
+  }: RollPureGoblinBirthSkillsOptions): CharacterSkill[] {
+    const inheritedCandidates = inheritedFactorIds.flatMap(
+      (factorId) => factorSkillInheritanceRules[factorId]?.skills ?? [],
+    )
+    const manifestedCandidates = baseRank === undefined
+      ? []
+      : pureGoblinSkillManifestationRules
+          .filter((rule) => rule.baseRank <= baseRank)
+          .flatMap((rule) => rule.skills)
+
+    if (inheritedCandidates.length === 0 && manifestedCandidates.length === 0) {
+      return []
+    }
+
+    const slotCount = PURE_GOBLIN_BIRTH_SKILL_SLOT_MAX
+    const selectedSkillIds = new Set(existingSkillIds)
+    const birthSkillIds: string[] = []
+
+    this.rollCandidates(inheritedCandidates, slotCount, selectedSkillIds, birthSkillIds, rng)
+    this.rollCandidates(manifestedCandidates, slotCount, selectedSkillIds, birthSkillIds, rng)
+
+    return birthSkillIds.map((skillId) => getCharacterSkill(skillId))
+  }
+
+  private static rollCandidates(
+    candidates: BirthSkillLotteryEntry[],
+    slotCount: number,
+    selectedSkillIds: Set<string>,
+    birthSkillIds: string[],
+    rng: () => number,
+  ): void {
+    for (const candidate of candidates) {
+      if (birthSkillIds.length >= slotCount) return
+      if (selectedSkillIds.has(candidate.skillId)) continue
+      if (rng() >= candidate.probability) continue
+
+      selectedSkillIds.add(candidate.skillId)
+      birthSkillIds.push(candidate.skillId)
+    }
+  }
+}

--- a/goblin_native/src/core/services/GoblinBirthService.ts
+++ b/goblin_native/src/core/services/GoblinBirthService.ts
@@ -1,6 +1,7 @@
 import type { Goblin, GoblinStats } from '../../shared/types'
 import { GoblinStatCalculator } from './GoblinStatCalculator'
 import { FactorInheritanceService, type InheritanceResult } from './FactorInheritanceService'
+import { BirthSkillService } from './BirthSkillService'
 import { calculateIndividualValue } from './BaseRankSystem'
 import { getDefaultSkillsForRace } from '../../shared/data/raceSkills'
 import {
@@ -15,7 +16,7 @@ import {
   calculateGoblinBaseMagicHeal,
   getGoblinBaseAttributes,
 } from '../../shared/utils/goblinHp'
-import { getLegacyRaceName, normalizeGoblinRaceId } from '../../shared/types/Race'
+import { getLegacyRaceName, isBaseGoblinRaceId, normalizeGoblinRaceId } from '../../shared/types/Race'
 
 const GOBLIN_NAMES = [
   'グリム', 'ゴブタ', 'ボブ', 'ゴロー', 'クロ', 'シロ', 'アカ', 'アオ',
@@ -75,7 +76,7 @@ export class GoblinBirthService {
     }
 
     const inheritance = baseGoblins ? this.evaluateFactorInheritance(baseGoblins) : undefined
-    return this.createGoblin(nextGoblinId, finalIV, inheritance)
+    return this.createGoblin(nextGoblinId, finalIV, inheritance, baseRank)
   }
 
   /**
@@ -115,7 +116,8 @@ export class GoblinBirthService {
   private createGoblin(
     id: number,
     individualValue = 1,
-    inheritance?: InheritanceResult
+    inheritance?: InheritanceResult,
+    baseRank?: number
   ): Goblin {
     const name = this.selectRandomName()
     // 個体値を1〜64の範囲にクランプ
@@ -133,6 +135,16 @@ export class GoblinBirthService {
       ? inheritance.variantAvatar!
       : '/src/assets/goblin/goblin.png'
 
+    const defaultSkills = getDefaultSkillsForRace(raceId)
+    const birthSkills = isBaseGoblinRaceId(raceId) && !inheritance?.isVariant
+      ? BirthSkillService.rollPureGoblinBirthSkills({
+          inheritedFactorIds: inheritance?.inheritedFactors ?? [],
+          baseRank,
+          existingSkillIds: defaultSkills.map((skill) => skill.id),
+          rng: this.random,
+        })
+      : []
+
     const goblin: Goblin = {
       id,
       name,
@@ -145,7 +157,7 @@ export class GoblinBirthService {
       baseAttributes: getGoblinBaseAttributes({ race, raceId }),
       effectiveStats: stats,  // 仮設定、後で計算
       individualValue: clampedIV,
-      skills: getDefaultSkillsForRace(raceId),
+      skills: [...defaultSkills, ...birthSkills],
       factors: inheritance?.inheritedFactors ?? [],
     }
 

--- a/goblin_native/src/core/services/__tests__/BirthSkillService.test.ts
+++ b/goblin_native/src/core/services/__tests__/BirthSkillService.test.ts
@@ -1,0 +1,36 @@
+import { BirthSkillService } from '../BirthSkillService'
+
+function sequenceRng(values: number[]): () => number {
+  let index = 0
+  return () => values[index++] ?? 0
+}
+
+describe('BirthSkillService', () => {
+  it('固定4枠を超えて追加しない', () => {
+    const skills = BirthSkillService.rollPureGoblinBirthSkills({
+      inheritedFactorIds: ['wolf'],
+      rng: sequenceRng([0, 0, 0, 0]),
+    })
+
+    expect(skills.map((skill) => skill.id)).toEqual([
+      'talent_accuracy_150',
+      'attack_count_up_2',
+      'equipment_accuracy_200',
+      'additional_damage_13',
+    ])
+  })
+
+  it('既存スキルと重複する候補は追加しない', () => {
+    const skills = BirthSkillService.rollPureGoblinBirthSkills({
+      inheritedFactorIds: ['wolf'],
+      existingSkillIds: ['talent_accuracy_150'],
+      rng: sequenceRng([0, 0, 0, 0]),
+    })
+
+    expect(skills.map((skill) => skill.id)).toEqual([
+      'attack_count_up_2',
+      'equipment_accuracy_200',
+      'additional_damage_13',
+    ])
+  })
+})

--- a/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
+++ b/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
@@ -23,6 +23,11 @@ function createSeededRng(seed: number): () => number {
   }
 }
 
+function sequenceRng(values: number[]): () => number {
+  let index = 0
+  return () => values[index++] ?? 0
+}
+
 describe('GoblinBirthService', () => {
   describe('createNewGoblin の引数パターン', () => {
     it('individualValue を直接指定した場合、その値が使われる', () => {
@@ -229,6 +234,47 @@ describe('GoblinBirthService', () => {
       expect(goblin1.name).toBe(goblin2.name)
       expect(goblin1.stats).toEqual(goblin2.stats)
       expect(goblin1.individualValue).toBe(goblin2.individualValue)
+    })
+
+    it('因子を継承した純ゴブリンは抽選枠内で亜種固有スキルを継承する', () => {
+      const parent = {
+        id: 1,
+        name: '親ゴブリン',
+        race: 'ゴブリン',
+        raceId: 'goblin' as const,
+        level: 1,
+        experience: 0,
+        avatar: '/src/assets/goblin/goblin.png',
+        stats: {
+          hp: 19,
+          atk: 11,
+          magicAtk: 10,
+          def: 11,
+          magicDef: 10,
+          attackCount: 2,
+          accuracy: 62,
+          evasion: 11,
+          magicHeal: 10,
+          criticalRate: 0,
+        },
+        skills: [],
+        factors: ['wolf'],
+      }
+      const rng = sequenceRng([0, 0.99, 0, 0, 0, 0])
+      const service = new GoblinBirthService(rng)
+
+      const goblin = service.createNewGoblin(2, 10, [parent], undefined, 1)
+
+      expect(goblin.raceId).toBe('goblin')
+      expect(goblin.factors).toEqual(['wolf'])
+      expect(goblin.skills.map((skill) => skill.id)).toEqual([
+        'goblin_pack_tactics',
+        'exp_bonus_70',
+        'talent_accuracy_150',
+        'attack_count_up_2',
+        'equipment_accuracy_200',
+        'additional_damage_13',
+      ])
     })
   })
 })

--- a/goblin_native/src/presentation/components/GoblinCard.tsx
+++ b/goblin_native/src/presentation/components/GoblinCard.tsx
@@ -1,11 +1,16 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { getGoblinDisplayImage, getGoblinDisplayImageScale } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
 import type { Goblin } from '@/shared/types'
-import { getRaceLabel } from '@/shared/i18n/entityLocalization'
+import { getFactorName, getRaceLabel, getSkillLabel } from '@/shared/i18n/entityLocalization'
+import { getDefaultSkillsForRace } from '@/shared/data/raceSkills'
+import { getUniqueSkillsById } from '@/shared/data/characterSkills'
+import { getFactor } from '@/shared/data/factors'
+import { GOBLIN_JOB_SKILL_IDS } from '@/shared/data/goblinJobs'
+import { EQUIPMENT_GRANTED_SKILL_IDS } from '@/shared/data/equipmentPoolLoader'
 
 interface GoblinCardProps {
   goblin: Goblin
@@ -27,6 +32,22 @@ export const GoblinCard = memo(function GoblinCard({
   const { t } = useTranslation()
   const stats = getEffectiveStats(goblin)
   const factorIds = goblin.factors ?? []
+  const visibleFactorIds = factorIds.slice(0, 2)
+  const extraFactorCount = Math.max(0, factorIds.length - visibleFactorIds.length)
+  const inheritedOrManifestedSkills = useMemo(() => {
+    const raceSkillIds = new Set(
+      getDefaultSkillsForRace(goblin.raceId ?? goblin.race).map((skill) => skill.id),
+    )
+    return getUniqueSkillsById(goblin.skills).filter(
+      (skill) => (
+        !raceSkillIds.has(skill.id) &&
+        !GOBLIN_JOB_SKILL_IDS.has(skill.id) &&
+        !EQUIPMENT_GRANTED_SKILL_IDS.has(skill.id)
+      ),
+    )
+  }, [goblin])
+  const visibleSkills = inheritedOrManifestedSkills.slice(0, 3)
+  const extraSkillCount = Math.max(0, inheritedOrManifestedSkills.length - visibleSkills.length)
 
   const content = (
     <View style={[
@@ -52,15 +73,41 @@ export const GoblinCard = memo(function GoblinCard({
           <Text style={[styles.level, isAssignedElsewhere && styles.levelDisabled]}>
             {t('ui.common.levelShort')}{goblin.level}
           </Text>
-          {factorIds.length > 0 && (
-            <View style={styles.factorIcons}>
-              {factorIds.map((factorId, index) => {
-                const FactorIcon = getFactorImage(factorId)
-                return <FactorIcon key={`${factorId}-${index}`} width={16} height={16} />
-              })}
-            </View>
-          )}
         </View>
+        {(factorIds.length > 0 || inheritedOrManifestedSkills.length > 0) && (
+          <View style={styles.traitRows}>
+            {factorIds.length > 0 && (
+              <View style={styles.traitRow}>
+                {visibleFactorIds.map((factorId, index) => {
+                  const FactorIcon = getFactorImage(factorId)
+                  return (
+                    <View key={`${factorId}-${index}`} style={styles.factorChip}>
+                      <FactorIcon width={13} height={13} />
+                      <Text style={styles.factorChipText} numberOfLines={1}>
+                        {getFactorName(getFactor(factorId) ?? { id: factorId, name: factorId })}
+                      </Text>
+                    </View>
+                  )
+                })}
+                {extraFactorCount > 0 && (
+                  <Text style={styles.moreChip}>+{extraFactorCount}</Text>
+                )}
+              </View>
+            )}
+            {inheritedOrManifestedSkills.length > 0 && (
+              <View style={styles.traitRow}>
+                {visibleSkills.map((skill) => (
+                  <Text key={skill.id} style={styles.skillChip} numberOfLines={1}>
+                    {getSkillLabel(skill)}
+                  </Text>
+                ))}
+                {extraSkillCount > 0 && (
+                  <Text style={styles.moreChip}>+{extraSkillCount}</Text>
+                )}
+              </View>
+            )}
+          </View>
+        )}
       </View>
       <View style={styles.statsContainer}>
         {assignedPartyName && (
@@ -125,6 +172,7 @@ const styles = StyleSheet.create({
   },
   info: {
     flex: 1,
+    minWidth: 0,
   },
   name: {
     fontSize: 14,
@@ -162,10 +210,49 @@ const styles = StyleSheet.create({
   levelDisabled: {
     color: '#9CA3AF',
   },
-  factorIcons: {
+  traitRows: {
+    marginTop: 4,
+    gap: 3,
+  },
+  traitRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 3,
+  },
+  factorChip: {
+    maxWidth: 104,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    backgroundColor: '#EEF2FF',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  factorChipText: {
+    flexShrink: 1,
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#4338CA',
+  },
+  skillChip: {
+    maxWidth: 128,
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#065F46',
+    backgroundColor: '#ECFDF5',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  moreChip: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#6B7280',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
   },
   statsContainer: {
     alignItems: 'flex-end',

--- a/goblin_native/src/shared/data/equipmentPoolLoader.ts
+++ b/goblin_native/src/shared/data/equipmentPoolLoader.ts
@@ -15,6 +15,11 @@ const WEAPON_RANGE_SKILLS: Record<WeaponRange, 'weapon_melee_attack' | 'weapon_r
   ranged: 'weapon_ranged_attack',
 }
 
+export const EQUIPMENT_GRANTED_SKILL_IDS = new Set<string>([
+  ...data.templates.flatMap((template) => template.grantedSkillIds ?? []),
+  ...Object.values(WEAPON_RANGE_SKILLS),
+])
+
 function cloneSkill(skill: CharacterSkill): CharacterSkill {
   return {
     ...skill,

--- a/goblin_native/src/shared/data/goblinJobs.ts
+++ b/goblin_native/src/shared/data/goblinJobs.ts
@@ -199,7 +199,7 @@ function buildGoblinJobDefinition(seed: GoblinJobDefinitionSeed): GoblinJobDefin
   }
 }
 
-const GOBLIN_JOB_SKILL_IDS = new Set<string>(
+export const GOBLIN_JOB_SKILL_IDS = new Set<string>(
   [
     ...Object.values(GOBLIN_JOB_DEFINITION_SEEDS)
       .flatMap((job) => job.skills.map((entry) => entry.skillId)),

--- a/goblin_native/src/shared/data/skillBirthRules.ts
+++ b/goblin_native/src/shared/data/skillBirthRules.ts
@@ -1,0 +1,302 @@
+import type { CharacterSkillId } from './skillCatalog'
+
+export interface BirthSkillLotteryEntry {
+  skillId: CharacterSkillId
+  probability: number
+}
+
+export interface FactorSkillInheritanceRule {
+  factorId: string
+  skills: BirthSkillLotteryEntry[]
+}
+
+export interface PureGoblinSkillManifestationRule {
+  baseRank: number
+  skills: BirthSkillLotteryEntry[]
+}
+
+export const PURE_GOBLIN_BIRTH_SKILL_SLOT_MAX = 4
+
+export const factorSkillInheritanceRules: Record<string, FactorSkillInheritanceRule> = {
+  slime: {
+    factorId: "slime",
+    skills: [
+      {
+        skillId: "talent_hp_150",
+        probability: 0.12
+      },
+      {
+        skillId: "armor_mastery_130",
+        probability: 0.1
+      },
+      {
+        skillId: "rear_guard",
+        probability: 0.08
+      },
+      {
+        skillId: "hp_regen_20",
+        probability: 0.08
+      }
+    ]
+  },
+  wolf: {
+    factorId: "wolf",
+    skills: [
+      {
+        skillId: "talent_accuracy_150",
+        probability: 0.12
+      },
+      {
+        skillId: "attack_count_up_2",
+        probability: 0.08
+      },
+      {
+        skillId: "equipment_accuracy_200",
+        probability: 0.08
+      },
+      {
+        skillId: "additional_damage_13",
+        probability: 0.08
+      }
+    ]
+  },
+  orc: {
+    factorId: "orc",
+    skills: [
+      {
+        skillId: "talent_atk_150",
+        probability: 0.12
+      }
+    ]
+  },
+  undead: {
+    factorId: "undead",
+    skills: [
+      {
+        skillId: "talent_itemSlots",
+        probability: 0.05
+      },
+      {
+        skillId: "undead_trait",
+        probability: 0.08
+      },
+      {
+        skillId: "hp_regen_20",
+        probability: 0.08
+      }
+    ]
+  },
+  hobgoblin: {
+    factorId: "hobgoblin",
+    skills: [
+      {
+        skillId: "talent_atk_150",
+        probability: 0.12
+      },
+      {
+        skillId: "inspire_150",
+        probability: 0.08
+      },
+      {
+        skillId: "survive_lethal_hp1",
+        probability: 0.06
+      },
+      {
+        skillId: "goblin_binder",
+        probability: 0.06
+      }
+    ]
+  },
+  lizardman: {
+    factorId: "lizardman",
+    skills: [
+      {
+        skillId: "two_column_attack",
+        probability: 0.08
+      }
+    ]
+  },
+  shadow: {
+    factorId: "shadow",
+    skills: [
+      {
+        skillId: "action_order_150",
+        probability: 0.08
+      },
+      {
+        skillId: "attack_count_up_1",
+        probability: 0.08
+      },
+      {
+        skillId: "evasion_up_30",
+        probability: 0.08
+      },
+      {
+        skillId: "critical_rate_up_10",
+        probability: 0.08
+      }
+    ]
+  }
+}
+
+export const pureGoblinSkillManifestationRules: PureGoblinSkillManifestationRule[] = [
+  {
+    baseRank: 1,
+    skills: [
+      {
+        skillId: "base_power_up_2",
+        probability: 0.04
+      },
+      {
+        skillId: "base_power_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_wisdom_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_spirit_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_vitality_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_agility_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_luck_up_1",
+        probability: 0.04
+      },
+      {
+        skillId: "base_vitality_up_2",
+        probability: 0.04
+      },
+      {
+        skillId: "evasion_up_20",
+        probability: 0.03
+      },
+      {
+        skillId: "talent_accuracy_150",
+        probability: 0.025
+      },
+      {
+        skillId: "talent_def_150",
+        probability: 0.025
+      },
+      {
+        skillId: "talent_hp_150",
+        probability: 0.025
+      },
+      {
+        skillId: "talent_attackCount_150",
+        probability: 0.025
+      }
+    ]
+  },
+  {
+    baseRank: 2,
+    skills: [
+      {
+        skillId: "talent_atk_150",
+        probability: 0.025
+      },
+      {
+        skillId: "talent_hp_150",
+        probability: 0.025
+      },
+      {
+        skillId: "critical_rate_up_10",
+        probability: 0.025
+      }
+    ]
+  },
+  {
+    baseRank: 3,
+    skills: [
+      {
+        skillId: "physical_damage_10",
+        probability: 0.025
+      },
+      {
+        skillId: "physical_reduction_5",
+        probability: 0.025
+      },
+      {
+        skillId: "hp_regen_flat_10",
+        probability: 0.02
+      }
+    ]
+  },
+  {
+    baseRank: 4,
+    skills: [
+      {
+        skillId: "attack_count_up_1",
+        probability: 0.018
+      },
+      {
+        skillId: "action_order_150",
+        probability: 0.018
+      },
+      {
+        skillId: "evasion_up_30",
+        probability: 0.018
+      }
+    ]
+  },
+  {
+    baseRank: 5,
+    skills: [
+      {
+        skillId: "survive_lethal_hp1",
+        probability: 0.015
+      },
+      {
+        skillId: "cover_low_hp_ally",
+        probability: 0.015
+      },
+      {
+        skillId: "critical_damage_bonus_12",
+        probability: 0.015
+      }
+    ]
+  },
+  {
+    baseRank: 6,
+    skills: [
+      {
+        skillId: "two_column_attack",
+        probability: 0.012
+      },
+      {
+        skillId: "instant_revive",
+        probability: 0.01
+      },
+      {
+        skillId: "party_rare_mult_1_25",
+        probability: 0.01
+      }
+    ]
+  },
+  {
+    baseRank: 7,
+    skills: [
+      {
+        skillId: "attack_count_up_2",
+        probability: 0.008
+      },
+      {
+        skillId: "two_actions",
+        probability: 0.006
+      },
+      {
+        skillId: "party_title_mult_1_25",
+        probability: 0.01
+      }
+    ]
+  }
+]

--- a/goblin_native/src/shared/i18n/entityLocalization.ts
+++ b/goblin_native/src/shared/i18n/entityLocalization.ts
@@ -107,6 +107,15 @@ export function getSkillLabel(skill: CharacterSkill): string {
     return i18n.t('battle.spellDamagePercent', { value: skill.spellDamagePercent })
   }
 
+  for (const [key, value] of Object.entries(skill.baseAttributeBonuses ?? {})) {
+    if (value !== undefined) {
+      return i18n.t('battle.baseAttributeBonus', {
+        stat: getStatLabel(key),
+        value,
+      })
+    }
+  }
+
   for (const [key, value] of Object.entries(skill.baseStatMultipliers ?? {})) {
     if (value !== undefined) {
       return i18n.t('battle.baseStatMultiplier', {

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -118,11 +118,28 @@ interface GoblinFactorSeed {
   source?: 'variant' | 'standalone'
 }
 
+interface BirthSkillLotteryEntry {
+  skillId: string
+  probability: number
+}
+
+interface FactorSkillInheritanceRule {
+  factorId: string
+  skills: BirthSkillLotteryEntry[]
+}
+
+interface PureGoblinSkillManifestationRule {
+  baseRank: number
+  skills: BirthSkillLotteryEntry[]
+}
+
 interface GoblinStudioData {
   races: GoblinRaceEntry[]
   factors: GoblinFactorSeed[]
   jobs: GoblinJobSeed[]
   variants: GoblinVariantSeed[]
+  factorSkillInheritanceRules: FactorSkillInheritanceRule[]
+  pureGoblinSkillManifestationRules: PureGoblinSkillManifestationRule[]
 }
 
 export function dataApiPlugin(options: Options): Plugin {
@@ -133,6 +150,7 @@ export function dataApiPlugin(options: Options): Plugin {
   const factorsFile = path.join(options.appSrc, 'shared', 'data', 'factors.ts')
   const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
   const variantsFile = path.join(options.appSrc, 'shared', 'data', 'goblinVariants.ts')
+  const skillBirthRulesFile = path.join(options.appSrc, 'shared', 'data', 'skillBirthRules.ts')
   const equipmentPoolFile = path.join(options.appSrc, 'shared', 'data', 'equipmentPool.json')
   const presetsFile = path.join(options.dataDir, 'party-presets.json')
   const libraryFile = path.join(options.dataDir, 'character-library.json')
@@ -315,7 +333,13 @@ export function dataApiPlugin(options: Options): Plugin {
             return json(
               res,
               200,
-              await readGoblinStudioData({ racesFile, factorsFile, jobsFile, variantsFile }),
+              await readGoblinStudioData({
+                racesFile,
+                factorsFile,
+                jobsFile,
+                variantsFile,
+                skillBirthRulesFile,
+              }),
             )
           }
           if (req.method === 'PUT') {
@@ -324,7 +348,7 @@ export function dataApiPlugin(options: Options): Plugin {
               res,
               200,
               await writeGoblinStudioData(
-                { racesFile, factorsFile, jobsFile, variantsFile },
+                { racesFile, factorsFile, jobsFile, variantsFile, skillBirthRulesFile },
                 body,
               ),
             )
@@ -748,12 +772,14 @@ async function readGoblinStudioData(paths: {
   factorsFile: string
   jobsFile: string
   variantsFile: string
+  skillBirthRulesFile: string
 }): Promise<GoblinStudioData> {
-  const [racesSource, factorsSource, jobsSource, variantsSource] = await Promise.all([
+  const [racesSource, factorsSource, jobsSource, variantsSource, skillBirthRulesSource] = await Promise.all([
     fs.readFile(paths.racesFile, 'utf8'),
     fs.readFile(paths.factorsFile, 'utf8'),
     fs.readFile(paths.jobsFile, 'utf8'),
     fs.readFile(paths.variantsFile, 'utf8'),
+    fs.readFile(paths.skillBirthRulesFile, 'utf8'),
   ])
 
   const racesObject = evaluateObjectLiteral<
@@ -780,6 +806,12 @@ async function readGoblinStudioData(paths: {
   )
   const standaloneFactorsObject = evaluateObjectLiteral<Record<string, GoblinFactorSeed>>(
     extractConstObjectLiteral(factorsSource, 'standaloneFactorDatabase'),
+  )
+  const factorSkillInheritanceRulesObject = evaluateObjectLiteral<Record<string, FactorSkillInheritanceRule>>(
+    extractConstObjectLiteral(skillBirthRulesSource, 'factorSkillInheritanceRules'),
+  )
+  const pureGoblinSkillManifestationRules = evaluateObjectLiteral<PureGoblinSkillManifestationRule[]>(
+    extractConstArrayLiteral(skillBirthRulesSource, 'pureGoblinSkillManifestationRules'),
   )
   const variantFactors: GoblinFactorSeed[] = Object.values(variantsObject).map((variant) => ({
     id: variant.factorId,
@@ -812,6 +844,8 @@ async function readGoblinStudioData(paths: {
     factors: [...variantFactors, ...standaloneFactors],
     jobs: Object.values(jobsObject),
     variants: Object.values(variantsObject),
+    factorSkillInheritanceRules: Object.values(factorSkillInheritanceRulesObject),
+    pureGoblinSkillManifestationRules,
   }
 }
 
@@ -821,6 +855,7 @@ async function writeGoblinStudioData(
     factorsFile: string
     jobsFile: string
     variantsFile: string
+    skillBirthRulesFile: string
   },
   body: unknown,
 ) {
@@ -828,11 +863,12 @@ async function writeGoblinStudioData(
     throw new Error('Invalid goblin data payload')
   }
 
-  const [racesSource, factorsSource, jobsSource, variantsSource] = await Promise.all([
+  const [racesSource, factorsSource, jobsSource, variantsSource, skillBirthRulesSource] = await Promise.all([
     fs.readFile(paths.racesFile, 'utf8'),
     fs.readFile(paths.factorsFile, 'utf8'),
     fs.readFile(paths.jobsFile, 'utf8'),
     fs.readFile(paths.variantsFile, 'utf8'),
+    fs.readFile(paths.skillBirthRulesFile, 'utf8'),
   ])
 
   const racesObject = Object.fromEntries(
@@ -883,6 +919,9 @@ async function writeGoblinStudioData(
         },
       ]),
   )
+  const factorSkillInheritanceRulesObject = Object.fromEntries(
+    body.factorSkillInheritanceRules.map((rule) => [rule.factorId, rule]),
+  )
 
   const nextRaces = replaceConstObjectLiteral(
     racesSource,
@@ -904,18 +943,36 @@ async function writeGoblinStudioData(
     'goblinVariantDefinitions',
     formatJsValue(variantsObject, 0),
   )
+  const nextSkillBirthRules = replaceConstArrayLiteral(
+    replaceConstObjectLiteral(
+      skillBirthRulesSource,
+      'factorSkillInheritanceRules',
+      formatJsValue(factorSkillInheritanceRulesObject, 0),
+    ),
+    'pureGoblinSkillManifestationRules',
+    formatJsValue(body.pureGoblinSkillManifestationRules, 0),
+  )
 
   await Promise.all([
     fs.writeFile(paths.racesFile, nextRaces, 'utf8'),
     fs.writeFile(paths.factorsFile, nextFactors, 'utf8'),
     fs.writeFile(paths.jobsFile, nextJobs, 'utf8'),
     fs.writeFile(paths.variantsFile, nextVariants, 'utf8'),
+    fs.writeFile(paths.skillBirthRulesFile, nextSkillBirthRules, 'utf8'),
   ])
 
   return { ok: true }
 }
 
 function extractConstObjectLiteral(source: string, constName: string): string {
+  return extractConstLiteral(source, constName, '{', '}')
+}
+
+function extractConstArrayLiteral(source: string, constName: string): string {
+  return extractConstLiteral(source, constName, '[', ']')
+}
+
+function extractConstLiteral(source: string, constName: string, open: '{' | '[', close: '}' | ']'): string {
   const marker = `const ${constName}`
   const markerIndex = source.indexOf(marker)
   if (markerIndex < 0) {
@@ -925,15 +982,29 @@ function extractConstObjectLiteral(source: string, constName: string): string {
   if (eqIndex < 0) {
     throw new Error(`Assignment not found: ${constName}`)
   }
-  const start = source.indexOf('{', eqIndex)
+  const start = source.indexOf(open, eqIndex)
   if (start < 0) {
-    throw new Error(`Object literal not found: ${constName}`)
+    throw new Error(`Literal not found: ${constName}`)
   }
-  const end = findMatchingBrace(source, start)
+  const end = findMatchingDelimiter(source, start, open, close)
   return source.slice(start, end + 1)
 }
 
 function replaceConstObjectLiteral(source: string, constName: string, nextObjectLiteral: string): string {
+  return replaceConstLiteral(source, constName, nextObjectLiteral, '{', '}')
+}
+
+function replaceConstArrayLiteral(source: string, constName: string, nextArrayLiteral: string): string {
+  return replaceConstLiteral(source, constName, nextArrayLiteral, '[', ']')
+}
+
+function replaceConstLiteral(
+  source: string,
+  constName: string,
+  nextLiteral: string,
+  open: '{' | '[',
+  close: '}' | ']',
+): string {
   const marker = `const ${constName}`
   const markerIndex = source.indexOf(marker)
   if (markerIndex < 0) {
@@ -943,15 +1014,20 @@ function replaceConstObjectLiteral(source: string, constName: string, nextObject
   if (eqIndex < 0) {
     throw new Error(`Assignment not found: ${constName}`)
   }
-  const start = source.indexOf('{', eqIndex)
+  const start = source.indexOf(open, eqIndex)
   if (start < 0) {
-    throw new Error(`Object literal not found: ${constName}`)
+    throw new Error(`Literal not found: ${constName}`)
   }
-  const end = findMatchingBrace(source, start)
-  return `${source.slice(0, start)}${nextObjectLiteral}${source.slice(end + 1)}`
+  const end = findMatchingDelimiter(source, start, open, close)
+  return `${source.slice(0, start)}${nextLiteral}${source.slice(end + 1)}`
 }
 
-function findMatchingBrace(source: string, start: number): number {
+function findMatchingDelimiter(
+  source: string,
+  start: number,
+  open: '{' | '[' = '{',
+  close: '}' | ']' = '}',
+): number {
   let depth = 0
   let quote: '"' | "'" | '`' | null = null
   let escape = false
@@ -1001,11 +1077,11 @@ function findMatchingBrace(source: string, start: number): number {
       quote = ch
       continue
     }
-    if (ch === '{') {
+    if (ch === open) {
       depth++
       continue
     }
-    if (ch === '}') {
+    if (ch === close) {
       depth--
       if (depth === 0) return i
     }
@@ -1054,6 +1130,8 @@ function isGoblinStudioDataShape(value: unknown): value is GoblinStudioData {
     Array.isArray(record.races) &&
     Array.isArray(record.factors) &&
     Array.isArray(record.jobs) &&
-    Array.isArray(record.variants)
+    Array.isArray(record.variants) &&
+    Array.isArray(record.factorSkillInheritanceRules) &&
+    Array.isArray(record.pureGoblinSkillManifestationRules)
   )
 }

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -318,11 +318,28 @@ export const GoblinFactorSeedSchema = z.object({
   source: z.enum(['variant', 'standalone']).optional(),
 })
 
+export const BirthSkillLotteryEntrySchema = z.object({
+  skillId: z.string(),
+  probability: z.number(),
+})
+
+export const FactorSkillInheritanceRuleSchema = z.object({
+  factorId: z.string(),
+  skills: z.array(BirthSkillLotteryEntrySchema),
+})
+
+export const PureGoblinSkillManifestationRuleSchema = z.object({
+  baseRank: z.number().int(),
+  skills: z.array(BirthSkillLotteryEntrySchema),
+})
+
 export const GoblinStudioDataSchema = z.object({
   races: z.array(GoblinRaceEntrySchema),
   factors: z.array(GoblinFactorSeedSchema),
   jobs: z.array(GoblinJobSeedSchema),
   variants: z.array(GoblinVariantSeedSchema),
+  factorSkillInheritanceRules: z.array(FactorSkillInheritanceRuleSchema),
+  pureGoblinSkillManifestationRules: z.array(PureGoblinSkillManifestationRuleSchema),
 })
 
 export type GoblinBaseAttributes = z.infer<typeof GoblinBaseAttributesSchema>
@@ -332,4 +349,7 @@ export type GoblinJobSkillSeed = z.infer<typeof GoblinJobSkillSeedSchema>
 export type GoblinJobSeed = z.infer<typeof GoblinJobSeedSchema>
 export type GoblinVariantSeed = z.infer<typeof GoblinVariantSeedSchema>
 export type GoblinFactorSeed = z.infer<typeof GoblinFactorSeedSchema>
+export type BirthSkillLotteryEntry = z.infer<typeof BirthSkillLotteryEntrySchema>
+export type FactorSkillInheritanceRule = z.infer<typeof FactorSkillInheritanceRuleSchema>
+export type PureGoblinSkillManifestationRule = z.infer<typeof PureGoblinSkillManifestationRuleSchema>
 export type GoblinStudioData = z.infer<typeof GoblinStudioDataSchema>

--- a/tools/studio/src/pages/GoblinDataPage.tsx
+++ b/tools/studio/src/pages/GoblinDataPage.tsx
@@ -9,9 +9,12 @@ import type {
   GoblinRaceEntry,
   GoblinStudioData,
   GoblinVariantSeed,
+  BirthSkillLotteryEntry,
+  FactorSkillInheritanceRule,
+  PureGoblinSkillManifestationRule,
 } from '../lib/schema'
 import { GoblinStudioDataSchema } from '../lib/schema'
-import { JobSkillListEditor, SkillIdListEditor } from '../components/SkillEditors'
+import { JobSkillListEditor, SkillIdListEditor, SkillMeta, SkillSelectField } from '../components/SkillEditors'
 import {
   FieldRow,
   NumberField,
@@ -32,7 +35,7 @@ type SaveState =
   | { kind: 'error'; message: string }
   | { kind: 'success' }
 
-type Tab = 'races' | 'factors' | 'variants' | 'jobs'
+type Tab = 'races' | 'factors' | 'variants' | 'jobs' | 'birthSkills'
 
 const EMPTY_ATTRIBUTES: GoblinBaseAttributes = {
   power: 10,
@@ -230,6 +233,12 @@ export function GoblinDataPage() {
         </button>
         <button className={tab === 'jobs' ? 'tab active' : 'tab'} onClick={() => setTab('jobs')}>
           Job
+        </button>
+        <button
+          className={tab === 'birthSkills' ? 'tab active' : 'tab'}
+          onClick={() => setTab('birthSkills')}
+        >
+          誕生スキル
         </button>
       </div>
 
@@ -527,6 +536,20 @@ export function GoblinDataPage() {
             )}
           </DataEditorLayout>
         )}
+
+        {tab === 'birthSkills' && (
+          <BirthSkillRulesEditor
+            inheritanceRules={draft.factorSkillInheritanceRules}
+            manifestationRules={draft.pureGoblinSkillManifestationRules}
+            factors={draft.factors}
+            onInheritanceChange={(factorSkillInheritanceRules) =>
+              updateDraft((prev) => ({ ...prev, factorSkillInheritanceRules }))
+            }
+            onManifestationChange={(pureGoblinSkillManifestationRules) =>
+              updateDraft((prev) => ({ ...prev, pureGoblinSkillManifestationRules }))
+            }
+          />
+        )}
       </div>
     </div>
   )
@@ -584,6 +607,234 @@ function DataEditorLayout<T>({
         </div>
       </aside>
       <div className="panel-stack">{children}</div>
+    </div>
+  )
+}
+
+function BirthSkillRulesEditor({
+  inheritanceRules,
+  manifestationRules,
+  factors,
+  onInheritanceChange,
+  onManifestationChange,
+}: {
+  inheritanceRules: FactorSkillInheritanceRule[]
+  manifestationRules: PureGoblinSkillManifestationRule[]
+  factors: GoblinFactorSeed[]
+  onInheritanceChange: (rules: FactorSkillInheritanceRule[]) => void
+  onManifestationChange: (rules: PureGoblinSkillManifestationRule[]) => void
+}) {
+  const factorOptions = factors.map((factor) => ({
+    id: factor.id,
+    label: `${factor.name || factor.id} / ${factor.id}`,
+  }))
+
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <div className="section-head">
+          <h3>因子スキル継承</h3>
+          <button
+            className="btn ghost small"
+            onClick={() => {
+              const used = new Set(inheritanceRules.map((rule) => rule.factorId))
+              const factorId = factorOptions.find((factor) => !used.has(factor.id))?.id ?? ''
+              onInheritanceChange([...inheritanceRules, { factorId, skills: [] }])
+            }}
+          >
+            + 追加
+          </button>
+        </div>
+        <div className="story-block-list">
+          {inheritanceRules.map((rule, index) => (
+            <div key={`${rule.factorId}-${index}`} className="story-block">
+              <div className="story-block-head">
+                <strong>{rule.factorId || '(factor 未設定)'}</strong>
+                <div className="pattern-actions">
+                  <button className="icon-btn" onClick={() => onInheritanceChange(moveItem(inheritanceRules, index, -1))}>
+                    ↑
+                  </button>
+                  <button className="icon-btn" onClick={() => onInheritanceChange(moveItem(inheritanceRules, index, 1))}>
+                    ↓
+                  </button>
+                  <button
+                    className="icon-btn danger"
+                    onClick={() => onInheritanceChange(inheritanceRules.filter((_, entryIndex) => entryIndex !== index))}
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+              <FieldRow>
+                <label className="field field-size-lg">
+                  <span className="field-label">factorId</span>
+                  <span className="field-input">
+                    <select
+                      value={rule.factorId}
+                      onChange={(e) =>
+                        onInheritanceChange(
+                          inheritanceRules.map((entry, entryIndex) =>
+                            entryIndex === index ? { ...entry, factorId: e.target.value } : entry,
+                          ),
+                        )
+                      }
+                    >
+                      <option value="">(未設定)</option>
+                      {factorOptions.map((factor) => (
+                        <option key={factor.id} value={factor.id}>
+                          {factor.label}
+                        </option>
+                      ))}
+                    </select>
+                  </span>
+                </label>
+              </FieldRow>
+              <SkillLotteryListEditor
+                skills={rule.skills}
+                onChange={(skills) =>
+                  onInheritanceChange(
+                    inheritanceRules.map((entry, entryIndex) =>
+                      entryIndex === index ? { ...entry, skills } : entry,
+                    ),
+                  )
+                }
+              />
+            </div>
+          ))}
+          {inheritanceRules.length === 0 && <p className="subtle">未設定</p>}
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="section-head">
+          <h3>純ゴブリン スキル発現</h3>
+          <button
+            className="btn ghost small"
+            onClick={() => {
+              const nextRank = Math.max(0, ...manifestationRules.map((rule) => rule.baseRank)) + 1
+              onManifestationChange([...manifestationRules, { baseRank: nextRank, skills: [] }])
+            }}
+          >
+            + 追加
+          </button>
+        </div>
+        <p className="subtle">誕生時の追加スキルは最大4枠です。継承スキルの後に発現スキルを判定します。</p>
+        <div className="story-block-list">
+          {manifestationRules.map((rule, index) => (
+            <div key={`${rule.baseRank}-${index}`} className="story-block">
+              <div className="story-block-head">
+                <strong>Rank {rule.baseRank}</strong>
+                <div className="pattern-actions">
+                  <button className="icon-btn" onClick={() => onManifestationChange(moveItem(manifestationRules, index, -1))}>
+                    ↑
+                  </button>
+                  <button className="icon-btn" onClick={() => onManifestationChange(moveItem(manifestationRules, index, 1))}>
+                    ↓
+                  </button>
+                  <button
+                    className="icon-btn danger"
+                    onClick={() => onManifestationChange(manifestationRules.filter((_, entryIndex) => entryIndex !== index))}
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+              <FieldRow>
+                <NumberField
+                  size="sm"
+                  label="baseRank"
+                  value={rule.baseRank}
+                  min={1}
+                  onChange={(baseRank) =>
+                    onManifestationChange(
+                      manifestationRules.map((entry, entryIndex) =>
+                        entryIndex === index ? { ...entry, baseRank } : entry,
+                      ),
+                    )
+                  }
+                />
+              </FieldRow>
+              <SkillLotteryListEditor
+                skills={rule.skills}
+                onChange={(skills) =>
+                  onManifestationChange(
+                    manifestationRules.map((entry, entryIndex) =>
+                      entryIndex === index ? { ...entry, skills } : entry,
+                    ),
+                  )
+                }
+              />
+            </div>
+          ))}
+          {manifestationRules.length === 0 && <p className="subtle">未設定</p>}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function SkillLotteryListEditor({
+  skills,
+  onChange,
+}: {
+  skills: BirthSkillLotteryEntry[]
+  onChange: (skills: BirthSkillLotteryEntry[]) => void
+}) {
+  return (
+    <div className="story-block-list">
+      {skills.map((skill, index) => (
+        <div key={`${skill.skillId}-${index}`} className="story-block">
+          <div className="story-block-head">
+            <strong>{skill.skillId || '(skill 未設定)'}</strong>
+            <div className="pattern-actions">
+              <button className="icon-btn" onClick={() => onChange(moveItem(skills, index, -1))}>
+                ↑
+              </button>
+              <button className="icon-btn" onClick={() => onChange(moveItem(skills, index, 1))}>
+                ↓
+              </button>
+              <button
+                className="icon-btn danger"
+                onClick={() => onChange(skills.filter((_, entryIndex) => entryIndex !== index))}
+              >
+                ×
+              </button>
+            </div>
+          </div>
+          <FieldRow>
+            <SkillSelectField
+              size="lg"
+              label="skillId"
+              value={skill.skillId}
+              onChange={(skillId) =>
+                onChange(
+                  skills.map((entry, entryIndex) =>
+                    entryIndex === index ? { ...entry, skillId } : entry,
+                  ),
+                )
+              }
+            />
+            <NumberField
+              size="sm"
+              label="probability"
+              value={skill.probability}
+              min={0}
+              step={0.01}
+              onChange={(probability) =>
+                onChange(
+                  skills.map((entry, entryIndex) =>
+                    entryIndex === index ? { ...entry, probability } : entry,
+                  ),
+                )
+              }
+            />
+          </FieldRow>
+          <SkillMeta skillId={skill.skillId} />
+        </div>
+      ))}
+      <button className="btn ghost small" onClick={() => onChange([...skills, { skillId: '', probability: 0 }])}>
+        + スキル
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `BirthSkillService` と `skillBirthRules` を新設し、純ゴブリン誕生時に因子継承スキル／ベースランク発現スキルを抽選付与（最大4枠）
- ゴブリン一覧の本配属カード／控えカードで、種族・職・装備由来を除いた固有スキルと因子をチップ形式で表示
- Studio 側で `skillBirthRules.ts` の抽選ルールを GUI から編集できる UI を追加

## Test plan
- [x] `npx tsc --noEmit` (型チェック)
- [x] `npm test -- --testPathPatterns="(BirthSkillService|GoblinBirthService)"` (24 テスト pass)
- [ ] 実機/シミュレータで純ゴブリン誕生時に固有スキルがカードに表示されることを確認
- [ ] 因子なし・因子あり・各ベースランクで抽選結果が想定通り変化することを確認
- [ ] Studio で抽選ルールを編集して保存できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)