### PR TITLE
feat(formation): パーティ詳細にPTスキル/ステータス比較/因子一覧を追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/party-info.tsx
+++ b/goblin_native/app/(tabs)/formation/party-info.tsx
@@ -5,11 +5,37 @@ import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
+import { getFactorImage } from '@/shared/utils/factorImages'
+import { calculateGoblinEffectiveStats, getEffectiveStats } from '@/shared/utils/goblinStats'
 import { getExpForNextLevel } from '@/core/services/ExperienceSystem'
 import { getRowDamageMultiplierFromSkills, getUniqueSkillsById } from '@/shared/data/characterSkills'
+import { getFactor } from '@/shared/data/factors'
+import { getFactorName, getStatLabel } from '@/shared/i18n/entityLocalization'
 import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
 import { EquipmentService } from '@/core/services/EquipmentService'
-import type { CharacterSkill, Goblin, Party } from '@/shared/types'
+import type { CharacterSkill, Goblin, GoblinStats, Party } from '@/shared/types'
+
+const STATUS_COMPARISON_KEYS: ReadonlyArray<keyof GoblinStats> = [
+  'hp',
+  'atk',
+  'magicAtk',
+  'def',
+  'magicDef',
+  'attackCount',
+  'accuracy',
+  'evasion',
+  'magicHeal',
+  'criticalRate',
+]
+
+type PartySkillCategory = 'rare' | 'title' | 'gold'
+
+type PartySkillEntry = {
+  category: PartySkillCategory
+  goblin: Goblin
+  skill: CharacterSkill
+  valueText: string
+}
 
 function getExpRateText(t: (key: string, options?: Record<string, unknown>) => string): string {
   return t('ui.formation.partyInfo.expRate')
@@ -30,6 +56,75 @@ function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`
 }
 
+function formatMultiplier(value: number): string {
+  return `${value.toFixed(2)}倍`
+}
+
+function formatBonusPercent(value: number): string {
+  return `+${value}%`
+}
+
+function getMemberFactorIds(goblin: Goblin): string[] {
+  return Array.from(
+    new Set(
+      [goblin.variantFactorId, ...(goblin.factors ?? [])].filter((factorId): factorId is string =>
+        Boolean(factorId),
+      ),
+    ),
+  )
+}
+
+function getFactorLabel(factorId: string): string {
+  const factor = getFactor(factorId)
+  return factor ? getFactorName(factor) : factorId
+}
+
+function FactorChip({ factorId }: { factorId: string }) {
+  const FactorIcon = getFactorImage(factorId)
+
+  return (
+    <View style={styles.factorChip}>
+      <FactorIcon width={13} height={13} />
+      <Text style={styles.factorChipText} numberOfLines={1}>
+        {getFactorLabel(factorId)}
+      </Text>
+    </View>
+  )
+}
+
+function getPartySkillEntries(goblin: Goblin, skills: CharacterSkill[]): PartySkillEntry[] {
+  return skills.flatMap((skill) => {
+    const entries: PartySkillEntry[] = []
+
+    if (skill.partyRareMultiplier !== undefined) {
+      entries.push({
+        category: 'rare',
+        goblin,
+        skill,
+        valueText: formatMultiplier(skill.partyRareMultiplier),
+      })
+    }
+    if (skill.partyTitleMultiplier !== undefined) {
+      entries.push({
+        category: 'title',
+        goblin,
+        skill,
+        valueText: formatMultiplier(skill.partyTitleMultiplier),
+      })
+    }
+    if (skill.goldBonusPercent !== undefined) {
+      entries.push({
+        category: 'gold',
+        goblin,
+        skill,
+        valueText: formatBonusPercent(skill.goldBonusPercent),
+      })
+    }
+
+    return entries
+  })
+}
+
 export default function PartyInfoScreen() {
   const { t } = useTranslation()
   const { partyId } = useLocalSearchParams<{ partyId: string }>()
@@ -38,6 +133,7 @@ export default function PartyInfoScreen() {
   const goblinsLoading = useGoblinStore((state) => state.isLoading)
   const [party, setParty] = useState<Party | null>(null)
   const [memberSkillsById, setMemberSkillsById] = useState<Record<number, CharacterSkill[]>>({})
+  const [memberStatsById, setMemberStatsById] = useState<Record<number, GoblinStats>>({})
 
   useEffect(() => {
     if (!partyId) {
@@ -58,12 +154,17 @@ export default function PartyInfoScreen() {
       .filter((goblin): goblin is Goblin => goblin !== undefined)
   }, [goblins, party])
 
+  const partySkillEntries = useMemo(() => {
+    return partyMembers.flatMap((goblin) => getPartySkillEntries(goblin, memberSkillsById[goblin.id] ?? goblin.skills))
+  }, [memberSkillsById, partyMembers])
+
   useEffect(() => {
     let cancelled = false
 
     const loadMemberSkills = async (): Promise<void> => {
       if (partyMembers.length === 0) {
         setMemberSkillsById({})
+        setMemberStatsById({})
         return
       }
 
@@ -72,7 +173,8 @@ export default function PartyInfoScreen() {
         partyMembers.map(async (goblin) => {
           const equippedItems = await repository.getByGoblinId(goblin.id)
           const equipmentSkills = EquipmentService.collectGrantedSkills(equippedItems)
-          return [goblin.id, [...goblin.skills, ...equipmentSkills]] as const
+          const effectiveStats = calculateGoblinEffectiveStats(goblin, equippedItems)
+          return [goblin.id, [...goblin.skills, ...equipmentSkills], effectiveStats] as const
         }),
       )
 
@@ -81,6 +183,12 @@ export default function PartyInfoScreen() {
       setMemberSkillsById(
         entries.reduce<Record<number, CharacterSkill[]>>((acc, [goblinId, skills]) => {
           acc[goblinId] = [...skills]
+          return acc
+        }, {}),
+      )
+      setMemberStatsById(
+        entries.reduce<Record<number, GoblinStats>>((acc, [goblinId, , stats]) => {
+          acc[goblinId] = stats
           return acc
         }, {}),
       )
@@ -171,6 +279,81 @@ export default function PartyInfoScreen() {
               </View>
             )
           })}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('ui.formation.partyInfo.partySkillTitle')}</Text>
+          {(['rare', 'title', 'gold'] as const).map((category) => {
+            const entries = partySkillEntries.filter((entry) => entry.category === category)
+
+            return (
+              <View key={category} style={styles.partySkillGroup}>
+                <Text style={styles.statusTitle}>{t(`ui.formation.partyInfo.partySkillCategory.${category}`)}</Text>
+                {entries.length > 0 ? (
+                  entries.map((entry, index) => (
+                    <View key={`${category}-${entry.goblin.id}-${entry.skill.id}-${index}`} style={styles.statusMemberRow}>
+                      <View style={styles.compactMemberInfo}>
+                        <Image source={getGoblinDisplayImage(entry.goblin)} style={styles.compactAvatar} />
+                        <Text style={styles.statusMemberName} numberOfLines={1}>{entry.goblin.name}</Text>
+                      </View>
+                      <Text style={styles.statusValue}>{entry.valueText}</Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.partySkillEmptyText}>{t('ui.formation.partyInfo.noPartySkills')}</Text>
+                )}
+              </View>
+            )
+          })}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('ui.formation.partyInfo.statusComparisonTitle')}</Text>
+          <View style={styles.statusList}>
+            {STATUS_COMPARISON_KEYS.map((statKey) => (
+              <View key={statKey} style={styles.statusGroup}>
+                <Text style={styles.statusTitle}>{getStatLabel(statKey)}</Text>
+                {partyMembers.map((goblin) => {
+                  const stats = memberStatsById[goblin.id] ?? getEffectiveStats(goblin)
+
+                  return (
+                    <View key={`${statKey}-${goblin.id}`} style={styles.statusMemberRow}>
+                      <View style={styles.compactMemberInfo}>
+                        <Image source={getGoblinDisplayImage(goblin)} style={styles.compactAvatar} />
+                        <Text style={styles.statusMemberName} numberOfLines={1}>{goblin.name}</Text>
+                      </View>
+                      <Text style={styles.statusValue}>{stats[statKey]}</Text>
+                    </View>
+                  )
+                })}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('ui.formation.partyInfo.factorListTitle')}</Text>
+          <View style={styles.factorMemberList}>
+            {partyMembers.map((goblin) => {
+              const factorIds = getMemberFactorIds(goblin)
+
+              return (
+                <View key={`factors-${goblin.id}`} style={styles.factorMemberBlock}>
+                  <View style={styles.factorMemberHeader}>
+                    <Image source={getGoblinDisplayImage(goblin)} style={styles.compactAvatar} />
+                    <Text style={styles.factorMemberName} numberOfLines={1}>{goblin.name}</Text>
+                  </View>
+                  {factorIds.length > 0 ? (
+                    factorIds.map((factorId) => (
+                      <FactorChip key={`${goblin.id}-${factorId}`} factorId={factorId} />
+                    ))
+                  ) : (
+                    <Text style={styles.factorEmptyText}>{t('ui.formation.partyInfo.noFactors')}</Text>
+                  )}
+                </View>
+              )
+            })}
+          </View>
         </View>
       </ScrollView>
     </>
@@ -272,5 +455,96 @@ const styles = StyleSheet.create({
     textAlign: 'right',
     fontSize: 13,
     color: '#374151',
+  },
+  statusList: {
+    gap: 12,
+  },
+  statusGroup: {
+    gap: 4,
+  },
+  statusTitle: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  statusMemberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingLeft: 8,
+  },
+  compactMemberInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    minWidth: 0,
+  },
+  compactAvatar: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+  },
+  statusMemberName: {
+    flex: 1,
+    fontSize: 12,
+    color: '#4B5563',
+  },
+  statusValue: {
+    minWidth: 52,
+    textAlign: 'right',
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  partySkillGroup: {
+    gap: 4,
+  },
+  partySkillEmptyText: {
+    paddingLeft: 8,
+    fontSize: 12,
+    color: '#9CA3AF',
+  },
+  factorMemberList: {
+    gap: 12,
+  },
+  factorMemberBlock: {
+    alignItems: 'flex-start',
+    gap: 4,
+  },
+  factorMemberHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    minWidth: 0,
+  },
+  factorMemberName: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '800',
+    color: '#111827',
+  },
+  factorChip: {
+    maxWidth: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    marginLeft: 32,
+    backgroundColor: '#EEF2FF',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  factorChipText: {
+    flexShrink: 1,
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#4338CA',
+  },
+  factorEmptyText: {
+    paddingLeft: 32,
+    fontSize: 12,
+    color: '#9CA3AF',
   },
 })

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -367,6 +367,16 @@ const en = {
         meleeWeapon: 'Melee Weapon',
         rangedWeapon: 'Ranged Weapon',
         noSkill: 'No Skill',
+        partySkillTitle: 'Party Skills',
+        partySkillCategory: {
+          rare: 'Item Acquisition Multiplier',
+          title: 'Title Grant Rate',
+          gold: 'Gold Gained',
+        },
+        noPartySkills: 'None',
+        statusComparisonTitle: 'Status Comparison',
+        factorListTitle: 'Factors',
+        noFactors: 'No factors',
       },
       playback: {
         dataNotFound: 'Expedition data not found',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -367,6 +367,16 @@ const ja = {
         meleeWeapon: '近接武器',
         rangedWeapon: '遠距離武器',
         noSkill: 'スキルなし',
+        partySkillTitle: 'PTスキル一覧',
+        partySkillCategory: {
+          rare: 'アイテム獲得倍率',
+          title: '称号付与率',
+          gold: '取得Gold',
+        },
+        noPartySkills: 'なし',
+        statusComparisonTitle: 'ステータス比較',
+        factorListTitle: '因子一覧',
+        noFactors: '因子なし',
       },
       playback: {
         dataNotFound: '遠征データが見つかりません',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -358,6 +358,16 @@ const ko = {
         meleeWeapon: '근접 무기',
         rangedWeapon: '원거리 무기',
         noSkill: '스킬 없음',
+        partySkillTitle: '파티 스킬 목록',
+        partySkillCategory: {
+          rare: '아이템 획득 배율',
+          title: '칭호 부여율',
+          gold: '획득 Gold',
+        },
+        noPartySkills: '없음',
+        statusComparisonTitle: '스테이터스 비교',
+        factorListTitle: '인자 목록',
+        noFactors: '인자 없음',
       },
       playback: {
         dataNotFound: '원정 데이터를 찾을 수 없습니다',


### PR DESCRIPTION
## Summary
- パーティ詳細画面に「PTスキル一覧」「ステータス比較」「因子一覧」セクションを追加
- en/ja/ko の i18n リソースに新規ラベルを追加

## Test plan
- [ ] パーティ詳細画面で PTスキル / ステータス / 因子 が正しく表示されることを確認
- [ ] ja/en/ko 各言語で表示確認
- [ ] `npx tsc --noEmit` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)