### PR TITLE
fix(expedition): ダンジョン制圧判定をボス踏破到達に統一

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -13,6 +13,7 @@ import type { ExpeditionRecord, Goblin, Story, TimelineEvent, TreasureDrop } fro
 import { getDungeonTierDisplayName } from '@/shared/types'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
+import { isDungeonCompleted } from '@/shared/utils/expeditionClear'
 
 function resolveTreasureName(drop: TreasureDrop): string {
   const template = getEquipmentTemplate(drop.templateId)
@@ -115,7 +116,7 @@ export default function ExpeditionResultScreen() {
   const getHeaderText = () => {
     if (!replay) return ''
     const area = areasData.find(a => a.id === replay.meta.areaId)
-    if (replay.summary.success && replay.summary.maxFloorReached === area?.floors) {
+    if (isDungeonCompleted(replay) && replay.summary.maxFloorReached === area?.floors) {
       return t('ui.result.completed')
     }
     if (replay.summary.success) {
@@ -132,7 +133,7 @@ export default function ExpeditionResultScreen() {
 
   useEffect(() => {
     if (!replay || !dungeon) return
-    const cleared = replay.summary.success && replay.summary.maxFloorReached >= dungeon.floors
+    const cleared = isDungeonCompleted(replay) && replay.summary.maxFloorReached >= dungeon.floors
     if (cleared && !dungeon.cleared) {
       void (async () => {
         await markDungeonCleared(dungeon, true, replay.meta.tier)

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -12,6 +12,7 @@ import type { IEquipmentRepository } from '../repositories/IEquipmentRepository'
 import type { LevelUpResult } from '../services/ExperienceSystem'
 import { FactorService } from '../services/FactorService'
 import { captureDungeon } from '../services/BaseRankSystem'
+import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
 
 export interface ExpeditionCompletionResult {
   levelUps: Map<number, LevelUpResult>
@@ -136,10 +137,11 @@ export class CompleteExpeditionUseCase {
     const bossEvent = replay.events.find(
       (e): e is Extract<TimelineEvent, { type: 'boss' }> => e.type === 'boss'
     )
+    const dungeonCompleted = isDungeonCompleted(replay)
 
     // 初回クリア判定（チュートリアル用の確定因子獲得などに使用）
     let isFirstClearSuccess = false
-    if (!isAbort && replay.summary.success) {
+    if (!isAbort && dungeonCompleted) {
       const baseStateBefore = await this.baseStateRepository.getBaseState()
       isFirstClearSuccess =
         baseStateBefore !== null &&
@@ -246,7 +248,7 @@ export class CompleteExpeditionUseCase {
           gold: currentBaseState.gold + goldGained,
         }
 
-        if (replay.summary.success) {
+        if (dungeonCompleted) {
           const wasCaptured = currentBaseState.capturedDungeons.includes(replay.meta.areaId)
           updatedBaseState = captureDungeon(replay.meta.areaId, updatedBaseState)
 

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -56,6 +56,23 @@ function createBattleEvent(xp: number, allyHPDelta: number[], at = 10, floor = 1
   }
 }
 
+function createBossEvent(
+  enemyId: string,
+  xp: number,
+  allyHPDelta: number[],
+  at = 60,
+  floor = 2,
+): Extract<TimelineEvent, { type: 'boss' }> {
+  return {
+    type: 'boss',
+    at,
+    floor,
+    enemy: { id: enemyId, name: 'テストボス', lvl: 1, count: 1, gold: 10 },
+    combat: { rounds: 3, outcome: 'win', allyHPDelta, enemyDefeated: 1 },
+    xp,
+  }
+}
+
 function createTestReplay(overrides: Partial<ExpeditionReplay> = {}): ExpeditionReplay {
   const party = overrides?.meta?.party ?? ['1']
   const partySize = party.length
@@ -264,6 +281,88 @@ describe('CompleteExpeditionUseCase', () => {
       expect(result.newDungeonCaptured).toBe('dungeon_1')
       const savedState = (baseRepo.saveBaseState as jest.Mock).mock.calls[0][0] as BaseState
       expect(savedState.capturedDungeons).toContain('dungeon_1')
+    })
+
+    it('途中帰還成功ではダンジョン制圧と因子獲得を行わない', async () => {
+      const goblin = createTestGoblin({ id: 1 })
+      const party = createTestParty({ id: 1, memberIds: [1] })
+      const baseState = createTestBaseState({ capturedDungeons: [] })
+      const events: TimelineEvent[] = [
+        { type: 'move_start', at: 0, floor: 1 },
+        createBattleEvent(5, [-1], 10, 1),
+        { type: 'floor_up', at: 10, from: 1, to: 2 },
+        { type: 'return', at: 30, reason: 'policy_return' },
+      ]
+      const replay = createTestReplay({
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'slime_cave',
+          areaName: 'スライムの洞窟',
+          floors: 2,
+          baseDurationSec: 30,
+          party: ['1'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'until_floor2',
+          seed: 12345,
+        },
+        events,
+        summary: { success: true, maxFloorReached: 2, xpGained: 5, goldGained: 0, casualties: [] },
+      })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const baseRepo = createMockBaseStateRepository(baseState)
+      const usecase = new CompleteExpeditionUseCase(goblinRepo, createMockPartyRepository([party]), baseRepo)
+      const result = await usecase.execute(1, replay)
+
+      expect(result.newDungeonCaptured).toBeUndefined()
+      expect(result.factorAcquisitions.size).toBe(0)
+      expect(goblinRepo.updateGoblinFactors).not.toHaveBeenCalled()
+      const savedState = (baseRepo.saveBaseState as jest.Mock).mock.calls[0][0] as BaseState
+      expect(savedState.capturedDungeons).not.toContain('slime_cave')
+    })
+
+    it('スライム洞窟の初回ボス踏破ではスライム因子を確定獲得する', async () => {
+      const goblin = createTestGoblin({ id: 1 })
+      const party = createTestParty({ id: 1, memberIds: [1] })
+      const baseState = createTestBaseState({ capturedDungeons: [] })
+      const events: TimelineEvent[] = [
+        { type: 'move_start', at: 0, floor: 1 },
+        createBattleEvent(5, [-1], 10, 1),
+        { type: 'floor_up', at: 10, from: 1, to: 2 },
+        createBossEvent('B_SLIME', 5, [-1], 30, 2),
+        { type: 'return', at: 30, reason: 'completed' },
+      ]
+      const replay = createTestReplay({
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'slime_cave',
+          areaName: 'スライムの洞窟',
+          floors: 2,
+          baseDurationSec: 30,
+          party: ['1'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'never',
+          seed: 12345,
+        },
+        events,
+        summary: { success: true, maxFloorReached: 2, xpGained: 10, goldGained: 0, casualties: [] },
+      })
+
+      const goblinRepo = createMockGoblinRepository([goblin])
+      const usecase = new CompleteExpeditionUseCase(
+        goblinRepo,
+        createMockPartyRepository([party]),
+        createMockBaseStateRepository(baseState),
+      )
+      const result = await usecase.execute(1, replay)
+
+      expect(result.newDungeonCaptured).toBe('slime_cave')
+      expect(result.factorAcquisitions.get(1)).toEqual(['slime'])
+      expect(goblinRepo.updateGoblinFactors).toHaveBeenCalledWith(
+        1,
+        ['slime'],
+        expect.objectContaining({ hp: expect.any(Number) }),
+      )
     })
 
     it('��に制圧済みのダンジョンではnewDungeonCapturedがundefined', async () => {

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -33,6 +33,7 @@ import { useTutorialStore } from '../stores/useTutorialStore'
 import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
 import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
+import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
 import { getExpeditionTimeMultiplierFromSkills } from '../../shared/data/characterSkills'
 import { EquipmentService } from '../../core/services/EquipmentService'
 import i18n from '../../shared/i18n'
@@ -144,7 +145,7 @@ export const useExpeditionFlow = ({
     const dungeon = areasData.find(area => area.id === record.dungeonId)
     if (!dungeon) return
 
-    const cleared = record.replay.summary.success &&
+    const cleared = isDungeonCompleted(record.replay) &&
       record.replay.summary.maxFloorReached >= dungeon.floors
     if (!cleared) return
 
@@ -164,11 +165,14 @@ export const useExpeditionFlow = ({
     const nextId = await getNextGoblinId()
     const areaLevel = record.replay.meta.effectiveAreaLevel ??
       getDungeonTierAreaLevel(dungeon.areaLevel ?? 1, tier ?? 0)
+    const latestGoblins = (
+      await Promise.all(record.replay.meta.party.map(id => goblinRepository.getGoblin(Number.parseInt(id, 10))))
+    ).filter((goblin): goblin is NonNullable<typeof goblin> => goblin !== null)
     const goblinBirthService = new GoblinBirthService()
     const newGoblin = goblinBirthService.createNewGoblin(
       nextId,
       undefined,
-      goblins,
+      latestGoblins.length > 0 ? latestGoblins : goblins,
       areaLevel,
       rank
     )
@@ -182,6 +186,7 @@ export const useExpeditionFlow = ({
     addPendingGoblin,
     checkAndUnlockStories,
     getNextGoblinId,
+    goblinRepository,
     goblins,
     isBaseLoading,
     isPendingLoading,

--- a/goblin_native/src/shared/utils/expeditionClear.ts
+++ b/goblin_native/src/shared/utils/expeditionClear.ts
@@ -1,0 +1,5 @@
+import type { ExpeditionReplay } from '../types'
+
+export function isDungeonCompleted(replay: ExpeditionReplay): boolean {
+  return replay.events.some(event => event.type === 'return' && event.reason === 'completed')
+}


### PR DESCRIPTION
## Summary
- 途中帰還(`reason=policy_return`)で `summary.success=true` になった場合にも、ダンジョン制圧や初回クリア因子が確定獲得されてしまう不具合を修正。
- `isDungeonCompleted` ユーティリティ（`reason=completed` の `return` イベント存在で判定）を導入し、結果画面・`CompleteExpeditionUseCase`・`useExpeditionFlow` で完走判定を一元化。
- 新規ゴブリン誕生時の親情報を、最新状態を取得するためリポジトリ経由で取り直すよう調整。
- ユースケースの単体テストを追加（途中帰還成功は制圧/因子獲得しない／スライム洞窟ボス踏破で確定獲得）。

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm test -- CompleteExpeditionUseCase`
- [ ] 実機/シミュレータで途中帰還ポリシー設定の遠征を完走前に終了させ、ダンジョンが「制圧」表示にならないこと
- [ ] スライム洞窟ボスを踏破し、初回クリア時のスライム因子確定獲得を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)