### PR TITLE
feat(battle-log): 2列攻撃の貫通ヒットを戦闘ログに区別表示

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -224,6 +224,10 @@ export default function BattleLogScreen() {
                   <Text key={`target-${targetIndex}`} style={[styles.logText, actorImage ? styles.logTargetIndented : undefined]}>
                     {target.totalDamage < 0
                       ? t('ui.formation.battleLog.targetHealed', { row: target.targetRow, name: target.targetName, heal: Math.abs(target.totalDamage) })
+                      : target.piercingHitCount && target.defeated
+                      ? t('ui.formation.battleLog.targetPiercedDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
+                      : target.piercingHitCount
+                      ? t('ui.formation.battleLog.targetPierced', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })
                       : target.defeated
                       ? t('ui.formation.battleLog.targetDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
                       : t('ui.formation.battleLog.targetHits', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })}

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -661,16 +661,17 @@ export class BattleSystem {
 
       const initialTarget = fixedTarget ?? selectTarget(aliveTargets, rng)
       const target = fixedTarget ?? this.resolveCoverTarget(initialTarget, targetGroup)
-      const attackTargets = [{ target, damageMultiplier: 1 }]
+      const attackTargets = [{ target, damageMultiplier: 1, isPiercing: false }]
       const secondColumnTarget = this.selectSecondColumnAttackTarget(unit, target, targetGroup, rng)
       if (secondColumnTarget) {
         attackTargets.push({
           target: secondColumnTarget,
           damageMultiplier: TWO_COLUMN_ATTACK_DAMAGE_MULTIPLIER,
+          isPiercing: true,
         })
       }
 
-      for (const { target: attackTarget, damageMultiplier } of attackTargets) {
+      for (const { target: attackTarget, damageMultiplier, isPiercing } of attackTargets) {
         if (unit.currentHP <= 0 || attackTarget.currentHP <= 0) continue
 
         const hitRate = this.calculateHitRate(unit, attackTarget, atkIdx + 1, rng)
@@ -717,7 +718,7 @@ export class BattleSystem {
           turnConsumedUnitKeys,
         )
 
-        this.accumulateTargetDetail(targetDetails, attackTarget, damage)
+        this.accumulateTargetDetail(targetDetails, attackTarget, damage, isPiercing)
       }
     }
 
@@ -1334,12 +1335,16 @@ export class BattleSystem {
     details: Map<string, AttackTargetDetail>,
     target: BattleUnit,
     damage: number,
+    isPiercing = false,
   ): void {
     const targetKey = this.getUnitKey(target)
     const existing = details.get(targetKey)
     if (existing) {
       existing.totalDamage += damage
       existing.hitCount++
+      if (isPiercing) {
+        existing.piercingHitCount = (existing.piercingHitCount ?? 0) + 1
+      }
       existing.defeated = target.currentHP <= 0
       existing.targetHP = target.currentHP
     } else {
@@ -1349,6 +1354,7 @@ export class BattleSystem {
         targetRow: target.row + 1,
         totalDamage: damage,
         hitCount: 1,
+        piercingHitCount: isPiercing ? 1 : undefined,
         defeated: target.currentHP <= 0,
         targetHP: target.currentHP,
       })

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -922,6 +922,8 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     expect(log.hitCount).toBe(2)
     expect(log.targets.map(target => target.targetId)).toEqual(['E_FRONT', 'E_BACK'])
     expect(log.targets.map(target => target.targetRow)).toEqual([1, 2])
+    expect(log.targets.find(target => target.targetId === 'E_FRONT')!.piercingHitCount).toBeUndefined()
+    expect(log.targets.find(target => target.targetId === 'E_BACK')!.piercingHitCount).toBe(1)
     const frontDamage = log.targets.find(target => target.targetId === 'E_FRONT')!.totalDamage
     const backDamage = log.targets.find(target => target.targetId === 'E_BACK')!.totalDamage
     expect(backDamage).toBe(Math.floor(frontDamage * 0.5))

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -427,6 +427,8 @@ const en = {
         attackCriticalSummary: '[Row {{row}}] {{actor}} critical attack! Hit {{count}} times!',
         targetDefeated: '[Row {{row}}] dealt {{damage}} to {{name}} and defeated them!',
         targetHits: '[Row {{row}}] dealt {{damage}} to {{name}} ({{count}} hits)',
+        targetPierced: '[Row {{row}}] the attack pierced through to rear {{name}} for {{damage}} damage ({{count}} hits)',
+        targetPiercedDefeated: '[Row {{row}}] the attack pierced through to rear {{name}}, dealing {{damage}} damage and defeating them!',
         targetHealed: '[Row {{row}}] healed {{name}} for {{heal}}',
         outcomeWin: 'Victory!',
         outcomeLose: 'Defeat...',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -427,6 +427,8 @@ const ja = {
         attackCriticalSummary: '[列{{row}}] {{actor}}の必殺攻撃！{{count}}回ヒット！',
         targetDefeated: '[列{{row}}] {{name}}に {{damage}}ダメージを与えて倒した！',
         targetHits: '[列{{row}}] {{name}}に {{damage}}ダメージ ({{count}}回)',
+        targetPierced: '[列{{row}}] 後列の{{name}}へ攻撃が貫通！{{damage}}ダメージ ({{count}}回)',
+        targetPiercedDefeated: '[列{{row}}] 後列の{{name}}へ攻撃が貫通し、{{damage}}ダメージを与えて倒した！',
         targetHealed: '[列{{row}}] {{name}}を {{heal}}回復',
         outcomeWin: '戦いに勝利した！',
         outcomeLose: '戦いに敗北した...',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -418,6 +418,8 @@ const ko = {
         attackCriticalSummary: '[열{{row}}] {{actor}}의 필살 공격! {{count}}회 히트!',
         targetDefeated: '[열{{row}}] {{name}}에게 {{damage}} 피해를 주고 쓰러뜨렸다!',
         targetHits: '[열{{row}}] {{name}}에게 {{damage}} 피해 ({{count}}회)',
+        targetPierced: '[열{{row}}] 후열의 {{name}}에게 공격이 관통! {{damage}} 피해 ({{count}}회)',
+        targetPiercedDefeated: '[열{{row}}] 후열의 {{name}}에게 공격이 관통해 {{damage}} 피해를 주고 쓰러뜨렸다!',
         targetHealed: '[열{{row}}] {{name}}을(를) {{heal}} 회복',
         outcomeWin: '전투에 승리했다!',
         outcomeLose: '전투에 패배했다...',

--- a/goblin_native/src/shared/types/Battle.ts
+++ b/goblin_native/src/shared/types/Battle.ts
@@ -5,6 +5,7 @@ export interface AttackTargetDetail {
   targetRow: number       // ターゲットの隊列番号
   totalDamage: number     // このターゲットへの合計ダメージ（回復は負値）
   hitCount: number        // このターゲットへの命中回数
+  piercingHitCount?: number // 2列攻撃で後列へ貫通した命中回数
   defeated: boolean       // この攻撃で倒したか
   targetHP: number        // 攻撃後の残りHP
 }


### PR DESCRIPTION
## Summary
- 2列攻撃で後列に貫通したヒットを `piercingHitCount` として集計し、戦闘ログで通常ヒット／撃破と区別表示
- `targetPierced` / `targetPiercedDefeated` の i18n キーを ja/en/ko に追加
- 既存テストに貫通ヒット数の検証を追加

## Test plan
- [ ] `npx tsc --noEmit` が通ること
- [ ] `npm test` で `CombatStats.test.ts` がパスすること
- [ ] 戦闘ログ画面で 2列攻撃時に「貫通」メッセージが表示されることを確認
- [ ] 後列ターゲットを撃破した際に貫通撃破メッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)