### PR TITLE
feat(battle-log): 戦闘ログにターンジャンプUIとアクター画像拡大を追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -1,16 +1,18 @@
-import { useMemo, useEffect } from 'react'
-import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { useMemo, useEffect, useRef, useCallback } from 'react'
+import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, type ImageSourcePropType } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import type { BattleLogEntry, BattleLogMeta, Goblin } from '@/shared/types'
 import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
-import { getGoblinBattleImage } from '@/shared/utils/goblinImages'
+import { getGoblinBattleImage, getGoblinDisplayImageScale } from '@/shared/utils/goblinImages'
 import { getEnemyImage } from '@/shared/utils/enemyImages'
 
 export default function BattleLogScreen() {
   const { t } = useTranslation()
   const { logId } = useLocalSearchParams<{ logId?: string }>()
+  const scrollViewRef = useRef<ScrollView>(null)
+  const turnOffsetRef = useRef<Record<number, number>>({})
 
   const stored = useMemo(() => {
     if (!logId) return null
@@ -22,6 +24,24 @@ export default function BattleLogScreen() {
   const battleLog = stored?.log ?? null
   const meta = stored?.meta ?? null
   const partySnapshot = stored?.partySnapshot ?? []
+
+  const turnIndexes = useMemo(() => {
+    if (!battleLog) return []
+    const turns: number[] = []
+    const seen = new Set<number>()
+    for (const entry of battleLog) {
+      if (entry.action !== 'turn_start' || seen.has(entry.turn)) continue
+      seen.add(entry.turn)
+      turns.push(entry.turn)
+    }
+    return turns
+  }, [battleLog])
+
+  const scrollToTurn = useCallback((turn: number) => {
+    const y = turnOffsetRef.current[turn]
+    if (y === undefined) return
+    scrollViewRef.current?.scrollTo({ y: Math.max(y - 8, 0), animated: true })
+  }, [])
 
   const goblinMap = useMemo(() => {
     const map = new Map<string, Goblin>()
@@ -64,181 +84,210 @@ export default function BattleLogScreen() {
       )}
 
       {battleLog && (
-        <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
-          {battleLog.map((entry, index) => {
-            if (entry.action === 'turn_start' && entry.turnState) {
-              const allyPartyEffects = entry.turnState.allyPartyEffects ?? []
-              const enemyPartyEffects = entry.turnState.enemyPartyEffects ?? []
-              return (
-                <View key={`turn-${entry.turn}-${index}`} style={styles.sectionCard}>
-                  <Text style={styles.sectionTitle}>{t('ui.formation.battleLog.turnStart', { turn: entry.turn })}</Text>
-                  <Text style={styles.sectionLabel}>{t('ui.formation.battleLog.allies')}</Text>
-                  {allyPartyEffects.length > 0 && (
-                    <Text style={styles.sectionText}>
-                      {t('ui.formation.battleLog.partyEffects', {
-                        effects: allyPartyEffects.map(effect => t(`ui.formation.battleLog.partyEffect.${effect}`)).join(' / '),
-                      })}
-                    </Text>
-                  )}
-                  {entry.turnState.allies.map(ally => (
-                    <Text key={ally.id} style={styles.sectionText}>
-                      {ally.name} {ally.currentHP}/{ally.maxHP} HP
-                    </Text>
-                  ))}
-                  <Text style={styles.sectionLabel}>{t('ui.formation.battleLog.enemies')}</Text>
-                  {enemyPartyEffects.length > 0 && (
-                    <Text style={styles.sectionText}>
-                      {t('ui.formation.battleLog.partyEffects', {
-                        effects: enemyPartyEffects.map(effect => t(`ui.formation.battleLog.partyEffect.${effect}`)).join(' / '),
-                      })}
-                    </Text>
-                  )}
-                  {entry.turnState.enemies.map((enemy, enemyIndex) => (
-                    <Text key={`${enemy.id}-${enemyIndex}`} style={styles.sectionText}>
-                      {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
-                    </Text>
-                  ))}
-                </View>
-              )
-            }
-
-            if (entry.action === 'turn_start') {
-              return null
-            }
-
-            const isSpell = entry.action !== t('battle.normalAttack') && entry.action !== 'turn_start'
-            const isHealingAction = entry.targets?.some(target => target.totalDamage < 0) ?? false
-            const isBarrierAction = entry.actionEffect === 'barrier' || entry.action === t('entities.spell.shield_barrier')
-            const isAttackUpAction = entry.actionEffect === 'attack_up' || entry.action === t('entities.spell.attack_up')
-            const isMagicFieldAction = entry.actionEffect === 'magic_field'
-
-            const allyGoblin = entry.isAlly ? goblinMap.get(entry.actorId) : undefined
-            const actorImage = allyGoblin
-              ? getGoblinBattleImage(allyGoblin)
-              : getEnemyImage({ id: entry.actorId, name: entry.actorName }) ?? undefined
-
-            if (entry.actionEffect === 'regen') {
-              const healed = Math.abs(entry.targets?.[0]?.totalDamage ?? 0)
-              return (
-                <View key={`log-${index}`} style={styles.logCard}>
-                  <View style={styles.logHeader}>
-                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
-                    <Text style={[styles.logText, styles.logHeaderText]}>
-                      {t('ui.formation.battleLog.regenSummary', { actor: entry.actorName, heal: healed })}
-                    </Text>
+        <View style={styles.logShell}>
+          <ScrollView ref={scrollViewRef} style={styles.body} contentContainerStyle={styles.bodyContent}>
+            {battleLog.map((entry, index) => {
+              if (entry.action === 'turn_start' && entry.turnState) {
+                const allyPartyEffects = entry.turnState.allyPartyEffects ?? []
+                const enemyPartyEffects = entry.turnState.enemyPartyEffects ?? []
+                return (
+                  <View
+                    key={`turn-${entry.turn}-${index}`}
+                    style={styles.sectionCard}
+                    onLayout={(event) => {
+                      turnOffsetRef.current[entry.turn] = event.nativeEvent.layout.y
+                    }}
+                  >
+                    <Text style={styles.sectionTitle}>{t('ui.formation.battleLog.turnStart', { turn: entry.turn })}</Text>
+                    <Text style={styles.sectionLabel}>{t('ui.formation.battleLog.allies')}</Text>
+                    {allyPartyEffects.length > 0 && (
+                      <Text style={styles.sectionText}>
+                        {t('ui.formation.battleLog.partyEffects', {
+                          effects: allyPartyEffects.map(effect => t(`ui.formation.battleLog.partyEffect.${effect}`)).join(' / '),
+                        })}
+                      </Text>
+                    )}
+                    {entry.turnState.allies.map(ally => (
+                      <Text key={ally.id} style={styles.sectionText}>
+                        {ally.name} {ally.currentHP}/{ally.maxHP} HP
+                      </Text>
+                    ))}
+                    <Text style={styles.sectionLabel}>{t('ui.formation.battleLog.enemies')}</Text>
+                    {enemyPartyEffects.length > 0 && (
+                      <Text style={styles.sectionText}>
+                        {t('ui.formation.battleLog.partyEffects', {
+                          effects: enemyPartyEffects.map(effect => t(`ui.formation.battleLog.partyEffect.${effect}`)).join(' / '),
+                        })}
+                      </Text>
+                    )}
+                    {entry.turnState.enemies.map((enemy, enemyIndex) => (
+                      <Text key={`${enemy.id}-${enemyIndex}`} style={styles.sectionText}>
+                        {enemy.name} {enemy.currentHP}/{enemy.maxHP} HP
+                      </Text>
+                    ))}
                   </View>
-                </View>
-              )
-            }
+                )
+              }
 
-            if (entry.actionEffect === 'defend') {
-              return (
-                <View key={`log-${index}`} style={styles.logCard}>
-                  <View style={styles.logHeader}>
-                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
-                    <View style={styles.logHeaderText}>
-                      <Text style={styles.logTitle}>
-                        {t('ui.formation.battleLog.defendTitle', { actor: entry.actorName, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
+              if (entry.action === 'turn_start') {
+                return null
+              }
+
+              const isSpell = entry.action !== t('battle.normalAttack') && entry.action !== 'turn_start'
+              const isHealingAction = entry.targets?.some(target => target.totalDamage < 0) ?? false
+              const isBarrierAction = entry.actionEffect === 'barrier' || entry.action === t('entities.spell.shield_barrier')
+              const isAttackUpAction = entry.actionEffect === 'attack_up' || entry.action === t('entities.spell.attack_up')
+              const isMagicFieldAction = entry.actionEffect === 'magic_field'
+
+              const allyGoblin = entry.isAlly ? goblinMap.get(entry.actorId) : undefined
+              const actorImage = allyGoblin
+                ? getGoblinBattleImage(allyGoblin)
+                : getEnemyImage({ id: entry.actorId, name: entry.actorName }) ?? undefined
+              const actorImageScale = allyGoblin
+                ? getGoblinDisplayImageScale(allyGoblin)
+                : getEnemyBattleLogImageScale(entry.actorId)
+
+              if (entry.actionEffect === 'regen') {
+                const healed = Math.abs(entry.targets?.[0]?.totalDamage ?? 0)
+                return (
+                  <View key={`log-${index}`} style={styles.logCard}>
+                    <View style={styles.logHeader}>
+                      {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
+                      <Text style={[styles.logText, styles.logHeaderText]}>
+                        {t('ui.formation.battleLog.regenSummary', { actor: entry.actorName, heal: healed })}
                       </Text>
                     </View>
                   </View>
-                </View>
-              )
-            }
+                )
+              }
 
-            if (isBarrierAction) {
+              if (entry.actionEffect === 'defend') {
+                return (
+                  <View key={`log-${index}`} style={styles.logCard}>
+                    <View style={styles.logHeader}>
+                      {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
+                      <View style={styles.logHeaderText}>
+                        <Text style={styles.logTitle}>
+                          {t('ui.formation.battleLog.defendTitle', { actor: entry.actorName, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                )
+              }
+
+              if (isBarrierAction) {
+                return (
+                  <View key={`log-${index}`} style={styles.logCard}>
+                    <View style={styles.logHeader}>
+                      {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
+                      <View style={styles.logHeaderText}>
+                        <Text style={styles.logTitle}>
+                          {t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
+                        </Text>
+                        <Text style={styles.logText}>
+                          {t('ui.formation.battleLog.shieldBarrierSummary')}
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                )
+              }
+
+              if (isAttackUpAction) {
+                return (
+                  <View key={`log-${index}`} style={styles.logCard}>
+                    <View style={styles.logHeader}>
+                      {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
+                      <View style={styles.logHeaderText}>
+                        <Text style={styles.logTitle}>
+                          {t('ui.formation.battleLog.attackUpTitle', { actor: entry.actorName, action: entry.action })}
+                        </Text>
+                        <Text style={styles.logText}>
+                          {t('ui.formation.battleLog.attackUpSummary')}
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                )
+              }
+
+              if (isMagicFieldAction) {
+                return (
+                  <View key={`log-${index}`} style={styles.logCard}>
+                    <View style={styles.logHeader}>
+                      {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
+                      <View style={styles.logHeaderText}>
+                        <Text style={styles.logTitle}>
+                          {t('ui.formation.battleLog.magicFieldTitle', { actor: entry.actorName, action: entry.action })}
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+                )
+              }
+
               return (
                 <View key={`log-${index}`} style={styles.logCard}>
                   <View style={styles.logHeader}>
-                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
+                    {actorImage && <BattleActorImage source={actorImage} scale={actorImageScale} />}
                     <View style={styles.logHeaderText}>
                       <Text style={styles.logTitle}>
-                        {t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })}
+                        {isSpell
+                          ? t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })
+                          : t('ui.formation.battleLog.attackTitle', { actor: entry.actorName, count: entry.attackCount, hp: entry.actorHP, maxHp: entry.actorMaxHP })
+                        }
                       </Text>
                       <Text style={styles.logText}>
-                        {t('ui.formation.battleLog.shieldBarrierSummary')}
+                        {isHealingAction
+                          ? t('ui.formation.battleLog.healSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
+                          : isSpell
+                          ? t('ui.formation.battleLog.spellSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
+                          : entry.isCritical
+                          ? t('ui.formation.battleLog.attackCriticalSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
+                          : t('ui.formation.battleLog.attackSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
+                        }
                       </Text>
                     </View>
                   </View>
-                </View>
-              )
-            }
-
-            if (isAttackUpAction) {
-              return (
-                <View key={`log-${index}`} style={styles.logCard}>
-                  <View style={styles.logHeader}>
-                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
-                    <View style={styles.logHeaderText}>
-                      <Text style={styles.logTitle}>
-                        {t('ui.formation.battleLog.attackUpTitle', { actor: entry.actorName, action: entry.action })}
-                      </Text>
-                      <Text style={styles.logText}>
-                        {t('ui.formation.battleLog.attackUpSummary')}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              )
-            }
-
-            if (isMagicFieldAction) {
-              return (
-                <View key={`log-${index}`} style={styles.logCard}>
-                  <View style={styles.logHeader}>
-                    {actorImage && <Image source={actorImage} style={styles.actorImage} />}
-                    <View style={styles.logHeaderText}>
-                      <Text style={styles.logTitle}>
-                        {t('ui.formation.battleLog.magicFieldTitle', { actor: entry.actorName, action: entry.action })}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              )
-            }
-
-            return (
-              <View key={`log-${index}`} style={styles.logCard}>
-                <View style={styles.logHeader}>
-                  {actorImage && <Image source={actorImage} style={styles.actorImage} />}
-                  <View style={styles.logHeaderText}>
-                    <Text style={styles.logTitle}>
-                      {isSpell
-                        ? t('ui.formation.battleLog.spellTitle', { actor: entry.actorName, action: entry.action, hp: entry.actorHP, maxHp: entry.actorMaxHP })
-                        : t('ui.formation.battleLog.attackTitle', { actor: entry.actorName, count: entry.attackCount, hp: entry.actorHP, maxHp: entry.actorMaxHP })
-                      }
+                  {entry.targets?.map((target, targetIndex) => (
+                    <Text key={`target-${targetIndex}`} style={[styles.logText, actorImage ? styles.logTargetIndented : undefined]}>
+                      {target.totalDamage < 0
+                        ? t('ui.formation.battleLog.targetHealed', { row: target.targetRow, name: target.targetName, heal: Math.abs(target.totalDamage) })
+                        : target.piercingHitCount && target.defeated
+                        ? t('ui.formation.battleLog.targetPiercedDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
+                        : target.piercingHitCount
+                        ? t('ui.formation.battleLog.targetPierced', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })
+                        : target.defeated
+                        ? t('ui.formation.battleLog.targetDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
+                        : t('ui.formation.battleLog.targetHits', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })}
                     </Text>
-                    <Text style={styles.logText}>
-                      {isHealingAction
-                        ? t('ui.formation.battleLog.healSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
-                        : isSpell
-                        ? t('ui.formation.battleLog.spellSummary', { row: entry.actorRow, actor: entry.actorName, action: entry.action, count: entry.hitCount })
-                        : entry.isCritical
-                        ? t('ui.formation.battleLog.attackCriticalSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
-                        : t('ui.formation.battleLog.attackSummary', { row: entry.actorRow, actor: entry.actorName, count: entry.hitCount })
-                      }
-                    </Text>
-                  </View>
+                  ))}
                 </View>
-                {entry.targets?.map((target, targetIndex) => (
-                  <Text key={`target-${targetIndex}`} style={[styles.logText, actorImage ? styles.logTargetIndented : undefined]}>
-                    {target.totalDamage < 0
-                      ? t('ui.formation.battleLog.targetHealed', { row: target.targetRow, name: target.targetName, heal: Math.abs(target.totalDamage) })
-                      : target.piercingHitCount && target.defeated
-                      ? t('ui.formation.battleLog.targetPiercedDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
-                      : target.piercingHitCount
-                      ? t('ui.formation.battleLog.targetPierced', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })
-                      : target.defeated
-                      ? t('ui.formation.battleLog.targetDefeated', { row: target.targetRow, name: target.targetName, damage: target.totalDamage })
-                      : t('ui.formation.battleLog.targetHits', { row: target.targetRow, name: target.targetName, damage: target.totalDamage, count: target.hitCount })}
-                  </Text>
+              )
+            })}
+
+            {meta && <BattleResultSection meta={meta} />}
+          </ScrollView>
+
+          {turnIndexes.length > 0 && (
+            <View style={styles.turnIndexContainer}>
+              <ScrollView contentContainerStyle={styles.turnIndexContent} showsVerticalScrollIndicator={false}>
+                {turnIndexes.map(turn => (
+                  <TouchableOpacity
+                    key={`turn-index-${turn}`}
+                    style={styles.turnIndexButton}
+                    onPress={() => scrollToTurn(turn)}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('ui.formation.battleLog.turnStart', { turn })}
+                  >
+                    <Text style={styles.turnIndexText}>{turn}</Text>
+                  </TouchableOpacity>
                 ))}
-              </View>
-            )
-          })}
-
-          {meta && <BattleResultSection meta={meta} />}
-        </ScrollView>
+              </ScrollView>
+            </View>
+          )}
+        </View>
       )}
     </SafeAreaView>
   )
@@ -282,6 +331,24 @@ function BattleResultSection({ meta }: { meta: BattleLogMeta }) {
       ))}
     </View>
   )
+}
+
+function BattleActorImage({ source, scale }: { source: ImageSourcePropType; scale: number }) {
+  return (
+    <View style={styles.actorImageFrame}>
+      <Image
+        source={source}
+        style={[styles.actorImage, { transform: [{ scale }] }]}
+        resizeMode="contain"
+      />
+    </View>
+  )
+}
+
+function getEnemyBattleLogImageScale(enemyId: string): number {
+  if (enemyId.startsWith('B_')) return 1.05
+  if (enemyId.startsWith('WFG') || enemyId.startsWith('CAT')) return 1.2
+  return 1.14
 }
 
 const styles = StyleSheet.create({
@@ -330,6 +397,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#6B7280',
   },
+  logShell: {
+    flex: 1,
+  },
   sectionCard: {
     backgroundColor: '#FFFFFF',
     borderRadius: 12,
@@ -366,17 +436,23 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     gap: 8,
   },
+  actorImageFrame: {
+    width: 50,
+    height: 50,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 1,
+  },
   actorImage: {
-    width: 28,
-    height: 28,
+    width: 42,
+    height: 42,
     borderRadius: 6,
-    marginTop: 2,
   },
   logHeaderText: {
     flex: 1,
   },
   logTargetIndented: {
-    marginLeft: 36,
+    marginLeft: 58,
   },
   logTitle: {
     fontSize: 13,
@@ -427,5 +503,30 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#D97706',
     marginTop: 2,
+  },
+  turnIndexContainer: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 28,
+    justifyContent: 'center',
+  },
+  turnIndexContent: {
+    flexGrow: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  turnIndexButton: {
+    width: 28,
+    minHeight: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  turnIndexText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#374151',
   },
 })


### PR DESCRIPTION
## Summary
- 戦闘ログ画面の右端にターン番号ボタン列を追加し、タップで該当ターン先頭にスクロールできるようにしました
- アクター画像を 50px フレーム内で拡大表示し、ゴブリン/敵ごとに表示スケールを個別調整しました

## Test plan
- [ ] 戦闘後にバトルログ画面を開き、右端のターン番号ボタンで各ターンへジャンプできることを確認
- [ ] 各ゴブリン/敵の画像がフレーム内で適切なサイズで表示されることを確認
- [ ] 既存ログ表示（回復・防御・バリア・攻撃UP・マジックフィールド・通常攻撃/魔法）が崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)