### PR TITLE
fix(story): ストーリーリーダーの遷移先を(tabs)グループ配下のパスに統一

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -284,7 +284,7 @@ export default function ExpeditionResultScreen() {
               <TouchableOpacity
                 key={story.id}
                 style={styles.storyButton}
-                onPress={() => router.push({ pathname: '/story/reader', params: { storyId: story.id } })}
+                onPress={() => router.push({ pathname: '/(tabs)/story/reader', params: { storyId: story.id } })}
               >
                 <Text style={styles.storyButtonText}>{story.title}</Text>
                 <Text style={styles.storyButtonArrow}>→</Text>

--- a/goblin_native/app/(tabs)/story/_layout.tsx
+++ b/goblin_native/app/(tabs)/story/_layout.tsx
@@ -3,10 +3,12 @@ import { Stack } from 'expo-router'
 export default function StoryLayout() {
   return (
     <Stack
+      initialRouteName="index"
       screenOptions={{
         headerShown: false,
       }}
     >
+      <Stack.Screen name="index" />
       <Stack.Screen name="reader" />
     </Stack>
   )

--- a/goblin_native/app/(tabs)/story/index.tsx
+++ b/goblin_native/app/(tabs)/story/index.tsx
@@ -20,7 +20,7 @@ export default function StoryTabScreen() {
   })
 
   const handleStoryPress = useCallback((storyId: string) => {
-    router.push({ pathname: '/story/reader', params: { storyId } })
+    router.push({ pathname: '/(tabs)/story/reader', params: { storyId } })
   }, [])
 
   return (

--- a/goblin_native/app/(tabs)/story/reader.tsx
+++ b/goblin_native/app/(tabs)/story/reader.tsx
@@ -17,6 +17,14 @@ export default function StoryReaderScreen() {
     return stories.find(s => s.id === storyId) ?? null
   }, [stories, storyId])
 
+  const navigateBackToStoryList = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back()
+      return
+    }
+    router.replace('/(tabs)/story')
+  }, [])
+
   // データリセットなどで storyId が失われた / 該当ストーリーが消えた場合は物語タブへ戻す
   useEffect(() => {
     if (isStoryLoading) return
@@ -61,7 +69,7 @@ export default function StoryReaderScreen() {
       <SafeAreaView style={styles.container}>
         <View style={styles.center}>
           <Text style={styles.errorText}>{t('ui.story.notFound')}</Text>
-          <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <TouchableOpacity style={styles.backButton} onPress={navigateBackToStoryList}>
             <Text style={styles.backButtonText}>{t('ui.common.back')}</Text>
           </TouchableOpacity>
         </View>
@@ -74,7 +82,7 @@ export default function StoryReaderScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['top', 'left', 'right', 'bottom']}>
       <View style={styles.navBar}>
-        <TouchableOpacity onPress={() => router.back()}>
+        <TouchableOpacity onPress={navigateBackToStoryList}>
           <Text style={styles.navBack}>← {t('ui.common.back')}</Text>
         </TouchableOpacity>
         <Text style={styles.navTitle} numberOfLines={1}>{story.title}</Text>
@@ -116,7 +124,7 @@ export default function StoryReaderScreen() {
           </View>
         )}
 
-        <TouchableOpacity style={styles.returnButton} onPress={() => router.back()}>
+        <TouchableOpacity style={styles.returnButton} onPress={navigateBackToStoryList}>
           <Text style={styles.returnButtonText}>{t('ui.common.back')}</Text>
         </TouchableOpacity>
       </ScrollView>


### PR DESCRIPTION
## Summary
- ストーリー一覧と遠征結果から `router.push` する `pathname` を `/(tabs)/story/reader` に揃え、タブグループ外パス指定による遷移失敗を回避
- `app/(tabs)/story/_layout.tsx` に `initialRouteName="index"` と `Stack.Screen name="index"` を明示し、Stack の初期表示を安定化
- `StoryReaderScreen` の戻る導線に `router.canGoBack()` チェックとフォールバック (`router.replace('/(tabs)/story')`) を追加し、ディープリンクや履歴喪失時もストーリー一覧へ戻れるよう修正

## Test plan
- [ ] 遠征結果画面の解放ストーリーボタンからリーダー画面へ遷移できる
- [ ] ストーリータブ → リーダー → 戻るで一覧に戻れる
- [ ] ストーリーが見つからない場合の「戻る」ボタンで一覧へ戻れる
- [ ] `npx tsc --noEmit` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)