### PR TITLE
feat(tips): タブバー上のTIPSバーとstudio管理ページを追加

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect } from 'react'
-import { Tabs } from 'expo-router'
+import { memo, useEffect, useMemo } from 'react'
+import { Tabs, usePathname } from 'expo-router'
 import { View, StyleSheet, useWindowDimensions } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
@@ -11,9 +11,11 @@ import SettingIcon from '../../assets/tab/tab_setting.svg'
 import { CurrentTimeBadge } from '@/presentation/components/CurrentTimeBadge'
 import { GoldBadge } from '@/presentation/components/GoldBadge'
 import { GoldenAcornBadge } from '@/presentation/components/GoldenAcornBadge'
+import { TipsBar, TIPS_BAR_HEIGHT } from '@/presentation/components/TipsBar'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
 import { useTutorialStore } from '@/presentation/stores/useTutorialStore'
 import { useTutorialOverlayStore } from '@/presentation/stores/useTutorialOverlayStore'
+import tipsData from '@/shared/data/tips.json'
 import type { TutorialStep } from '@/shared/types/Tutorial'
 
 interface TabIconProps {
@@ -49,16 +51,27 @@ const FULL_SCREEN_MESSAGE_BY_STEP: Partial<Record<TutorialStep, string>> = {
 }
 
 const TAB_COUNT = 5
+const FALLBACK_TIP_TEXT = 'ゴブリンたちは特定の敵から因子を獲得する可能性がある'
+
+function pickTipText(): string {
+  const tips = tipsData.tips.filter((tip) => tip.enabled && tip.text.trim().length > 0)
+  if (tips.length === 0) return FALLBACK_TIP_TEXT
+  const index = Math.floor(Math.random() * tips.length)
+  return tips[index].text
+}
 
 export default function TabLayout() {
   const { t } = useTranslation()
+  const pathname = usePathname()
+  const tipText = useMemo(() => pickTipText(), [pathname])
   const unreadCount = useStoryStore((state) => state.unreadCount)
   const insets = useSafeAreaInsets()
   const basePadding = 8
   const baseHeight = 60
   const safeAreaPadding = Math.max(basePadding, insets.bottom)
   const tabBarHeight = baseHeight + safeAreaPadding
-  const badgeBottom = baseHeight + safeAreaPadding + 8
+  const tipsBarBottom = tabBarHeight
+  const badgeBottom = tabBarHeight + TIPS_BAR_HEIGHT + 8
   const { width: screenWidth, height: screenHeight } = useWindowDimensions()
   const tutorialStep = useTutorialStore((state) => state.step)
   const setEntry = useTutorialOverlayStore((state) => state.setEntry)
@@ -124,6 +137,9 @@ export default function TabLayout() {
           fontSize: 12,
           fontWeight: '600',
         },
+        sceneStyle: {
+          paddingBottom: TIPS_BAR_HEIGHT,
+        },
         headerShown: true,
         headerStyle: {
           backgroundColor: '#FFFFFF',
@@ -180,6 +196,7 @@ export default function TabLayout() {
         }}
       />
     </Tabs>
+    <TipsBar bottom={tipsBarBottom} text={tipText} />
     <CurrentTimeBadge bottom={badgeBottom} />
     <GoldenAcornBadge bottom={badgeBottom + 32} />
     <GoldBadge bottom={badgeBottom} />

--- a/goblin_native/src/presentation/components/TipsBar.tsx
+++ b/goblin_native/src/presentation/components/TipsBar.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+
+interface TipsBarProps {
+  bottom: number
+  text: string
+}
+
+export const TIPS_BAR_HEIGHT = 34
+
+export const TipsBar = memo(function TipsBar({ bottom, text }: TipsBarProps) {
+  return (
+    <View style={[styles.container, { bottom }]} pointerEvents="none">
+      <Text style={styles.label}>TIPS</Text>
+      <Text style={styles.text} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.82}>
+        {text}
+      </Text>
+    </View>
+  )
+})
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: TIPS_BAR_HEIGHT,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+    paddingHorizontal: 12,
+    zIndex: 20,
+  },
+  label: {
+    flexShrink: 0,
+    borderRadius: 4,
+    backgroundColor: '#E5E7EB',
+    color: '#4B5563',
+    fontSize: 10,
+    fontWeight: '800',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  text: {
+    flex: 1,
+    color: '#4B5563',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+})

--- a/goblin_native/src/shared/data/tips.json
+++ b/goblin_native/src/shared/data/tips.json
@@ -1,0 +1,44 @@
+{
+  "tips": [
+    {
+      "id": "factor_from_enemy",
+      "text": "ゴブリンたちは特定の敵から因子を獲得する可能性がある",
+      "enabled": true
+    },
+    {
+      "id": "tip_1",
+      "text": "ゴブリンは因子を引き継いで産まれてくることがある",
+      "enabled": true
+    },
+    {
+      "id": "tip_2",
+      "text": "因子を引き継ぐと因子由来の亜種になることがある",
+      "enabled": true
+    },
+    {
+      "id": "tip_3",
+      "text": "ゴブリンは固有スキルを持って産まれることがある",
+      "enabled": true
+    },
+    {
+      "id": "tip_4",
+      "text": "ゴブリンは因子による固有スキルを引き継ぐことがある",
+      "enabled": true
+    },
+    {
+      "id": "tip_5",
+      "text": "武器には近距離、遠距離武器がある",
+      "enabled": true
+    },
+    {
+      "id": "tip_6",
+      "text": "隊列によってダメージ補正がある",
+      "enabled": true
+    },
+    {
+      "id": "tip_7",
+      "text": "隊列が前に行くほど狙われやすい",
+      "enabled": true
+    }
+  ]
+}

--- a/tools/studio/src/App.tsx
+++ b/tools/studio/src/App.tsx
@@ -11,6 +11,7 @@ import { SkillCatalogPage } from './pages/SkillCatalogPage'
 import { EquipmentPoolPage } from './pages/EquipmentPoolPage'
 import { DungeonUnlockFlowPage } from './pages/DungeonUnlockFlowPage'
 import { BalanceReferencePage } from './pages/BalanceReferencePage'
+import { TipsPage } from './pages/TipsPage'
 import { PartyStoreProvider } from './stores/partyStore'
 
 export function App() {
@@ -27,6 +28,7 @@ export function App() {
             <Link to="/stories">ストーリー</Link>
             <Link to="/goblins">ゴブリン</Link>
             <Link to="/equipment">アイテム</Link>
+            <Link to="/tips">TIPS</Link>
             <Link to="/skills">Skill</Link>
             <Link to="/party">PT編成</Link>
             <Link to="/simulate">シミュレーション</Link>
@@ -43,6 +45,7 @@ export function App() {
             <Route path="/stories/:storyId" element={<StoryDetailPage />} />
             <Route path="/goblins" element={<GoblinDataPage />} />
             <Route path="/equipment" element={<EquipmentPoolPage />} />
+            <Route path="/tips" element={<TipsPage />} />
             <Route path="/skills" element={<SkillCatalogPage />} />
             <Route path="/party" element={<PartyPage />} />
             <Route path="/simulate" element={<SimulatePage />} />

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -34,6 +34,16 @@ interface StoryFile {
   stories: StoryRecord[]
 }
 
+interface TipRecord {
+  id: string
+  text: string
+  enabled: boolean
+}
+
+interface TipsFile {
+  tips: TipRecord[]
+}
+
 interface StorySummary {
   id: string
   title: string
@@ -146,6 +156,7 @@ export function dataApiPlugin(options: Options): Plugin {
   const areaDir = path.join(options.appSrc, 'shared', 'data', 'expeditionArea')
   const enemyDir = path.join(options.appSrc, 'shared', 'data', 'enemy')
   const storyFile = path.join(options.appSrc, 'shared', 'data', 'story', 'stories.json')
+  const tipsFile = path.join(options.appSrc, 'shared', 'data', 'tips.json')
   const racesFile = path.join(options.appSrc, 'shared', 'data', 'races.ts')
   const factorsFile = path.join(options.appSrc, 'shared', 'data', 'factors.ts')
   const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
@@ -285,6 +296,23 @@ export function dataApiPlugin(options: Options): Plugin {
           if (req.method === 'PUT') {
             const body = await readBody(req)
             await writeEquipmentPool(equipmentPoolFile, body)
+            return json(res, 200, { ok: true })
+          }
+          return json(res, 405, { error: 'Method not allowed' })
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          return json(res, 500, { error: message })
+        }
+      })
+
+      server.middlewares.use('/api/tips', async (req, res) => {
+        try {
+          if (req.method === 'GET') {
+            return json(res, 200, await readTipsFile(tipsFile))
+          }
+          if (req.method === 'PUT') {
+            const body = await readBody(req)
+            await writeTipsFile(tipsFile, body)
             return json(res, 200, { ok: true })
           }
           return json(res, 405, { error: 'Method not allowed' })
@@ -636,6 +664,34 @@ async function writeEquipmentPool(filePath: string, body: unknown): Promise<void
   await writeJson(filePath, body)
 }
 
+async function readTipsFile(filePath: string): Promise<TipsFile> {
+  const raw = await readJson(filePath)
+  if (!isTipsFileShape(raw)) {
+    throw new Error('Invalid tips file')
+  }
+  return raw
+}
+
+async function writeTipsFile(filePath: string, body: unknown): Promise<void> {
+  if (!isTipsFileShape(body)) {
+    throw new Error('Tips file must contain tips array with id/text/enabled')
+  }
+  const ids = new Set<string>()
+  for (const tip of body.tips) {
+    if (tip.id.trim() === '') {
+      throw new Error('Tip id must not be empty')
+    }
+    if (tip.text.trim() === '') {
+      throw new Error(`Tip ${tip.id} text must not be empty`)
+    }
+    if (ids.has(tip.id)) {
+      throw new Error(`Duplicate tip id: ${tip.id}`)
+    }
+    ids.add(tip.id)
+  }
+  await writeJson(filePath, body)
+}
+
 async function readJson(filePath: string): Promise<any> {
   const raw = await fs.readFile(filePath, 'utf8')
   return JSON.parse(raw)
@@ -760,6 +816,23 @@ function isStoryShape(value: unknown): value is StoryRecord {
     typeof record.order === 'number' &&
     Array.isArray(record.rewards) &&
     Array.isArray(record.chapters)
+  )
+}
+
+function isTipsFileShape(value: unknown): value is TipsFile {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    Array.isArray(record.tips) &&
+    record.tips.every((tip) => {
+      if (!tip || typeof tip !== 'object') return false
+      const tipRecord = tip as Record<string, unknown>
+      return (
+        typeof tipRecord.id === 'string' &&
+        typeof tipRecord.text === 'string' &&
+        typeof tipRecord.enabled === 'boolean'
+      )
+    })
   )
 }
 

--- a/tools/studio/src/pages/TipsPage.tsx
+++ b/tools/studio/src/pages/TipsPage.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+interface TipRecord {
+  id: string
+  text: string
+  enabled: boolean
+}
+
+interface TipsFile {
+  tips: TipRecord[]
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'error'; message: string }
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+const API_URL = '/api/tips'
+
+export function TipsPage() {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [tipsFile, setTipsFile] = useState<TipsFile | null>(null)
+  const originalRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoadState({ kind: 'loading' })
+    ;(async () => {
+      try {
+        const res = await fetch(API_URL)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const raw = await res.json()
+        if (!isTipsFile(raw)) {
+          throw new Error('tips.json の形式が不正です')
+        }
+        if (cancelled) return
+        originalRef.current = JSON.stringify(raw)
+        setTipsFile(raw)
+        setLoadState({ kind: 'ready' })
+      } catch (err) {
+        if (!cancelled) {
+          setLoadState({
+            kind: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = useMemo(() => {
+    if (!tipsFile || originalRef.current === null) return false
+    return JSON.stringify(tipsFile) !== originalRef.current
+  }, [tipsFile])
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  const updateTip = useCallback((index: number, patch: Partial<TipRecord>) => {
+    setTipsFile((prev) => {
+      if (!prev) return prev
+      return {
+        tips: prev.tips.map((tip, tipIndex) =>
+          tipIndex === index ? { ...tip, ...patch } : tip,
+        ),
+      }
+    })
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const addTip = useCallback(() => {
+    setTipsFile((prev) => {
+      if (!prev) return prev
+      return {
+        tips: [
+          ...prev.tips,
+          {
+            id: generateUniqueId(prev.tips),
+            text: '新しいTIPS',
+            enabled: true,
+          },
+        ],
+      }
+    })
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const deleteTip = useCallback((index: number) => {
+    setTipsFile((prev) => {
+      if (!prev) return prev
+      return { tips: prev.tips.filter((_, tipIndex) => tipIndex !== index) }
+    })
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!tipsFile) return
+    const error = validateTipsFile(tipsFile)
+    if (error) {
+      setSaveState({ kind: 'error', message: error })
+      return
+    }
+    setSaveState({ kind: 'saving' })
+    try {
+      const res = await fetch(API_URL, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tipsFile),
+      })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.error ?? `HTTP ${res.status}`)
+      }
+      originalRef.current = JSON.stringify(tipsFile)
+      setSaveState({ kind: 'success' })
+    } catch (err) {
+      setSaveState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [tipsFile])
+
+  const revert = useCallback(() => {
+    if (originalRef.current === null) return
+    setTipsFile(JSON.parse(originalRef.current) as TipsFile)
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  if (loadState.kind === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState.kind === 'error') {
+    return <p className="state-msg error">読み込みに失敗しました: {loadState.message}</p>
+  }
+  if (!tipsFile) return null
+
+  return (
+    <div className="detail">
+      <div className="detail-head">
+        <div>
+          <h2>TIPS管理</h2>
+          <p className="subtle">tips.json · {tipsFile.tips.length} 件</p>
+        </div>
+        <SaveBar isDirty={isDirty} saveState={saveState} onSave={save} onRevert={revert} />
+      </div>
+
+      <div className="panel-stack">
+        <div className="card">
+          <div className="tips-toolbar">
+            <button className="btn primary small" onClick={addTip}>
+              + 新規追加
+            </button>
+          </div>
+          <table className="enemy-table tips-table">
+            <thead>
+              <tr>
+                <th>有効</th>
+                <th>id</th>
+                <th>本文</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {tipsFile.tips.map((tip, index) => (
+                <tr key={`${tip.id}-${index}`}>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={tip.enabled}
+                      onChange={(e) => updateTip(index, { enabled: e.target.checked })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="inline-input"
+                      value={tip.id}
+                      onChange={(e) => updateTip(index, { id: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="inline-input flex1"
+                      value={tip.text}
+                      onChange={(e) => updateTip(index, { text: e.target.value })}
+                    />
+                  </td>
+                  <td className="num">
+                    <button className="btn ghost small" onClick={() => deleteTip(index)}>
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {tipsFile.tips.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="subtle">TIPSがありません</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SaveBar({
+  isDirty,
+  saveState,
+  onSave,
+  onRevert,
+}: {
+  isDirty: boolean
+  saveState: SaveState
+  onSave: () => void
+  onRevert: () => void
+}) {
+  return (
+    <div className="save-bar">
+      {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+      {saveState.kind === 'success' && !isDirty && <span className="saved">保存しました</span>}
+      {saveState.kind === 'error' && <span className="save-error">{saveState.message}</span>}
+      <button className="btn ghost" onClick={onRevert} disabled={!isDirty || saveState.kind === 'saving'}>
+        取り消し
+      </button>
+      <button className="btn primary" onClick={onSave} disabled={!isDirty || saveState.kind === 'saving'}>
+        保存
+      </button>
+    </div>
+  )
+}
+
+function isTipsFile(value: unknown): value is TipsFile {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    Array.isArray(record.tips) &&
+    record.tips.every((tip) => {
+      if (!tip || typeof tip !== 'object') return false
+      const tipRecord = tip as Record<string, unknown>
+      return (
+        typeof tipRecord.id === 'string' &&
+        typeof tipRecord.text === 'string' &&
+        typeof tipRecord.enabled === 'boolean'
+      )
+    })
+  )
+}
+
+function validateTipsFile(file: TipsFile): string | null {
+  const ids = new Set<string>()
+  for (const tip of file.tips) {
+    if (tip.id.trim() === '') return '空の id があります'
+    if (tip.text.trim() === '') return `本文が空です: ${tip.id}`
+    if (!/^[a-z0-9_]+$/.test(tip.id)) {
+      return `id は小文字英数字と _ のみにしてください: ${tip.id}`
+    }
+    if (ids.has(tip.id)) return `id が重複しています: ${tip.id}`
+    ids.add(tip.id)
+  }
+  return null
+}
+
+function generateUniqueId(tips: TipRecord[]): string {
+  const ids = new Set(tips.map((tip) => tip.id))
+  let n = 1
+  while (ids.has(`tip_${n}`)) n++
+  return `tip_${n}`
+}

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -308,6 +308,20 @@ code {
   background: var(--highlight);
 }
 
+.tips-table tbody tr {
+  cursor: default;
+}
+
+.tips-table td:nth-child(3) {
+  width: 100%;
+}
+
+.tips-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.8rem;
+}
+
 .enemy-table td.num,
 .enemy-table th.num,
 .weights td.num,


### PR DESCRIPTION
## Summary
- タブ画面下部に表示するTIPSバー (`TipsBar`) を追加し、`tips.json` からランダム抽選した文言を表示
- studioに `/tips` ページと `/api/tips` エンドポイントを追加し、TIPSの追加・編集・有効化を管理可能に
- タブバーレイアウトのバッジ位置をTIPSバー高さ分オフセットして調整

## Test plan
- [ ] iOS / Android で各タブを切り替えるたびにTIPSが切り替わるか確認
- [ ] 既存のバッジ (時刻 / ゴールド / 黄金どんぐり) の表示位置に重なりがないか確認
- [ ] studioの `/tips` ページからTIPSの追加・編集・無効化が `tips.json` に反映されるか確認
- [ ] `tips.json` を空にした際にフォールバック文言が表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)