### PR TITLE
balance(drop): 装備テンプレートのランクを1ずつ下げる

### DIFF
--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -51,71 +51,71 @@ function createDummyEnemy(overrides?: Partial<Enemy>): Enemy {
 
 describe('rollTreasureDrops', () => {
   describe('アイテムランク定義', () => {
-    it('最大ランクは 8。rank 0 は1カテゴリに複数個ありうる', () => {
-      // 剣（11アイテム: 下位3つはrank 0、その後1刻みで8まで）
+    it('最大ランクは 7。rank 0 は1カテゴリに複数個ありうる', () => {
+      // 剣（11アイテム: 下位4つはrank 0、その後1刻みで7まで）
       expect(getEquipmentTemplate('sword_cypress_stick')?.rank).toBe(0)
       expect(getEquipmentTemplate('sword_club')?.rank).toBe(0)
       expect(getEquipmentTemplate('sword_copper')?.rank).toBe(0)
-      expect(getEquipmentTemplate('sword_broad')?.rank).toBe(1)
-      expect(getEquipmentTemplate('sword_long')?.rank).toBe(2)
-      expect(getEquipmentTemplate('sword_mithril')?.rank).toBe(3)
-      expect(getEquipmentTemplate('sword_royal')?.rank).toBe(4)
-      expect(getEquipmentTemplate('sword_kaiser')?.rank).toBe(5)
-      expect(getEquipmentTemplate('sword_ancient')?.rank).toBe(6)
-      expect(getEquipmentTemplate('sword_dragon')?.rank).toBe(7)
-      expect(getEquipmentTemplate('sword_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('sword_broad')?.rank).toBe(0)
+      expect(getEquipmentTemplate('sword_long')?.rank).toBe(1)
+      expect(getEquipmentTemplate('sword_mithril')?.rank).toBe(2)
+      expect(getEquipmentTemplate('sword_royal')?.rank).toBe(3)
+      expect(getEquipmentTemplate('sword_kaiser')?.rank).toBe(4)
+      expect(getEquipmentTemplate('sword_ancient')?.rank).toBe(5)
+      expect(getEquipmentTemplate('sword_dragon')?.rank).toBe(6)
+      expect(getEquipmentTemplate('sword_adamant')?.rank).toBe(7)
 
       // 爪（剣と同じ配列）
       expect(getEquipmentTemplate('claw_sharp')?.rank).toBe(0)
       expect(getEquipmentTemplate('claw_beast')?.rank).toBe(0)
       expect(getEquipmentTemplate('claw_copper')?.rank).toBe(0)
-      expect(getEquipmentTemplate('claw_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('claw_adamant')?.rank).toBe(7)
 
-      // 弓（9アイテム: 0〜8）
+      // 弓（9アイテム: 0〜7）
       expect(getEquipmentTemplate('bow_slingshot')?.rank).toBe(0)
-      expect(getEquipmentTemplate('bow_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('bow_adamant')?.rank).toBe(7)
 
-      // 鎧（10アイテム: 下位2つがrank 0）
+      // 鎧（10アイテム: 下位3つがrank 0）
       expect(getEquipmentTemplate('armor_tattered_cloth')?.rank).toBe(0)
       expect(getEquipmentTemplate('armor_leather_vest')?.rank).toBe(0)
-      expect(getEquipmentTemplate('armor_fur_vest')?.rank).toBe(1)
-      expect(getEquipmentTemplate('armor_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('armor_fur_vest')?.rank).toBe(0)
+      expect(getEquipmentTemplate('armor_adamant')?.rank).toBe(7)
 
-      // 盾（9アイテム: 0〜8、入門帯を追加）
+      // 盾（9アイテム: 0〜7、入門帯を追加）
       expect(getEquipmentTemplate('shield_pot_lid')?.rank).toBe(0)
-      expect(getEquipmentTemplate('shield_wooden')?.rank).toBe(1)
-      expect(getEquipmentTemplate('shield_shield')?.rank).toBe(2)
-      expect(getEquipmentTemplate('shield_mithril')?.rank).toBe(3)
-      expect(getEquipmentTemplate('shield_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('shield_wooden')?.rank).toBe(0)
+      expect(getEquipmentTemplate('shield_shield')?.rank).toBe(1)
+      expect(getEquipmentTemplate('shield_mithril')?.rank).toBe(2)
+      expect(getEquipmentTemplate('shield_adamant')?.rank).toBe(7)
 
       // 小手（10アイテム: 下位2つがrank 0）
       expect(getEquipmentTemplate('gauntlet_cloth_gloves')?.rank).toBe(0)
       expect(getEquipmentTemplate('gauntlet_leather')?.rank).toBe(0)
-      expect(getEquipmentTemplate('gauntlet_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('gauntlet_adamant')?.rank).toBe(7)
 
-      // ワンド（9アイテム: 0〜8、入門帯を追加）
+      // ワンド（9アイテム: 0〜7、入門帯を追加）
       expect(getEquipmentTemplate('wand_twig')?.rank).toBe(0)
-      expect(getEquipmentTemplate('wand_apprentice')?.rank).toBe(1)
-      expect(getEquipmentTemplate('wand_wand')?.rank).toBe(2)
-      expect(getEquipmentTemplate('wand_mithril')?.rank).toBe(3)
-      expect(getEquipmentTemplate('wand_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('wand_apprentice')?.rank).toBe(0)
+      expect(getEquipmentTemplate('wand_wand')?.rank).toBe(1)
+      expect(getEquipmentTemplate('wand_mithril')?.rank).toBe(2)
+      expect(getEquipmentTemplate('wand_adamant')?.rank).toBe(7)
 
-      // ロッド（9アイテム: 0〜8、入門帯を追加）
+      // ロッド（9アイテム: 0〜7、入門帯を追加）
       expect(getEquipmentTemplate('rod_acolyte')?.rank).toBe(0)
-      expect(getEquipmentTemplate('rod_wooden')?.rank).toBe(1)
-      expect(getEquipmentTemplate('rod_rod')?.rank).toBe(2)
-      expect(getEquipmentTemplate('rod_mithril')?.rank).toBe(3)
-      expect(getEquipmentTemplate('rod_adamant')?.rank).toBe(8)
+      expect(getEquipmentTemplate('rod_wooden')?.rank).toBe(0)
+      expect(getEquipmentTemplate('rod_rod')?.rank).toBe(1)
+      expect(getEquipmentTemplate('rod_mithril')?.rank).toBe(2)
+      expect(getEquipmentTemplate('rod_adamant')?.rank).toBe(7)
     })
 
-    it('装備の rank は全カテゴリで 0〜8 に収まる', () => {
-      for (let r = 0; r <= 8; r++) {
+    it('装備の rank は全カテゴリで 0〜7 に収まる', () => {
+      for (let r = 0; r <= 7; r++) {
         // 各ランクに最低1アイテムは存在する（全カテゴリ合算）
         expect(getEquipmentByRank(r).length).toBeGreaterThan(0)
       }
-      // rank 9 以上は存在しない
+      // rank 8 以上は存在しない
+      expect(getEquipmentByRank(8).length).toBe(0)
       expect(getEquipmentByRank(9).length).toBe(0)
-      expect(getEquipmentByRank(10).length).toBe(0)
     })
 
     it('getEquipmentByRank(0) は全カテゴリの最弱装備を含む（盾/ワンド/ロッドの入門帯も）', () => {
@@ -130,17 +130,17 @@ describe('rollTreasureDrops', () => {
       expect(ids.has('rod_acolyte')).toBe(true)
     })
 
-    it('getEquipmentByRank(1) は各カテゴリの入門上位を含む', () => {
+    it('getEquipmentByRank(1) は各カテゴリのスタンダード帯を含む', () => {
       const ids = new Set(getEquipmentByRank(1).map((t) => t.id))
-      expect(ids.has('shield_wooden')).toBe(true)
-      expect(ids.has('wand_apprentice')).toBe(true)
-      expect(ids.has('rod_wooden')).toBe(true)
-      expect(ids.has('sword_broad')).toBe(true)
-      expect(ids.has('armor_fur_vest')).toBe(true)
+      expect(ids.has('shield_shield')).toBe(true)
+      expect(ids.has('wand_wand')).toBe(true)
+      expect(ids.has('rod_rod')).toBe(true)
+      expect(ids.has('sword_long')).toBe(true)
+      expect(ids.has('armor_armor')).toBe(true)
     })
 
-    it('getEquipmentByRank(8) は全カテゴリのアダマント装備を含む', () => {
-      const ids = new Set(getEquipmentByRank(8).map((t) => t.id))
+    it('getEquipmentByRank(7) は全カテゴリのアダマント装備を含む', () => {
+      const ids = new Set(getEquipmentByRank(7).map((t) => t.id))
       expect(ids.has('sword_adamant')).toBe(true)
       expect(ids.has('claw_adamant')).toBe(true)
       expect(ids.has('bow_adamant')).toBe(true)
@@ -460,7 +460,7 @@ describe('rollTreasureDrops', () => {
     })
 
     it('rare=1 のときレアドロップ率は極めて低い (約 0.1% 以下)', () => {
-      // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank5) はノーマルでは出ない
+      // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank4) はノーマルでは出ない
       const enemy = createDummyEnemy({
         level: 1,
         rareEquipmentDrops: [{ templateId: 'sword_kaiser' }],
@@ -478,7 +478,7 @@ describe('rollTreasureDrops', () => {
     })
 
     it('rareDropMultiplierBoost を 2 にするとレアドロップ率が上がる（ノーマルには波及しない）', () => {
-      // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank5) はノーマルでは出ない
+      // 敵レベル1のためノーマルは rank0 のみ → sword_kaiser (rank4) はノーマルでは出ない
       const enemy = createDummyEnemy({
         level: 1,
         rareEquipmentDrops: [{ templateId: 'sword_kaiser' }],

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -112,7 +112,7 @@
       "range": "melee",
       "price": 60,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "sword_long",
@@ -143,7 +143,7 @@
       "range": "melee",
       "price": 100,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "sword_mithril",
@@ -174,7 +174,7 @@
       "range": "melee",
       "price": 500,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "sword_royal",
@@ -205,7 +205,7 @@
       "range": "melee",
       "price": 2500,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "sword_kaiser",
@@ -236,7 +236,7 @@
       "range": "melee",
       "price": 12500,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "sword_ancient",
@@ -267,7 +267,7 @@
       "range": "melee",
       "price": 60000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "sword_dragon",
@@ -297,7 +297,7 @@
       ],
       "range": "melee",
       "price": 240000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "sword_adamant",
@@ -327,7 +327,7 @@
       ],
       "range": "melee",
       "price": 720000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 武器:爪 (melee) ====="
@@ -422,7 +422,7 @@
       "range": "melee",
       "price": 60,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "claw_steel",
@@ -445,7 +445,7 @@
       "range": "melee",
       "price": 100,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "claw_mithril",
@@ -468,7 +468,7 @@
       "range": "melee",
       "price": 500,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "claw_royal",
@@ -491,7 +491,7 @@
       "range": "melee",
       "price": 2500,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "claw_kaiser",
@@ -514,7 +514,7 @@
       "range": "melee",
       "price": 12500,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "claw_ancient",
@@ -537,7 +537,7 @@
       "range": "melee",
       "price": 60000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "claw_dragon",
@@ -559,7 +559,7 @@
       ],
       "range": "melee",
       "price": 240000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "claw_adamant",
@@ -581,7 +581,7 @@
       ],
       "range": "melee",
       "price": 720000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 武器:弓 (ranged) ====="
@@ -628,7 +628,7 @@
       "range": "ranged",
       "price": 40,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "bow_long",
@@ -659,7 +659,7 @@
       "range": "ranged",
       "price": 1000,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "bow_mithril",
@@ -690,7 +690,7 @@
       "range": "ranged",
       "price": 5000,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "bow_royal",
@@ -721,7 +721,7 @@
       "range": "ranged",
       "price": 25000,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "bow_kaiser",
@@ -752,7 +752,7 @@
       "range": "ranged",
       "price": 125000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "bow_ancient",
@@ -783,7 +783,7 @@
       "range": "ranged",
       "price": 500000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "bow_dragon",
@@ -813,7 +813,7 @@
       ],
       "range": "ranged",
       "price": 1500000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "bow_adamant",
@@ -843,7 +843,7 @@
       ],
       "range": "ranged",
       "price": 3000000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 防具:鎧 (armor) ====="
@@ -909,7 +909,7 @@
       ],
       "price": 30,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "armor_armor",
@@ -934,7 +934,7 @@
       ],
       "price": 100,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "armor_mithril",
@@ -959,7 +959,7 @@
       ],
       "price": 500,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "armor_royal",
@@ -984,7 +984,7 @@
       ],
       "price": 2500,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "armor_kaiser",
@@ -1009,7 +1009,7 @@
       ],
       "price": 12500,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "armor_ancient",
@@ -1034,7 +1034,7 @@
       ],
       "price": 60000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "armor_dragon",
@@ -1058,7 +1058,7 @@
         "physical_reduction_11"
       ],
       "price": 240000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "armor_adamant",
@@ -1082,7 +1082,7 @@
         "physical_reduction_12"
       ],
       "price": 720000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 防具:ローブ (robe) ====="
@@ -1107,7 +1107,7 @@
       ],
       "price": 200,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "robe_mithril",
@@ -1128,7 +1128,7 @@
         "magic_reduction_7"
       ],
       "price": 1000,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "robe_royal",
@@ -1149,7 +1149,7 @@
         "magic_reduction_8"
       ],
       "price": 5000,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "robe_kaiser",
@@ -1171,7 +1171,7 @@
       ],
       "price": 25000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "robe_ancient",
@@ -1193,7 +1193,7 @@
       ],
       "price": 125000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "robe_dragon",
@@ -1214,7 +1214,7 @@
         "magic_reduction_11"
       ],
       "price": 500000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "robe_adamant",
@@ -1235,7 +1235,7 @@
         "magic_reduction_12"
       ],
       "price": 1500000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 防具:盾 (shield) ====="
@@ -1278,7 +1278,7 @@
       ],
       "price": 30,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "shield_shield",
@@ -1309,7 +1309,7 @@
       ],
       "price": 80,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "shield_mithril",
@@ -1340,7 +1340,7 @@
       ],
       "price": 400,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "shield_royal",
@@ -1371,7 +1371,7 @@
       ],
       "price": 2000,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "shield_kaiser",
@@ -1402,7 +1402,7 @@
       ],
       "price": 10000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "shield_ancient",
@@ -1433,7 +1433,7 @@
       ],
       "price": 50000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "shield_dragon",
@@ -1463,7 +1463,7 @@
         "breath_reduction_11"
       ],
       "price": 200000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "shield_adamant",
@@ -1493,7 +1493,7 @@
         "breath_reduction_12"
       ],
       "price": 600000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 防具:小手 (gauntlet) ====="
@@ -1574,7 +1574,7 @@
       ],
       "price": 30,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "gauntlet_gauntlet",
@@ -1600,7 +1600,7 @@
       ],
       "price": 2000,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "gauntlet_mithril",
@@ -1626,7 +1626,7 @@
       ],
       "price": 10000,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "gauntlet_royal",
@@ -1652,7 +1652,7 @@
       ],
       "price": 50000,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "gauntlet_kaiser",
@@ -1678,7 +1678,7 @@
       ],
       "price": 250000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "gauntlet_ancient",
@@ -1704,7 +1704,7 @@
       ],
       "price": 1250000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "gauntlet_dragon",
@@ -1729,7 +1729,7 @@
         "critical_rate_up_10"
       ],
       "price": 2500000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "gauntlet_adamant",
@@ -1754,7 +1754,7 @@
         "critical_rate_up_10"
       ],
       "price": 5000000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 魔具:ワンド (wand) ====="
@@ -1789,7 +1789,7 @@
       ],
       "price": 30,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "wand_wand",
@@ -1810,7 +1810,7 @@
       ],
       "price": 200,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "wand_mithril",
@@ -1831,7 +1831,7 @@
       ],
       "price": 1000,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "wand_royal",
@@ -1852,7 +1852,7 @@
       ],
       "price": 5000,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "wand_kaiser",
@@ -1873,7 +1873,7 @@
       ],
       "price": 25000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "wand_ancient",
@@ -1894,7 +1894,7 @@
       ],
       "price": 125000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "wand_dragon",
@@ -1914,7 +1914,7 @@
         "spell_damage_15"
       ],
       "price": 500000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "wand_adamant",
@@ -1934,7 +1934,7 @@
         "spell_damage_16"
       ],
       "price": 1500000,
-      "rank": 8
+      "rank": 7
     },
     {
       "_comment": "===== 魔具:ロッド (rod) ====="
@@ -1969,7 +1969,7 @@
       ],
       "price": 30,
       "unlockRank": 1,
-      "rank": 1
+      "rank": 0
     },
     {
       "id": "rod_rod",
@@ -1990,7 +1990,7 @@
       ],
       "price": 200,
       "unlockRank": 1,
-      "rank": 2
+      "rank": 1
     },
     {
       "id": "rod_mithril",
@@ -2011,7 +2011,7 @@
       ],
       "price": 1000,
       "unlockRank": 2,
-      "rank": 3
+      "rank": 2
     },
     {
       "id": "rod_royal",
@@ -2032,7 +2032,7 @@
       ],
       "price": 5000,
       "unlockRank": 2,
-      "rank": 4
+      "rank": 3
     },
     {
       "id": "rod_kaiser",
@@ -2053,7 +2053,7 @@
       ],
       "price": 25000,
       "unlockRank": 3,
-      "rank": 5
+      "rank": 4
     },
     {
       "id": "rod_ancient",
@@ -2074,7 +2074,7 @@
       ],
       "price": 125000,
       "unlockRank": 5,
-      "rank": 6
+      "rank": 5
     },
     {
       "id": "rod_dragon",
@@ -2094,7 +2094,7 @@
         "magic_heal_to_hp_11"
       ],
       "price": 500000,
-      "rank": 7
+      "rank": 6
     },
     {
       "id": "rod_adamant",
@@ -2114,7 +2114,7 @@
         "magic_heal_to_hp_12"
       ],
       "price": 1500000,
-      "rank": 8
+      "rank": 7
     },
     {
       "id": "accessory_split_core",


### PR DESCRIPTION
## Summary
- 各装備カテゴリの \`rank\` 値を一律 -1（rank 0 はそのまま据え置き）
- 同じ敵レベル / 同じ \`DROP_RANK_TABLE\` でも、従来より1ティア上位の装備が出やすくなり低レベル帯のドロップ体験を改善
- 最大ランクは 8（adamant）→ 7 に縮小

## 影響範囲
- \`src/shared/data/equipmentPool.json\`: 71件の \`rank\` を -1（broad/iron/short/fur_vest/wooden/copper/apprentice 等の入門上位帯が rank 0 へ合流）
- \`DROP_RANK_TABLE\` / \`DropRankRoller\` 側は変更なし
- \`unlockRank\` ベースの商店ロジックには影響なし

## 確認内容
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npx jest\`（22 suite / 414 tests）すべて pass
- [x] \`TreasureDrop.test.ts\` の rank 期待値・最大ランクを新配置に合わせて更新
- [ ] 実機で低〜中レベル帯の遠征ドロップを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)