### PR TITLE
feat(training): ジョブ取得後のゴブリンを訓練対象から除外

### DIFF
--- a/goblin_native/app/base/training.tsx
+++ b/goblin_native/app/base/training.tsx
@@ -199,6 +199,7 @@ export default function BaseTrainingScreen() {
 
         <View style={styles.noteCard}>
           <Text style={styles.noteText}>{t('ui.training.noteGoblinOnly')}</Text>
+          <Text style={styles.noteText}>{t('ui.training.noteJobLocked')}</Text>
         </View>
       </ScrollView>
 

--- a/goblin_native/src/shared/data/__tests__/goblinJobs.test.ts
+++ b/goblin_native/src/shared/data/__tests__/goblinJobs.test.ts
@@ -43,6 +43,11 @@ describe('goblinJobs', () => {
     expect(canTrainGoblin(createGoblin({ id: 0, race: '始祖ゴブリン', raceId: 'founder' }))).toBe(false)
   })
 
+  it('既にジョブを持つゴブリンは訓練対象にならない', () => {
+    expect(canTrainGoblin(createGoblin({ race: 'ゴブリン', job: 'guard' }))).toBe(false)
+    expect(canTrainGoblin(createGoblin({ race: 'ゴブリン', job: 'mage' }))).toBe(false)
+  })
+
   it('ジョブ変更時に種族スキルとジョブスキルを再構成し、その他のスキルは保持する', () => {
     const goblin = createGoblin({
       job: 'guard',

--- a/goblin_native/src/shared/data/goblinJobs.ts
+++ b/goblin_native/src/shared/data/goblinJobs.ts
@@ -240,7 +240,7 @@ export function isPureGoblin(goblin: Goblin): boolean {
 }
 
 export function canTrainGoblin(goblin: Goblin): boolean {
-  return isPureGoblin(goblin) && !isProtectedGoblin(goblin)
+  return isPureGoblin(goblin) && !isProtectedGoblin(goblin) && !goblin.job
 }
 
 export function getGoblinJobSkills(job: GoblinJob, level: number): CharacterSkill[] {

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -265,6 +265,7 @@ const en = {
       trainButton: 'Train {{name}}',
       selectJobPlaceholder: 'Select a job',
       noteGoblinOnly: 'Only goblins can be trained. Slime goblins and wolf goblins cannot be trained.',
+      noteJobLocked: 'Once a goblin has been assigned a job, the job cannot be changed.',
       modalTitle: 'Select Training Target',
       modalEmpty: 'No goblins available to select',
       modalGoblinLine: '{{race}} / {{jobName}}',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -265,6 +265,7 @@ const ja = {
       trainButton: '{{name}}を訓練する',
       selectJobPlaceholder: 'ジョブを選択してください',
       noteGoblinOnly: '・訓練はゴブリンのみ対象です。スライムゴブリン、ウルフゴブリンは訓練できません。',
+      noteJobLocked: '・一度ジョブに就いたゴブリンは、ジョブを変更できません。',
       modalTitle: '訓練対象を選択',
       modalEmpty: '選択できるゴブリンがいません',
       modalGoblinLine: '{{race}} / {{jobName}}',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -264,6 +264,7 @@ const ko = {
       trainButton: '{{name}} 훈련하기',
       selectJobPlaceholder: '직업을 선택하세요',
       noteGoblinOnly: '훈련 대상은 고블린뿐입니다. 슬라임 고블린과 울프 고블린은 훈련할 수 없습니다.',
+      noteJobLocked: '한번 직업을 얻은 고블린은 직업을 변경할 수 없습니다.',
       modalTitle: '훈련 대상 선택',
       modalEmpty: '선택할 수 있는 고블린이 없습니다',
       modalGoblinLine: '{{race}} / {{jobName}}',


### PR DESCRIPTION
## Summary
- 拠点訓練所で、すでにジョブを得ているゴブリンを訓練対象から除外
- 一度ジョブに就いたゴブリンはジョブ変更不可となるように仕様変更
- 訓練画面の注意書きに変更不可の旨を追記 (ja/en/ko)

## 主要変更
- `src/shared/data/goblinJobs.ts` `canTrainGoblin` に `!goblin.job` 条件を追加
- `src/shared/data/__tests__/goblinJobs.test.ts` ジョブ済みゴブリンが対象外になるテストを追加
- `app/base/training.tsx` 注意書きに `noteJobLocked` を表示
- `src/shared/i18n/resources/{ja,en,ko}.ts` `noteJobLocked` を追加

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest src/shared/data/__tests__/goblinJobs.test.ts`
- [ ] 訓練所画面で、ジョブ未取得ゴブリンのみが選択モーダルに出ることを確認
- [ ] ジョブ取得済みゴブリンを訓練対象として選択できないことを確認
- [ ] 注意書きに「一度ジョブに就いたら変更不可」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)