### PR TITLE
feat(base): ランクアップ可能時に拠点タブと拠点拡張メニューに!バッジを表示

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -14,6 +14,7 @@ import { GoldBadge } from '@/presentation/components/GoldBadge'
 import { GoldenAcornBadge } from '@/presentation/components/GoldenAcornBadge'
 import { TipsBar, TIPS_BAR_HEIGHT } from '@/presentation/components/TipsBar'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
+import { useBaseStore, selectCanRankUp } from '@/presentation/stores/useBaseStore'
 import { useTutorialStore } from '@/presentation/stores/useTutorialStore'
 import { useTutorialOverlayStore } from '@/presentation/stores/useTutorialOverlayStore'
 import tipsData from '@/shared/data/tips.json'
@@ -66,6 +67,7 @@ export default function TabLayout() {
   const pathname = usePathname()
   const tipText = useMemo(() => pickTipText(), [pathname])
   const unreadCount = useStoryStore((state) => state.unreadCount)
+  const canRankUp = useBaseStore(selectCanRankUp)
   const insets = useSafeAreaInsets()
   const basePadding = 8
   const baseHeight = 60
@@ -186,6 +188,8 @@ export default function TabLayout() {
           headerTitle: t('ui.tabs.base'),
           headerShown: false,
           tabBarIcon: ({ color }) => <TabIcon Icon={BaseIcon} color={color} size={40} />,
+          tabBarBadge: canRankUp ? '!' : undefined,
+          tabBarBadgeStyle: { backgroundColor: '#DC2626', color: '#FFFFFF', fontSize: 10, fontWeight: '800' },
         }}
       />
       <Tabs.Screen

--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import type { Href } from 'expo-router'
 import { useTranslation } from 'react-i18next'
-import { useBaseStore, selectRank, selectMaxParties, selectMaxGoblins } from '@/presentation/stores/useBaseStore'
+import { useBaseStore, selectRank, selectMaxParties, selectMaxGoblins, selectCanRankUp } from '@/presentation/stores/useBaseStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { GOBLIN_TRAINING_UNLOCK_RANK } from '@/shared/data/goblinJobs'
 import { getBaseLocationName } from '@/shared/i18n/entityLocalization'
@@ -32,6 +32,7 @@ type BaseMenuItem = {
   href: Extract<Href, string>
   unlockRank: number
   Icon: FC<SvgProps>
+  showBadge?: boolean
 }
 
 export default function BaseManagementScreen() {
@@ -40,6 +41,7 @@ export default function BaseManagementScreen() {
   const rank = useBaseStore(selectRank)
   const maxParties = useBaseStore(selectMaxParties)
   const maxGoblins = useBaseStore(selectMaxGoblins)
+  const canRankUp = useBaseStore(selectCanRankUp)
   const goblins = useGoblinStore((state) => state.goblins)
   const baseLocationName = getBaseLocationName(rank) || t('ui.base.locationUnknown')
   const baseHeaderImage = baseHeaderImages[rank] ?? baseHeaderImages[4]
@@ -58,6 +60,7 @@ export default function BaseManagementScreen() {
       href: '/base/upgrade' as const,
       unlockRank: 1,
       Icon: UpgradeIcon,
+      showBadge: canRankUp,
     },
     {
       title: t('ui.base.trainingTitle'),
@@ -139,7 +142,14 @@ export default function BaseManagementScreen() {
           <View style={styles.menuList}>
             {menuItems.map((item) => (
               <TouchableOpacity key={item.href} style={styles.menuButton} onPress={() => router.push(item.href)}>
-                <item.Icon width={42} height={42} />
+                <View style={styles.menuButtonIconWrap}>
+                  <item.Icon width={42} height={42} />
+                  {item.showBadge ? (
+                    <View style={styles.menuButtonBadge} pointerEvents="none">
+                      <Text style={styles.menuButtonBadgeText}>!</Text>
+                    </View>
+                  ) : null}
+                </View>
                 <View style={styles.menuButtonTextGroup}>
                   <Text style={styles.menuButtonTitle}>{item.title}</Text>
                   <Text style={styles.menuButtonDescription}>{item.description}</Text>
@@ -346,6 +356,31 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 6,
     shadowOffset: { width: 0, height: 2 },
+  },
+  menuButtonIconWrap: {
+    width: 42,
+    height: 42,
+    position: 'relative',
+  },
+  menuButtonBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 18,
+    height: 18,
+    paddingHorizontal: 4,
+    borderRadius: 9,
+    backgroundColor: '#DC2626',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderColor: '#FFFFFF',
+  },
+  menuButtonBadgeText: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontWeight: '800',
+    color: '#FFFFFF',
   },
   menuButtonTextGroup: {
     flex: 1,

--- a/goblin_native/src/presentation/stores/useBaseStore.ts
+++ b/goblin_native/src/presentation/stores/useBaseStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import type { BaseState, Goblin } from '../../shared/types'
 import { SQLiteBaseStateRepository } from '../../infrastructure/repositories'
 import { SQLitePendingGoblinRepository } from '../../infrastructure/repositories'
-import { performRankUp as executeRankUp } from '../../core/services/BaseRankSystem'
+import { performRankUp as executeRankUp, checkRankUpAvailable } from '../../core/services/BaseRankSystem'
 
 const baseStateRepository = SQLiteBaseStateRepository.getInstance()
 const pendingGoblinRepository = SQLitePendingGoblinRepository.getInstance()
@@ -104,6 +104,8 @@ export const selectMaxParties = (s: BaseStoreState) => s.baseState?.currentMaxPa
 export const selectIvBonus = (s: BaseStoreState) => s.baseState?.currentIVBonus ?? 0
 export const selectGold = (s: BaseStoreState) => s.baseState?.gold ?? 0
 export const selectCapacity = (s: BaseStoreState) => s.baseState?.capacity ?? 10
+export const selectCanRankUp = (s: BaseStoreState) =>
+  s.baseState ? checkRankUpAvailable(s.baseState).canRankUp : false
 
 /** UseCase等にリポジトリを渡す必要がある場合に使用 */
 export const getBaseStateRepository = () => baseStateRepository


### PR DESCRIPTION
## Summary
- 拠点制圧アラートを誤って閉じても気づけるよう、ランクアップ可能になったタイミングで「拠点タブ」と「拠点管理画面の拠点拡張メニュー」に `!` バッジを表示
- 既存の `checkRankUpAvailable(baseState)` を再利用した `selectCanRankUp` selector を `useBaseStore` に追加
- ランクアップ実行で次ランクの解禁条件未達となり、両バッジが自動的に消える

## 動作対象
拠点ランクアップ条件を満たすすべてのダンジョン制圧時に動作（`isBaseCapture: true` のダンジョンと完全に整合）。

| 達成ランク | 制圧条件ダンジョン |
|-----------|-------------|
| → ランク2 | ゴブリン集落・中枢 |
| → ランク3 | 辺境の村 |
| → ランク4 | オークの砦 |
| → ランク5 | 辺境の城・本丸 |
| → ランク6 | ヴァンパイアの古城 |
| → ランク7 | 王都決戦・玉座の間 |

## Test plan
- [ ] ゴブリン集落・中枢を初回制圧 → 拠点タブと拠点拡張メニューに `!` バッジが表示される
- [ ] アラートを閉じてもバッジは残る
- [ ] `/base/upgrade` でランクアップ実行 → バッジが消える
- [ ] 次の対象ダンジョン（辺境の村など）を制圧 → 再度バッジが点灯
- [ ] `npx tsc --noEmit` がエラーなく通る