### PR TITLE
feat(expedition): areaLevelを各エリアの最低敵レベルに揃える

### DIFF
--- a/goblin_native/src/shared/data/enemy/goblin_village_1.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_1.json
@@ -13,7 +13,7 @@
       "attackCount": 2,
       "accuracy": 200,
       "evasion": 14,
-      "exp": 8,
+      "exp": 15,
       "gold": 6,
       "magicDef": 4,
       "baseAttributes": {
@@ -38,7 +38,7 @@
       "attackCount": 2,
       "accuracy": 215,
       "evasion": 17,
-      "exp": 12,
+      "exp": 15,
       "gold": 10,
       "magicDef": 1,
       "baseAttributes": {
@@ -89,7 +89,7 @@
       "attackCount": 2,
       "accuracy": 230,
       "evasion": 13,
-      "exp": 18,
+      "exp": 15,
       "gold": 15,
       "skills": [
         {
@@ -121,7 +121,7 @@
       "attackCount": 2,
       "accuracy": 240,
       "evasion": 14,
-      "exp": 20,
+      "exp": 18,
       "gold": 18,
       "magicDef": 36,
       "baseAttributes": {

--- a/goblin_native/src/shared/data/enemy/goblin_village_2.json
+++ b/goblin_native/src/shared/data/enemy/goblin_village_2.json
@@ -13,7 +13,7 @@
       "attackCount": 2,
       "accuracy": 200,
       "evasion": 15,
-      "exp": 8,
+      "exp": 18,
       "gold": 6,
       "magicDef": 4,
       "baseAttributes": {
@@ -38,7 +38,7 @@
       "attackCount": 2,
       "accuracy": 215,
       "evasion": 18,
-      "exp": 12,
+      "exp": 18,
       "gold": 10,
       "magicDef": 1,
       "baseAttributes": {
@@ -63,7 +63,7 @@
       "attackCount": 2,
       "accuracy": 230,
       "evasion": 15,
-      "exp": 15,
+      "exp": 18,
       "gold": 12,
       "magicDef": 7,
       "baseAttributes": {
@@ -121,7 +121,7 @@
       "attackCount": 2,
       "accuracy": 240,
       "evasion": 12,
-      "exp": 20,
+      "exp": 18,
       "gold": 18,
       "magicDef": 36,
       "baseAttributes": {

--- a/goblin_native/src/shared/data/enemy/orc_fortress_1.json
+++ b/goblin_native/src/shared/data/enemy/orc_fortress_1.json
@@ -6,15 +6,15 @@
       "raceTags": [
         "orc"
       ],
-      "level": 42,
-      "hp": 1064,
+      "level": 45,
+      "hp": 1290,
       "atk": 294,
-      "def": 70,
+      "def": 149,
       "magicDef": 50,
       "attackCount": 5,
       "accuracy": 560,
-      "evasion": 46,
-      "exp": 59,
+      "evasion": 44,
+      "exp": 203,
       "gold": 50,
       "skills": [
         {
@@ -44,15 +44,15 @@
       "raceTags": [
         "orc"
       ],
-      "level": 40,
-      "hp": 840,
+      "level": 45,
+      "hp": 1060,
       "atk": 200,
-      "def": 13,
+      "def": 122,
       "magicDef": 20,
       "attackCount": 4,
       "accuracy": 560,
-      "evasion": 46,
-      "exp": 45,
+      "evasion": 61,
+      "exp": 203,
       "gold": 37,
       "skills": [
         {
@@ -75,15 +75,15 @@
       "raceTags": [
         "troll"
       ],
-      "level": 44,
-      "hp": 1115,
+      "level": 47,
+      "hp": 1370,
       "atk": 308,
-      "def": 73,
+      "def": 156,
       "magicDef": 53,
       "attackCount": 5,
       "accuracy": 560,
       "evasion": 46,
-      "exp": 62,
+      "exp": 212,
       "gold": 53,
       "skills": [
         {
@@ -110,15 +110,15 @@
       "raceTags": [
         "orc"
       ],
-      "level": 54,
-      "hp": 1850,
+      "level": 65,
+      "hp": 2590,
       "atk": 473,
-      "def": 135,
+      "def": 283,
       "magicDef": 61,
       "attackCount": 7,
       "accuracy": 640,
-      "evasion": 52,
-      "exp": 270,
+      "evasion": 73,
+      "exp": 293,
       "gold": 216,
       "skills": [
         {

--- a/goblin_native/src/shared/data/enemy/road_1.json
+++ b/goblin_native/src/shared/data/enemy/road_1.json
@@ -6,14 +6,14 @@
       "raceTags": [
         "beast"
       ],
-      "level": 8,
-      "hp": 80,
+      "level": 14,
+      "hp": 130,
       "atk": 18,
-      "def": 15,
+      "def": 20,
       "attackCount": 2,
       "accuracy": 270,
-      "evasion": 18,
-      "exp": 24,
+      "evasion": 22,
+      "exp": 42,
       "gold": 16,
       "magicDef": 7,
       "baseAttributes": {
@@ -31,14 +31,14 @@
       "raceTags": [
         "beast"
       ],
-      "level": 9,
-      "hp": 100,
+      "level": 14,
+      "hp": 170,
       "atk": 24,
-      "def": 20,
+      "def": 25,
       "attackCount": 3,
       "accuracy": 300,
       "evasion": 18,
-      "exp": 32,
+      "exp": 42,
       "gold": 22,
       "magicDef": 10,
       "baseAttributes": {
@@ -56,14 +56,14 @@
       "raceTags": [
         "insect"
       ],
-      "level": 10,
-      "hp": 130,
+      "level": 14,
+      "hp": 260,
       "atk": 28,
-      "def": 34,
+      "def": 41,
       "attackCount": 3,
       "accuracy": 305,
-      "evasion": 17,
-      "exp": 38,
+      "evasion": 13,
+      "exp": 42,
       "gold": 26,
       "magicDef": 19,
       "baseAttributes": {
@@ -88,7 +88,7 @@
       "attackCount": 0,
       "accuracy": 0,
       "evasion": 28,
-      "exp": 120,
+      "exp": 98,
       "gold": 180,
       "magicDef": 33,
       "baseAttributes": {
@@ -113,7 +113,7 @@
       "attackCount": 1,
       "accuracy": 380,
       "evasion": 25,
-      "exp": 85,
+      "exp": 104,
       "gold": 70,
       "skills": [
         {
@@ -145,7 +145,7 @@
       "attackCount": 10,
       "accuracy": 395,
       "evasion": 28,
-      "exp": 90,
+      "exp": 104,
       "gold": 72,
       "magicDef": 33,
       "baseAttributes": {
@@ -171,7 +171,7 @@
       "attackCount": 1,
       "accuracy": 385,
       "evasion": 28,
-      "exp": 92,
+      "exp": 98,
       "gold": 76,
       "skills": [
         {
@@ -209,7 +209,7 @@
       "attackCount": 1,
       "accuracy": 375,
       "evasion": 27,
-      "exp": 95,
+      "exp": 98,
       "gold": 78,
       "skills": [
         {

--- a/goblin_native/src/shared/data/expeditionArea/allArea.json
+++ b/goblin_native/src/shared/data/expeditionArea/allArea.json
@@ -14,7 +14,7 @@
     {
       "id": "forest_outskirts",
       "name": "周辺の森",
-      "areaLevel": 4,
+      "areaLevel": 2,
       "floors": 3,
       "exploration_time_sec_first": 180,
       "exploration_time_sec": 60,
@@ -25,7 +25,7 @@
     {
       "id": "goblin_village_1",
       "name": "ゴブリン集落・外縁",
-      "areaLevel": 6,
+      "areaLevel": 5,
       "floors": 2,
       "exploration_time_sec_first": 540,
       "exploration_time_sec": 180,
@@ -36,7 +36,7 @@
     {
       "id": "goblin_village_2",
       "name": "ゴブリン集落・内部",
-      "areaLevel": 7,
+      "areaLevel": 6,
       "floors": 2,
       "exploration_time_sec_first": 600,
       "exploration_time_sec": 200,
@@ -47,7 +47,7 @@
     {
       "id": "goblin_village_3",
       "name": "ゴブリン集落・中枢",
-      "areaLevel": 8,
+      "areaLevel": 7,
       "floors": 2,
       "exploration_time_sec_first": 720,
       "exploration_time_sec": 240,
@@ -60,7 +60,7 @@
     {
       "id": "undead_ruins_1",
       "name": "忘れられた廃墟・入口",
-      "areaLevel": 9,
+      "areaLevel": 10,
       "floors": 2,
       "exploration_time_sec_first": 900,
       "exploration_time_sec": 300,
@@ -82,7 +82,7 @@
     {
       "id": "undead_ruins_3",
       "name": "忘れられた廃墟・最奥",
-      "areaLevel": 11,
+      "areaLevel": 10,
       "floors": 2,
       "exploration_time_sec_first": 1260,
       "exploration_time_sec": 420,
@@ -93,7 +93,7 @@
     {
       "id": "road_1",
       "name": "街道",
-      "areaLevel": 12,
+      "areaLevel": 14,
       "floors": 2,
       "exploration_time_sec_first": 1620,
       "exploration_time_sec": 540,
@@ -104,7 +104,7 @@
     {
       "id": "orc_camp_1",
       "name": "オークの野営地・前哨",
-      "areaLevel": 20,
+      "areaLevel": 14,
       "floors": 2,
       "exploration_time_sec_first": 2160,
       "exploration_time_sec": 720,
@@ -115,7 +115,7 @@
     {
       "id": "orc_camp_2",
       "name": "オークの野営地・陣営",
-      "areaLevel": 21,
+      "areaLevel": 14,
       "floors": 2,
       "exploration_time_sec_first": 2340,
       "exploration_time_sec": 780,
@@ -126,7 +126,7 @@
     {
       "id": "orc_camp_3",
       "name": "オークの野営地・本陣",
-      "areaLevel": 22,
+      "areaLevel": 14,
       "floors": 2,
       "exploration_time_sec_first": 2700,
       "exploration_time_sec": 900,
@@ -140,7 +140,7 @@
     {
       "id": "human_village",
       "name": "辺境の村",
-      "areaLevel": 24,
+      "areaLevel": 21,
       "floors": 4,
       "exploration_time_sec_first": 5400,
       "exploration_time_sec": 1800,
@@ -153,7 +153,7 @@
     {
       "id": "wolf_grassland_1",
       "name": "ウルフ草原",
-      "areaLevel": 34,
+      "areaLevel": 30,
       "floors": 3,
       "exploration_time_sec_first": 5880,
       "exploration_time_sec": 1960,
@@ -164,7 +164,7 @@
     {
       "id": "subjugation_force_1",
       "name": "vs討伐隊防衛戦・先遣隊",
-      "areaLevel": 40,
+      "areaLevel": 66,
       "floors": 3,
       "exploration_time_sec_first": 5700,
       "exploration_time_sec": 1900,
@@ -175,7 +175,7 @@
     {
       "id": "subjugation_force_2",
       "name": "vs討伐隊防衛戦・本隊",
-      "areaLevel": 42,
+      "areaLevel": 64,
       "floors": 3,
       "exploration_time_sec_first": 5820,
       "exploration_time_sec": 1940,
@@ -186,7 +186,7 @@
     {
       "id": "subjugation_force_3",
       "name": "vs討伐隊防衛戦・決戦",
-      "areaLevel": 44,
+      "areaLevel": 68,
       "floors": 3,
       "exploration_time_sec_first": 6000,
       "exploration_time_sec": 2000,
@@ -241,7 +241,7 @@
     {
       "id": "hobbit_hills_1",
       "name": "ホビットの丘陵村",
-      "areaLevel": 25,
+      "areaLevel": 50,
       "floors": 2,
       "exploration_time_sec_first": 5700,
       "exploration_time_sec": 1900,
@@ -250,7 +250,7 @@
     {
       "id": "dwarf_mine_1",
       "name": "ドワーフ坑道・入口",
-      "areaLevel": 25,
+      "areaLevel": 50,
       "floors": 2,
       "exploration_time_sec_first": 6000,
       "exploration_time_sec": 2000,
@@ -260,7 +260,7 @@
     {
       "id": "dwarf_mine_2",
       "name": "ドワーフ坑道・深層",
-      "areaLevel": 27,
+      "areaLevel": 50,
       "floors": 2,
       "exploration_time_sec_first": 6120,
       "exploration_time_sec": 2040,
@@ -271,7 +271,7 @@
     {
       "id": "dwarf_mine_3",
       "name": "ドワーフ坑道・最深部",
-      "areaLevel": 29,
+      "areaLevel": 50,
       "floors": 2,
       "exploration_time_sec_first": 6300,
       "exploration_time_sec": 2100,
@@ -312,7 +312,7 @@
     {
       "id": "lizardman_swamp_1",
       "name": "リザードマンの沼砦・浅瀬",
-      "areaLevel": 46,
+      "areaLevel": 36,
       "floors": 2,
       "exploration_time_sec_first": 6300,
       "exploration_time_sec": 2100,
@@ -323,7 +323,7 @@
     {
       "id": "lizardman_swamp_2",
       "name": "リザードマンの沼砦・深沼",
-      "areaLevel": 46,
+      "areaLevel": 42,
       "floors": 2,
       "exploration_time_sec_first": 6420,
       "exploration_time_sec": 2140,
@@ -334,7 +334,7 @@
     {
       "id": "lizardman_swamp_3",
       "name": "リザードマンの沼砦・本拠",
-      "areaLevel": 46,
+      "areaLevel": 44,
       "floors": 2,
       "exploration_time_sec_first": 6600,
       "exploration_time_sec": 2200,
@@ -344,7 +344,7 @@
     {
       "id": "orc_fortress_1",
       "name": "オークの砦",
-      "areaLevel": 75,
+      "areaLevel": 45,
       "floors": 5,
       "exploration_time_sec_first": 10800,
       "exploration_time_sec": 3600,

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_1.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_1",
   "name": "ドワーフ坑道・入口",
-  "areaLevel": 25,
+  "areaLevel": 50,
   "floors": 2,
   "baseDurationSec": 6000,
   "description": "坑道の入口。ドワーフ坑夫たちが工具を武器に抵抗してくる。",

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_2.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_2",
   "name": "ドワーフ坑道・深層",
-  "areaLevel": 27,
+  "areaLevel": 50,
   "floors": 2,
   "baseDurationSec": 6120,
   "description": "坑道深部。戦士やルーン鍛冶師が待ち構える。",

--- a/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/dwarf_mine_3.json
@@ -1,7 +1,7 @@
 {
   "id": "dwarf_mine_3",
   "name": "ドワーフ坑道・最深部",
-  "areaLevel": 29,
+  "areaLevel": 50,
   "floors": 2,
   "baseDurationSec": 6300,
   "description": "坑道の最深部。坑道守護者と擲弾兵に守られた鍛冶王が待ち受ける。鍛冶能力をゴブリン国家に取り込め。",

--- a/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
+++ b/goblin_native/src/shared/data/expeditionArea/forest_outskirts.json
@@ -1,7 +1,7 @@
 {
   "id": "forest_outskirts",
   "name": "周辺の森",
-  "areaLevel": 4,
+  "areaLevel": 2,
   "floors": 3,
   "baseDurationSec": 180,
   "description": "明るい森、弱い獣や小鬼が出現",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_1.json
@@ -1,7 +1,7 @@
 {
   "id": "goblin_village_1",
   "name": "ゴブリン集落・外縁",
-  "areaLevel": 6,
+  "areaLevel": 5,
   "floors": 2,
   "baseDurationSec": 540,
   "description": "ゴブリン集落の外縁部。雑兵ゴブリンやシーフが群れをなして徘徊している。",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_2.json
@@ -1,7 +1,7 @@
 {
   "id": "goblin_village_2",
   "name": "ゴブリン集落・内部",
-  "areaLevel": 7,
+  "areaLevel": 6,
   "floors": 2,
   "baseDurationSec": 600,
   "description": "集落の内部へ侵入。ウォリアーやメイジが組織的に守りを固めている。",

--- a/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/goblin_village_3.json
@@ -1,5 +1,5 @@
 {
-  "areaLevel": 8,
+  "areaLevel": 7,
   "baseDurationSec": 720,
   "description": "集落の中枢。ガードに守られた奥にホブゴブリンが君臨する。独立を勝ち取るため、反逆の狼煙を上げる。",
   "encounter": {

--- a/goblin_native/src/shared/data/expeditionArea/hobbit_hills_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/hobbit_hills_1.json
@@ -1,7 +1,7 @@
 {
   "id": "hobbit_hills_1",
   "name": "ホビットの丘陵村",
-  "areaLevel": 25,
+  "areaLevel": 50,
   "floors": 2,
   "baseDurationSec": 5700,
   "description": "辺境の村の先に広がる丘陵地。身軽なホビットの斥候と投石手が補給路を守っている。",

--- a/goblin_native/src/shared/data/expeditionArea/human_village.json
+++ b/goblin_native/src/shared/data/expeditionArea/human_village.json
@@ -1,7 +1,7 @@
 {
   "id": "human_village",
   "name": "辺境の村",
-  "areaLevel": 24,
+  "areaLevel": 21,
   "floors": 4,
   "baseDurationSec": 5400,
   "description": "辺境の村の中心部。自警団と猟師を退け、西方にゴブリンの脅威を刻みつけろ。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_1.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_1",
   "name": "リザードマンの沼砦・浅瀬",
-  "areaLevel": 46,
+  "areaLevel": 36,
   "floors": 2,
   "baseDurationSec": 6300,
   "description": "沼砦の浅瀬。沼の戦士と毒牙兵が水際で襲いかかる。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_2.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_2",
   "name": "リザードマンの沼砦・深沼",
-  "areaLevel": 46,
+  "areaLevel": 42,
   "floors": 2,
   "baseDurationSec": 6420,
   "description": "砦の深部。呪術師や暗殺者が潜む危険な沼地。",

--- a/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/lizardman_swamp_3.json
@@ -1,7 +1,7 @@
 {
   "id": "lizardman_swamp_3",
   "name": "リザードマンの沼砦・本拠",
-  "areaLevel": 46,
+  "areaLevel": 44,
   "floors": 2,
   "baseDurationSec": 6600,
   "description": "砦の本拠。鱗の重装兵に守られた沼王が待ち受ける。毒と夜襲の術を奪い、次の大戦に備えろ。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_1.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_1",
   "name": "オークの野営地・前哨",
-  "areaLevel": 20,
+  "areaLevel": 14,
   "floors": 2,
   "baseDurationSec": 2160,
   "description": "オーク野営地の前哨。前線のブルートと、その後方に控える兵たちが見張りに立っている。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_2.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_2",
   "name": "オークの野営地・陣営",
-  "areaLevel": 21,
+  "areaLevel": 14,
   "floors": 2,
   "baseDurationSec": 2340,
   "description": "野営地の陣営部。前に出るブルートを壁に、兵たちが厚く控える。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_camp_3.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_camp_3",
   "name": "オークの野営地・本陣",
-  "areaLevel": 22,
+  "areaLevel": 14,
   "floors": 2,
   "baseDurationSec": 2700,
   "description": "野営地の本陣。ブルートが陣を固め、奥にはオーク遠征隊長が控える。攻略すれば拠点として利用可能。",

--- a/goblin_native/src/shared/data/expeditionArea/orc_fortress_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/orc_fortress_1.json
@@ -1,7 +1,7 @@
 {
   "id": "orc_fortress_1",
   "name": "オークの砦",
-  "areaLevel": 75,
+  "areaLevel": 45,
   "floors": 5,
   "baseDurationSec": 10800,
   "description": "野営地の奥に築かれた石造りの砦。解放直後の戦力ではまず歯が立たない。オークの重装兵に加え、傭兵として雇われたトロルが門を守っている。",

--- a/goblin_native/src/shared/data/expeditionArea/road_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/road_1.json
@@ -1,7 +1,7 @@
 {
   "id": "road_1",
   "name": "街道",
-  "areaLevel": 12,
+  "areaLevel": 14,
   "floors": 2,
   "baseDurationSec": 1620,
   "description": "ゴブリン集落から最も近い街道。森から出てくる狼や盗賊、荷を守る人間の護衛が行き交う。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_1.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_1",
   "name": "vs討伐隊防衛戦・先遣隊",
-  "areaLevel": 40,
+  "areaLevel": 66,
   "floors": 3,
   "baseDurationSec": 5700,
   "description": "辺境城から先遣隊が接近。正規兵と弓兵を中心とした少数部隊を迎撃せよ。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_2.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_2",
   "name": "vs討伐隊防衛戦・本隊",
-  "areaLevel": 42,
+  "areaLevel": 64,
   "floors": 3,
   "baseDurationSec": 5820,
   "description": "討伐隊の本隊が到着。騎士・魔術師・クレリックを含む正規編成で攻勢が激化する。",

--- a/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/subjugation_force_3.json
@@ -1,7 +1,7 @@
 {
   "id": "subjugation_force_3",
   "name": "vs討伐隊防衛戦・決戦",
-  "areaLevel": 44,
+  "areaLevel": 68,
   "floors": 3,
   "baseDurationSec": 6000,
   "description": "辺境城騎士団長が自ら前線に立つ。精鋭部隊との最終決戦。撃退せよ。",

--- a/goblin_native/src/shared/data/expeditionArea/undead_ruins_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/undead_ruins_1.json
@@ -1,7 +1,7 @@
 {
   "id": "undead_ruins_1",
   "name": "忘れられた廃墟・入口",
-  "areaLevel": 9,
+  "areaLevel": 10,
   "floors": 2,
   "baseDurationSec": 900,
   "description": "廃墟の入口付近。スケルトンとゾンビが徘徊する薄暗い回廊。",

--- a/goblin_native/src/shared/data/expeditionArea/undead_ruins_3.json
+++ b/goblin_native/src/shared/data/expeditionArea/undead_ruins_3.json
@@ -1,7 +1,7 @@
 {
   "id": "undead_ruins_3",
   "name": "忘れられた廃墟・最奥",
-  "areaLevel": 11,
+  "areaLevel": 10,
   "floors": 2,
   "baseDurationSec": 1260,
   "description": "廃墟の最深部。屍鬼が群れをなし、奥には死霊術師の残骸が眠る。",

--- a/goblin_native/src/shared/data/expeditionArea/wolf_grassland_1.json
+++ b/goblin_native/src/shared/data/expeditionArea/wolf_grassland_1.json
@@ -1,7 +1,7 @@
 {
   "id": "wolf_grassland_1",
   "name": "ウルフ草原",
-  "areaLevel": 34,
+  "areaLevel": 30,
   "floors": 3,
   "baseDurationSec": 5880,
   "description": "辺境の村の西に広がる草原。大型ウルフの群れを屈服させ、騎獣と機動戦力を手に入れろ。",


### PR DESCRIPTION
## Summary
- スライムの洞窟〜vs討伐隊（subjugation_force_3）までの解放経路上の主要エリアと一部周辺エリアで、`areaLevel` を「そのエリアに出現する敵の最低レベル」へ揃え直し
- `allArea.json` と個別 `expeditionArea/*.json` の `areaLevel` を同期
- road_1 / ゴブリン村 / オーク砦の敵パラメータ（level・HP・exp 等）を併せてバランス調整

## areaLevel 変更一覧
| エリア | 旧 | 新 |
| --- | --- | --- |
| forest_outskirts | 4 | 2 |
| goblin_village_1 | 6 | 5 |
| goblin_village_2 | 7 | 6 |
| goblin_village_3 | 8 | 7 |
| undead_ruins_1 | 9 | 10 |
| undead_ruins_3 | 11 | 10 |
| road_1 | 12 | 14 |
| orc_camp_1 | 20 | 14 |
| orc_camp_2 | 21 | 14 |
| orc_camp_3 | 22 | 14 |
| human_village | 24 | 21 |
| wolf_grassland_1 | 34 | 30 |
| lizardman_swamp_1 | 46 | 36 |
| lizardman_swamp_2 | 46 | 42 |
| lizardman_swamp_3 | 46 | 44 |
| orc_fortress_1 | 75 | 45 |
| subjugation_force_1 | 40 | 66 |
| subjugation_force_2 | 42 | 64 |
| subjugation_force_3 | 44 | 68 |
| hobbit_hills_1 | 25 | 50 |
| dwarf_mine_1 | 25 | 50 |
| dwarf_mine_2 | 27 | 50 |
| dwarf_mine_3 | 29 | 50 |

## Test plan
- [x] `npx tsc --noEmit` をパス
- [x] `src/shared/data/__tests__` と `ExpeditionEngine.test.ts` をパス
- [ ] 編成画面の「Area Lv.X」表示が新しい値で出ることを確認
- [ ] 遠征完了後の新ゴブリン IV 範囲（`calculateIndividualValue`）が新しい areaLevel に応じて算出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)