### PR TITLE
feat(encyclopedia): モンスター詳細のステータスをグリッド化し因子欄を追加

### DIFF
--- a/goblin_native/app/encyclopedia-detail/[dungeonId]/[enemyId].tsx
+++ b/goblin_native/app/encyclopedia-detail/[dungeonId]/[enemyId].tsx
@@ -7,6 +7,7 @@ import {
   STAT_ROWS,
   formatStatValue,
   getEnemyEntry,
+  getFactorDropNames,
   getRareDropNames,
   getUnlockedTiers,
 } from '@/presentation/encyclopedia/encyclopediaData'
@@ -67,6 +68,7 @@ export default function EncyclopediaMonsterDetailScreen() {
         {tiers.map((tier) => {
           const tieredEnemy = applyDungeonTierScalingToEnemy(entry.enemy, tier)
           const rareDrops = getRareDropNames(tieredEnemy)
+          const factorDrops = getFactorDropNames(tieredEnemy)
           const skills = tieredEnemy.skills ?? []
           const spells = tieredEnemy.spells ?? []
           const tierMeta = DUNGEON_TIER_META.find((meta) => meta.tier === tier)
@@ -82,18 +84,18 @@ export default function EncyclopediaMonsterDetailScreen() {
                 </View>
               </View>
 
-              <View style={styles.statList}>
+              <View style={styles.statGrid}>
                 {STAT_ROWS.map((row) => (
-                  <View key={row.key} style={styles.statRow}>
+                  <View key={row.key} style={styles.statCell}>
                     <Text style={styles.statLabel}>{row.label}</Text>
                     <Text style={styles.statValue}>{formatStatValue(tieredEnemy[row.key])}</Text>
                   </View>
                 ))}
               </View>
 
-              <View style={styles.statList}>
+              <View style={styles.attributeGrid}>
                 {ATTRIBUTE_ROWS.map((row) => (
-                  <View key={row.key} style={styles.statRow}>
+                  <View key={row.key} style={styles.attributeCell}>
                     <Text style={styles.statLabel}>{row.label}</Text>
                     <Text style={styles.statValue}>{tieredEnemy.baseAttributes[row.key]}</Text>
                   </View>
@@ -142,6 +144,15 @@ export default function EncyclopediaMonsterDetailScreen() {
                   ))
                 )}
               </View>
+
+              {factorDrops.length > 0 ? (
+                <View style={styles.infoBlock}>
+                  <Text style={styles.infoTitle}>{t('ui.encyclopedia.factorDrops')}</Text>
+                  {factorDrops.map((factorName) => (
+                    <Text key={factorName} style={styles.dropLine}>・{factorName}</Text>
+                  ))}
+                </View>
+              ) : null}
             </View>
           )
         })}
@@ -232,21 +243,41 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 17,
   },
-  statList: {
+  statGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     borderRadius: 8,
     backgroundColor: '#F9FAFB',
     borderWidth: 1,
     borderColor: '#E5E7EB',
     overflow: 'hidden',
   },
-  statRow: {
+  statCell: {
+    width: '50%',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 8,
+    gap: 8,
+    paddingVertical: 6,
     paddingHorizontal: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#E5E7EB',
+  },
+  attributeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    borderRadius: 8,
+    backgroundColor: '#F9FAFB',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    overflow: 'hidden',
+  },
+  attributeCell: {
+    width: '33.3333%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
   },
   statLabel: {
     fontSize: 12,

--- a/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
+++ b/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
@@ -1,6 +1,7 @@
 import { getEnemyDatabase } from '@/shared/data/enemy'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
-import { getEquipmentLabel } from '@/shared/i18n/entityLocalization'
+import { getFactor } from '@/shared/data/factors'
+import { getEquipmentLabel, getFactorName } from '@/shared/i18n/entityLocalization'
 import { DUNGEON_TIER_LIST, type DungeonTier } from '@/shared/types/DungeonTier'
 import type { Dungeon, Enemy } from '@/shared/types'
 
@@ -94,5 +95,12 @@ export function getRareDropNames(enemy: Enemy): string[] {
   return (enemy.rareEquipmentDrops ?? []).map((drop) => {
     const template = getEquipmentTemplate(drop.templateId)
     return template ? getEquipmentLabel(template) : drop.templateId
+  })
+}
+
+export function getFactorDropNames(enemy: Enemy): string[] {
+  return (enemy.factorDrops ?? []).map((drop) => {
+    const factor = getFactor(drop.factorId)
+    return factor ? getFactorName(factor) : drop.factorId
   })
 }

--- a/goblin_native/src/shared/data/enemy/slime_cave.json
+++ b/goblin_native/src/shared/data/enemy/slime_cave.json
@@ -63,7 +63,7 @@
       },
       "rareEquipmentDrops": [
         {
-          "templateId": "accessory_locuk_medal"
+          "templateId": "accessory_luck_medal"
         }
       ]
     }

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -84,6 +84,7 @@ const en = {
       normal: 'Enemy',
       skills: 'Skills',
       rareDrops: 'Rare Drops',
+      factorDrops: 'Factors',
       none: 'None',
       spellCharges: '{{count}} uses',
     },

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -84,6 +84,7 @@ const ja = {
       normal: '通常敵',
       skills: 'スキル',
       rareDrops: 'レアドロップ',
+      factorDrops: '因子',
       none: 'なし',
       spellCharges: '使用回数 {{count}}',
     },

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -83,6 +83,7 @@ const ko = {
       normal: '일반 적',
       skills: '스킬',
       rareDrops: '희귀 드롭',
+      factorDrops: '인자',
       none: '없음',
       spellCharges: '{{count}}회 사용',
     },


### PR DESCRIPTION
## Summary
- 図鑑のモンスター詳細でステータス表示を 2 列グリッド、属性を 3 列グリッドに変更し、見やすくコンパクトに
- 因子ドロップを持つ敵に「因子」セクションを追加し、因子名を一覧表示（ja / en / ko 対応）
- `slime_cave.json` のレアドロップ `templateId` のタイポ修正（`accessory_locuk_medal` → `accessory_luck_medal`）

## Test plan
- [ ] 図鑑のモンスター詳細を開き、ステータスがグリッドで詰まって表示されることを確認
- [ ] 因子ドロップを持つ敵で「因子」欄が表示され、因子名が正しく出ることを確認
- [ ] 因子ドロップを持たない敵では「因子」欄が表示されないことを確認
- [ ] スライムの洞窟ボスのレアドロップが「ラッキーメダル」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)