### PR TITLE
feat(formation): PT装備一覧を装備変更画面と同じ縦並び行UIに変更

### DIFF
--- a/goblin_native/app/(tabs)/formation/equipment-list.tsx
+++ b/goblin_native/app/(tabs)/formation/equipment-list.tsx
@@ -8,9 +8,46 @@ import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
 import { EquipmentService } from '@/core/services/EquipmentService'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
+import { applySkillBonusesToEquipmentBonuses } from '@/shared/data/characterSkills'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
-import type { EquipmentInstance, EquipmentTemplate, Goblin, Party } from '@/shared/types'
-import { getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
+import type { CharacterSkill, EquipmentInstance, Goblin, Party } from '@/shared/types'
+import { getEquipmentDisplayName, getStatLabel } from '@/shared/i18n/entityLocalization'
+
+type DisplayBonus = {
+  stat: string
+  value: number
+}
+
+function formatBonus(stat: string, value: number): string {
+  const displayValue = Number.isInteger(value) ? value : Math.trunc(value * 10) / 10
+  const isPercent = stat.includes('percent') || stat === 'damage_reduction'
+  return `${displayValue > 0 ? '+' : ''}${displayValue}${isPercent ? '%' : ''}`
+}
+
+function isDisplayValueZero(value: number): boolean {
+  const displayValue = Number.isInteger(value) ? value : Math.trunc(value * 10) / 10
+  return displayValue === 0
+}
+
+function getDisplayBonuses(
+  eq: EquipmentInstance,
+  skills: CharacterSkill[],
+  penaltyMultiplier: number,
+): DisplayBonus[] {
+  const originalBonuses = EquipmentService.calculateEquipmentBonuses([eq])
+  const penalizedBonuses = originalBonuses.map((bonus) => ({
+    ...bonus,
+    value: Number((bonus.value * penaltyMultiplier).toFixed(4)),
+  }))
+  const adjustedBonuses = applySkillBonusesToEquipmentBonuses(skills, penalizedBonuses)
+  return adjustedBonuses
+    .map((bonus) => ({ stat: bonus.stat, value: bonus.value }))
+    .filter((bonus) => !isDisplayValueZero(bonus.value))
+}
+
+function getInlineBonusLabel(bonus: DisplayBonus): string {
+  return `${getStatLabel(bonus.stat)}${formatBonus(bonus.stat, bonus.value)}`
+}
 
 export default function PartyEquipmentListScreen() {
   const { t } = useTranslation()
@@ -114,6 +151,11 @@ export default function PartyEquipmentListScreen() {
           partyMembers.map(member => {
             const equippedItems = equipmentMap[member.id] ?? []
             const maxSlots = EquipmentService.getAvailableSlots(member)
+            const penaltyMultipliers = EquipmentService.getEquipmentPenaltyMultipliers(equippedItems)
+            const characterSkills: CharacterSkill[] = [
+              ...member.skills,
+              ...EquipmentService.collectGrantedSkills(equippedItems),
+            ]
 
             return (
               <TouchableOpacity
@@ -141,11 +183,28 @@ export default function PartyEquipmentListScreen() {
                       const template = getEquipmentTemplate(item.templateId)
                       if (!template) return null
 
+                      const multiplier = penaltyMultipliers.get(item.templateId) ?? 1
+                      const penaltyPercent = multiplier !== 1 ? Math.round(multiplier * 100) : undefined
+                      const displayBonuses = getDisplayBonuses(item, characterSkills, multiplier)
+                      const inlineStats = displayBonuses.map((bonus) => getInlineBonusLabel(bonus)).join('  ')
+                      const displayName = getEquipmentDisplayName(item, template)
+                      const itemName = penaltyPercent !== undefined
+                        ? `${penaltyPercent}％ ${displayName}`
+                        : displayName
+
                       return (
-                        <View key={item.id} style={styles.equipmentChip}>
-                          <Text style={styles.equipmentChipText} numberOfLines={1}>
-                            {getEquipmentDisplayName(item, template)}
-                          </Text>
+                        <View
+                          key={item.id}
+                          style={[styles.itemRow, penaltyPercent !== undefined && styles.itemRowPenalty]}
+                        >
+                          <View style={styles.itemInfo}>
+                            <Text style={styles.itemStats} numberOfLines={1}>
+                              {inlineStats}
+                            </Text>
+                            <Text style={styles.itemName} numberOfLines={1}>
+                              {itemName}
+                            </Text>
+                          </View>
                         </View>
                       )
                     })}
@@ -258,21 +317,32 @@ const styles = StyleSheet.create({
     color: '#9CA3AF',
   },
   equipmentList: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
     gap: 8,
   },
-  equipmentChip: {
-    backgroundColor: '#EFF6FF',
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    borderRadius: 10,
     borderWidth: 1,
-    borderColor: '#BFDBFE',
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    maxWidth: '100%',
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
   },
-  equipmentChipText: {
+  itemRowPenalty: {
+    borderColor: '#F59E0B',
+    backgroundColor: '#FFFBEB',
+  },
+  itemInfo: {
+    flex: 1,
+  },
+  itemStats: {
     fontSize: 12,
-    color: '#1D4ED8',
+    color: '#6B7280',
+    marginBottom: 4,
+  },
+  itemName: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1F2937',
   },
 })


### PR DESCRIPTION
## Summary
- PTメンバーの装備アイテム一覧を、横並びチップから装備変更画面と同じ縦並びの行レイアウトに変更
- 各行は上段にステータス（例: `攻撃力+5  守備力+3`）、下段にアイテム名を表示し、装備変更画面と視覚的に統一
- 同種装備の重複ペナルティが発生している場合は、装備変更画面と同じく黄色枠＋「○○％ アイテム名」表記で表示（所持スキル・装備付与スキルも考慮）

## Test plan
- [ ] PT装備一覧画面で各メンバーの装備が縦並びで表示されることを確認
- [ ] ステータス値とアイテム名が装備変更画面と一致することを確認
- [ ] 同種装備を複数装備しているメンバーでペナルティ表示（黄色枠 + ％表記）が出ることを確認
- [ ] 装備0個のメンバーで「装備中のアイテムはありません」が表示されることを確認
- [ ] 「変更する」タップで対象メンバーの装備変更画面が開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)