### PR TITLE
fix(shop): 装備購入時のアラート文言を「購入しました」に変更

### DIFF
--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -192,7 +192,7 @@ const ja = {
       insufficientGoldTitle: 'ゴールドが足りません',
       insufficientGoldBody: '必要額: {{price}}G\n所持ゴールド: {{gold}}G',
       buySuccessTitle: '購入しました',
-      buySuccessBody: '{{name}}を在庫に追加しました。',
+      buySuccessBody: '{{name}}を購入しました。',
       sellConfirmTitle: '売却確認',
       sellConfirmBody: '{{name}}を{{price}}Gで売却しますか？',
       sellAction: '売却する',


### PR DESCRIPTION
## Summary
- 装備商店でアイテム購入時に表示されるアラート本文が「{{name}}を在庫に追加しました。」となっていたが、本作には「在庫」という概念がないため文脈に合っていなかった
- シンプルに「{{name}}を購入しました。」へ変更
- 対象: `src/shared/i18n/resources/ja.ts` の `buySuccessBody`

## Test plan
- [ ] 装備商店でアイテムを購入し、アラート本文が「{{name}}を購入しました。」になっていることを確認
- [ ] `npx tsc --noEmit` がエラーなく通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)