### PR TITLE
fix(formation): 進行中遠征の履歴表示で現在階層を表示するよう修正

### DIFF
--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -34,6 +34,7 @@ import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
 import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
 import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
+import { computeCurrentFloor } from '../../shared/utils/expeditionFloor'
 import { getExpeditionTimeMultiplierFromSkills } from '../../shared/data/characterSkills'
 import { EquipmentService } from '../../core/services/EquipmentService'
 import i18n from '../../shared/i18n'
@@ -646,7 +647,9 @@ export const useExpeditionFlow = ({
       const items = history.map(record => {
         const dungeon = areasData.find(area => area.id === record.dungeonId)
         const ongoing = isExpeditionOngoing(record, currentTime)
-        const floorReached = record.replay?.summary.maxFloorReached ?? 1
+        const floorReached = ongoing
+          ? computeCurrentFloor(record, currentTime)
+          : record.replay?.summary.maxFloorReached ?? 1
         const remainingMinutes = ongoing && record.returnTime
           ? getRemainingMinutes(record.returnTime, currentTime)
           : 0

--- a/goblin_native/src/shared/utils/__tests__/expeditionFloor.test.ts
+++ b/goblin_native/src/shared/utils/__tests__/expeditionFloor.test.ts
@@ -1,0 +1,112 @@
+import { computeCurrentFloor } from '../expeditionFloor'
+import type { ExpeditionRecord, ExpeditionReplay, TimelineEvent } from '../../types'
+
+function createReplay(events: TimelineEvent[], durationSec = 600, maxFloorReached = 3): ExpeditionReplay {
+  return {
+    meta: {
+      expeditionId: 'r1',
+      areaId: 'test_area',
+      areaName: 'テスト',
+      floors: 3,
+      baseDurationSec: 600,
+      party: ['1'],
+      partyRewardMultipliers: { gold: 1, rareDrop: 1, title: 1 } as never,
+      returnPolicy: 'never',
+      seed: 1,
+    },
+    durationSec,
+    events,
+    summary: {
+      success: true,
+      maxFloorReached,
+      xpGained: 0,
+      goldGained: 0,
+      casualties: [],
+    },
+  }
+}
+
+function createRecord(replay: ExpeditionReplay | undefined, startTime: Date, returnTime: Date | null): ExpeditionRecord {
+  return {
+    id: 'r1',
+    userId: 'u1',
+    partyId: 1,
+    partyName: 'PT',
+    dungeonId: 'test_area',
+    dungeonName: 'テスト',
+    startTime,
+    returnTime,
+    status: 'ongoing',
+    returnPolicy: 'never',
+    replay,
+    createdAt: startTime,
+    updatedAt: startTime,
+  }
+}
+
+const start = new Date('2026-05-11T12:00:00Z')
+const ret = new Date('2026-05-11T12:10:00Z') // 600秒
+
+describe('computeCurrentFloor', () => {
+  it('replay が無ければ 1F を返す', () => {
+    const record = createRecord(undefined, start, ret)
+    expect(computeCurrentFloor(record, start)).toBe(1)
+  })
+
+  it('returnTime が null なら 1F を返す', () => {
+    const replay = createReplay([{ type: 'floor_up', at: 10, from: 1, to: 2 }])
+    const record = createRecord(replay, start, null)
+    expect(computeCurrentFloor(record, start)).toBe(1)
+  })
+
+  it('開始直後は 1F を返す（イベント未到達）', () => {
+    const replay = createReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'floor_up', at: 200, from: 1, to: 2 },
+      { type: 'floor_up', at: 400, from: 2, to: 3 },
+    ])
+    const record = createRecord(replay, start, ret)
+    expect(computeCurrentFloor(record, start)).toBe(1)
+  })
+
+  it('経過時間が floor_up の at を越えたら次の階を返す', () => {
+    const replay = createReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'floor_up', at: 200, from: 1, to: 2 },
+      { type: 'floor_up', at: 400, from: 2, to: 3 },
+    ])
+    const record = createRecord(replay, start, ret)
+    // 経過時間 5分 (300s) -> cutoff 300 -> 2F
+    const now = new Date(start.getTime() + 5 * 60 * 1000)
+    expect(computeCurrentFloor(record, now)).toBe(2)
+  })
+
+  it('帰還時刻に到達したら最終階層を返す', () => {
+    const replay = createReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'floor_up', at: 200, from: 1, to: 2 },
+      { type: 'floor_up', at: 400, from: 2, to: 3 },
+    ])
+    const record = createRecord(replay, start, ret)
+    expect(computeCurrentFloor(record, ret)).toBe(3)
+  })
+
+  it('battle / exploring / treasure の floor も反映する', () => {
+    const replay = createReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'exploring', at: 100, floor: 1 },
+      { type: 'floor_up', at: 200, from: 1, to: 2 },
+      { type: 'battle', at: 250, floor: 2, enemy: { id: 'e', name: 'e', stats: {} as never, gold: 0 } as never, combat: {} as never, xp: 0 },
+      { type: 'treasure', at: 350, floor: 2, items: [] },
+    ])
+    const record = createRecord(replay, start, ret)
+    // 4分 (240s) -> 2F (floor_up at 200 が反映)
+    expect(computeCurrentFloor(record, new Date(start.getTime() + 4 * 60 * 1000))).toBe(2)
+  })
+
+  it('totalMs が 0 以下なら 1F を返す', () => {
+    const replay = createReplay([{ type: 'floor_up', at: 0, from: 1, to: 2 }])
+    const record = createRecord(replay, start, start) // returnTime === startTime
+    expect(computeCurrentFloor(record, start)).toBe(1)
+  })
+})

--- a/goblin_native/src/shared/utils/expeditionFloor.ts
+++ b/goblin_native/src/shared/utils/expeditionFloor.ts
@@ -1,0 +1,34 @@
+import type { ExpeditionRecord } from '../types'
+
+/**
+ * 進行中の遠征について、現在時刻時点で到達している階層を計算する。
+ * リプレイは出発時に最後まで先に計算済みのため、summary.maxFloorReached を
+ * そのまま使うと「最終到達階層」が表示されてしまうため、経過時間に対応する
+ * イベントだけを走査して階層を求める。
+ */
+export function computeCurrentFloor(record: ExpeditionRecord, now: Date): number {
+  const replay = record.replay
+  if (!replay || !record.returnTime) return 1
+  const startMs = record.startTime.getTime()
+  const returnMs = record.returnTime.getTime()
+  const totalMs = returnMs - startMs
+  if (totalMs <= 0) return 1
+  const elapsedRatio = Math.min(1, Math.max(0, (now.getTime() - startMs) / totalMs))
+  const cutoffSec = elapsedRatio * replay.durationSec
+  let floor = 1
+  for (const event of replay.events) {
+    if (event.at > cutoffSec) break
+    if (event.type === 'floor_up') {
+      floor = Math.max(floor, event.to)
+    } else if (
+      event.type === 'battle' ||
+      event.type === 'boss' ||
+      event.type === 'exploring' ||
+      event.type === 'treasure' ||
+      event.type === 'move_start'
+    ) {
+      floor = Math.max(floor, event.floor)
+    }
+  }
+  return floor
+}


### PR DESCRIPTION
## Summary
- 編成画面のPTカード下「遠征履歴」で、進行中の遠征に最終到達階層が表示されていた不具合を修正
- リプレイは出発時に最後まで先に計算済みのため、`summary.maxFloorReached` をそのまま使うと最終階が出てしまっていた
- 経過時間に対応するイベントのみを走査して現在階層を求める `computeCurrentFloor` ユーティリティを追加し、`ongoing` 時のみそれを使用

## Test plan
- [x] `npx jest src/shared/utils/__tests__/expeditionFloor.test.ts` (7 cases pass)
- [x] `npx tsc --noEmit`
- [ ] 編成画面で遠征を開始し、PTカード下部の遠征履歴が `[1F]: 帰還予定 ...` から始まり、時間経過で階層が増えることを確認
- [ ] 遠征完了後の履歴は最終到達階層が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)