### PR TITLE
feat(formation): 出撃時に常に確認アラートを表示しPT/ダンジョン情報を提示

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -386,13 +386,8 @@ export default function FormationScreen() {
       return
     }
 
-    const promptGoldenAcornBulk = (onChoose: (useAcorn: boolean) => void) => {
+    const promptGoldenAcornBulkDetails = () => {
       const acornCount = getGoldenAcornCount()
-      // 全PT分のドングリを保有している場合のみ選択肢を出す
-      if (acornCount < inputs.length) {
-        onChoose(false)
-        return
-      }
       Alert.alert(
         t('ui.formation.index.goldenAcornBulkPromptTitle'),
         t('ui.formation.index.goldenAcornBulkPromptBody', {
@@ -401,14 +396,27 @@ export default function FormationScreen() {
         }),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.index.goldenAcornBulkStartWithout'), onPress: () => onChoose(false) },
-          { text: t('ui.formation.index.goldenAcornBulkUseAndStart'), onPress: () => onChoose(true) },
+          { text: t('ui.formation.index.goldenAcornBulkUseAndStart'), onPress: () => void doBulkLaunch(true) },
         ],
       )
     }
 
-    const launchWithGoldenAcornPrompt = () => {
-      promptGoldenAcornBulk((useAcorn) => void doBulkLaunch(useAcorn))
+    const showBulkLaunchConfirmation = () => {
+      const names = inputs.map((input) => input.party.name).join('\n')
+      const body = t('ui.formation.index.bulkLaunchConfirmBody', { names })
+      const acornCount = getGoldenAcornCount()
+      const buttons: Array<{ text: string; style?: 'cancel' | 'destructive'; onPress?: () => void }> = [
+        { text: t('ui.formation.common.launch'), onPress: () => void doBulkLaunch(false) },
+      ]
+      if (acornCount >= inputs.length) {
+        buttons.push({
+          text: t('ui.formation.index.bulkLaunchGoldenAcornButton'),
+          onPress: promptGoldenAcornBulkDetails,
+        })
+      }
+      buttons.push({ text: t('ui.common.cancel'), style: 'cancel' })
+
+      Alert.alert(t('ui.formation.index.bulkLaunchConfirmTitle'), body, buttons)
     }
 
     const maxPendingGoblins = rank * 5
@@ -419,13 +427,13 @@ export default function FormationScreen() {
         t('ui.formation.index.pendingOverflowBody', { count: inputs.length }),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.common.launch'), onPress: launchWithGoldenAcornPrompt },
+          { text: t('ui.formation.common.launch'), onPress: showBulkLaunchConfirmation },
         ],
       )
       return
     }
 
-    launchWithGoldenAcornPrompt()
+    showBulkLaunchConfirmation()
   }, [dungeons, parties, pendingGoblins.length, rank, startBulkExpedition, t])
 
   const canBulkLaunch = useMemo(() => {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -353,25 +353,55 @@ export default function ExpeditionPreparationScreen() {
       }
     }
 
-    const promptGoldenAcorn = (onChoose: (useAcorn: boolean) => void) => {
+    const promptGoldenAcornDetails = () => {
       const acornCount = getGoldenAcornCount()
-      if (acornCount <= 0) {
-        onChoose(false)
-        return
-      }
       Alert.alert(
         t('ui.formation.preparation.goldenAcornPromptTitle'),
         t('ui.formation.preparation.goldenAcornPromptBody', { count: acornCount }),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.preparation.goldenAcornStartWithout'), onPress: () => onChoose(false) },
-          { text: t('ui.formation.preparation.goldenAcornUseAndStart'), onPress: () => onChoose(true) },
+          { text: t('ui.formation.preparation.goldenAcornUseAndStart'), onPress: () => void doStartExpedition(true) },
         ],
       )
     }
 
-    const launchWithGoldenAcornPrompt = () => {
-      promptGoldenAcorn((useAcorn) => void doStartExpedition(useAcorn))
+    const showLaunchConfirmation = () => {
+      const dungeonLabel = getDungeonTierDisplayName(
+        formatDungeonLabel(selectedDungeon, selectedTier),
+        selectedTier,
+      )
+      const targetText = selectedTargetFloor === null
+        ? t('ui.formation.preparation.launchConfirmTargetDeepest')
+        : t('ui.formation.preparation.launchConfirmTargetUntil', { floor: selectedTargetFloor })
+      const returnPolicyText = getReturnPolicyLabel(selectedReturnPolicy)
+      const totalSeconds = estimatedExplorationTime ?? 0
+      const hours = Math.floor(totalSeconds / 3600)
+      const minutes = Math.floor((totalSeconds % 3600) / 60)
+      const seconds = totalSeconds % 60
+      const explorationTimeText = t('ui.formation.preparation.launchConfirmDurationFormat', {
+        hours,
+        minutes,
+        seconds,
+      })
+      const body = t('ui.formation.preparation.launchConfirmBody', {
+        target: targetText,
+        returnPolicy: returnPolicyText,
+        explorationTime: explorationTimeText,
+      })
+
+      const acornCount = getGoldenAcornCount()
+      const buttons: Array<{ text: string; style?: 'cancel' | 'destructive'; onPress?: () => void }> = [
+        { text: t('ui.formation.common.launch'), onPress: () => void doStartExpedition(false) },
+      ]
+      if (acornCount > 0) {
+        buttons.push({
+          text: t('ui.formation.preparation.launchConfirmGoldenAcornButton'),
+          onPress: promptGoldenAcornDetails,
+        })
+      }
+      buttons.push({ text: t('ui.common.cancel'), style: 'cancel' })
+
+      Alert.alert(dungeonLabel, body, buttons)
     }
 
     const maxPendingGoblins = rank * 5
@@ -381,20 +411,22 @@ export default function ExpeditionPreparationScreen() {
         t('ui.formation.preparation.pendingOverflowBody'),
         [
           { text: t('ui.common.cancel'), style: 'cancel' },
-          { text: t('ui.formation.common.launch'), onPress: launchWithGoldenAcornPrompt },
+          { text: t('ui.formation.common.launch'), onPress: showLaunchConfirmation },
         ],
       )
       return
     }
 
-    launchWithGoldenAcornPrompt()
+    showLaunchConfirmation()
   }, [
+    estimatedExplorationTime,
     pendingGoblins.length,
     party,
     rank,
     selectedDungeon,
     selectedDungeonId,
     selectedReturnPolicy,
+    selectedTargetFloor,
     selectedTier,
     partyMembers.length,
     startExpedition,

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -324,6 +324,9 @@ const en = {
         goldenAcornBulkPromptBody: 'Spend {{count}} acorns to halve travel time and double Gold, rare drops, and titles for each party.\n{{remaining}} remaining',
         goldenAcornBulkUseAndStart: 'Use for All & Dispatch',
         goldenAcornBulkStartWithout: 'Dispatch Without',
+        bulkLaunchConfirmTitle: 'Parties to Dispatch',
+        bulkLaunchConfirmBody: '{{names}}',
+        bulkLaunchGoldenAcornButton: '★ Use Golden Acorns',
       },
       preparation: {
         title: 'Expedition Prep',
@@ -364,6 +367,11 @@ const en = {
         goldenAcornPromptBody: 'Halves travel time and doubles Gold, rare drops, and titles.\n{{count}} remaining',
         goldenAcornUseAndStart: 'Use and Dispatch',
         goldenAcornStartWithout: 'Dispatch Without',
+        launchConfirmBody: 'Target Floor: {{target}}\nReturn Policy: {{returnPolicy}}\nDuration: {{explorationTime}}',
+        launchConfirmTargetDeepest: 'Explore to the deepest floor',
+        launchConfirmTargetUntil: 'Up to Floor {{floor}}',
+        launchConfirmDurationFormat: '{{hours}}h {{minutes}}m {{seconds}}s',
+        launchConfirmGoldenAcornButton: '★ Use Golden Acorn',
       },
       edit: {
         title: 'Edit Members',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -324,6 +324,9 @@ const ja = {
         goldenAcornBulkPromptBody: '{{count}}PT分（{{count}}個）を消費し、各PTの探索時間 1/2、Gold・レア・称号 2倍 で出撃します。\n残り {{remaining}} 個',
         goldenAcornBulkUseAndStart: '全PTで使用して出撃',
         goldenAcornBulkStartWithout: '使わずに出撃',
+        bulkLaunchConfirmTitle: '出撃するパーティ',
+        bulkLaunchConfirmBody: '{{names}}',
+        bulkLaunchGoldenAcornButton: '★金のドングリを使用',
       },
       preparation: {
         title: '冒険準備',
@@ -364,6 +367,11 @@ const ja = {
         goldenAcornPromptBody: '探索時間 1/2、Gold・レア・称号倍率がすべて 2倍 になります。\n残り {{count}} 個',
         goldenAcornUseAndStart: '使用して出発',
         goldenAcornStartWithout: '使わずに出発',
+        launchConfirmBody: '目標階層：{{target}}\n帰還条件：{{returnPolicy}}\n探索時間：{{explorationTime}}',
+        launchConfirmTargetDeepest: '最下層まで攻略する',
+        launchConfirmTargetUntil: '{{floor}}フロアまで攻略する',
+        launchConfirmDurationFormat: '{{hours}}時間{{minutes}}分{{seconds}}秒',
+        launchConfirmGoldenAcornButton: '★金のドングリを使用',
       },
       edit: {
         title: 'メンバー編集',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -319,6 +319,9 @@ const ko = {
         abortConfirmTitle: '귀환 확인',
         abortConfirmBody: '원정을 중도 종료합니다.\n골드와 아이템은 가져올 수 없습니다.\n경험치와 HP 상태는 유지됩니다.',
         abortConfirmOk: '귀환하기',
+        bulkLaunchConfirmTitle: '출격할 파티',
+        bulkLaunchConfirmBody: '{{names}}',
+        bulkLaunchGoldenAcornButton: '★금 도토리 사용',
       },
       preparation: {
         title: '원정 준비',
@@ -355,6 +358,11 @@ const ko = {
         startFailedTitle: '원정에 실패했습니다',
         startFailedBody: '원정 시작 중 오류가 발생했습니다',
         pendingOverflowBody: '대기 슬롯이 가득 찼습니다. 원정 성공 시 고블린이 추가되면 받지 못하고 폐기될 수 있습니다. 출격할까요?',
+        launchConfirmBody: '목표 층: {{target}}\n귀환 조건: {{returnPolicy}}\n탐색 시간: {{explorationTime}}',
+        launchConfirmTargetDeepest: '최하층까지 탐색',
+        launchConfirmTargetUntil: '{{floor}}층까지 공략',
+        launchConfirmDurationFormat: '{{hours}}시간 {{minutes}}분 {{seconds}}초',
+        launchConfirmGoldenAcornButton: '★금 도토리 사용',
       },
       edit: {
         title: '멤버 편집',


### PR DESCRIPTION
## Summary
- 単体出撃: 金のドングリ所持の有無に関わらず常に確認アラートを表示。タイトルにダンジョン名、本文に目標階層・帰還条件・探索時間（X時間Y分Z秒）を表示
- 一括出撃: 出撃するPT名（既出撃中などは除外）を改行区切りで列挙する確認アラートを表示
- ボタンは `出撃` / `★金のドングリを使用`（所持時のみ） / `キャンセル` の3択に統一。ドングリ使用時は従来の説明アラートで `使用して出撃` / `キャンセル` の確認に進む

## Test plan
- [ ] 冒険準備画面で出撃ボタンを押すと、ドングリ未所持でも確認アラートが表示される
- [ ] 確認アラートにダンジョン名・目標階層・帰還条件・探索時間が正しく表示される
- [ ] ドングリ所持時、「★金のドングリを使用」を選ぶと詳細アラートが出て `使用して出撃` で消費して出撃できる
- [ ] 一括出撃で出撃対象のPT名のみが列挙され、出撃中のPTは含まれない
- [ ] 一括出撃でPT数分のドングリ所持時のみ「★金のドングリを使用」ボタンが表示される
- [ ] 待機枠不足時の確認アラート → 新しい確認アラートの順で進める

🤖 Generated with [Claude Code](https://claude.com/claude-code)