### PR TITLE
fix(formation): 未クリアTierで踏破済の探索時間が使われるバグ修正＋Tierスケール導入

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -226,8 +226,8 @@ export default function ExpeditionPreparationScreen() {
 
   const estimatedExplorationTime = useMemo(() => {
     if (!selectedDungeon) return null
-    return estimateExplorationTime(selectedDungeon, selectedReturnPolicy)
-  }, [estimateExplorationTime, selectedDungeon, selectedReturnPolicy])
+    return estimateExplorationTime(selectedDungeon, selectedReturnPolicy, 1, false, selectedTier)
+  }, [estimateExplorationTime, selectedDungeon, selectedReturnPolicy, selectedTier])
 
   const handleEditParty = useCallback(() => {
     void advanceTutorial('select_party_member')

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -32,7 +32,7 @@ import { useStoryStore } from '../stores/useStoryStore'
 import { useTutorialStore } from '../stores/useTutorialStore'
 import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
-import { getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
+import { computeDungeonExplorationTime, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
 import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
 import { computeCurrentFloor } from '../../shared/utils/expeditionFloor'
 import { getExpeditionTimeMultiplierFromSkills } from '../../shared/data/characterSkills'
@@ -200,14 +200,20 @@ export const useExpeditionFlow = ({
     returnPolicy: ExpeditionRequest['returnPolicy'],
     partyExpeditionTimeMultiplier: number = 1,
     goldenAcornUsed: boolean = false,
+    tier: DungeonTier = 0,
   ): number => {
     if (instantDungeonExploration) {
       return 1
     }
 
-    const baseTime = dungeon.cleared
-      ? dungeon.exploration_time_sec
-      : dungeon.exploration_time_sec_first
+    const tierCleared = (dungeon.maxClearedTier ?? 0) > tier
+    const baseTime = computeDungeonExplorationTime(
+      dungeon.id,
+      dungeon.exploration_time_sec_first,
+      dungeon.exploration_time_sec,
+      tier,
+      tierCleared,
+    )
     const multiplierMap: Record<ExpeditionRequest['returnPolicy'], number> = {
       never: 1.0,
       until_floor2: 0.4,
@@ -288,6 +294,7 @@ export const useExpeditionFlow = ({
           returnPolicy,
           partyExpeditionTimeMultiplier,
           useGoldenAcorn,
+          tier ?? 0,
         )
         const request: ExpeditionRequest = {
           partyId: party.id.toString(),
@@ -391,6 +398,7 @@ export const useExpeditionFlow = ({
             returnPolicy,
             partyExpeditionTimeMultiplier,
             acornAppliedForThisInput,
+            tier ?? 0,
           )
           const request: ExpeditionRequest = {
             partyId: party.id.toString(),

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -94,3 +94,62 @@ export function getDungeonTierDisplayName(baseName: string, tier: DungeonTier): 
   if (!meta.prefix) return baseName
   return `${meta.prefix} ${baseName}`
 }
+
+/** 探索時間 tier 係数: time(tier) = base + delta × DUNGEON_TIER_TIME_FACTOR[tier] */
+export const DUNGEON_TIER_TIME_FACTOR = [0, 1, 8 / 3, 5, 10, 20] as const
+
+/** ダンジョン探索時間クラス */
+export type DungeonTierClass = 'A' | 'B' | 'C'
+
+/** クラスごとの tier delta（増分単位、秒）: first=踏破前, cleared=踏破後 */
+export const DUNGEON_TIER_TIME_DELTA: Record<DungeonTierClass, { first: number; cleared: number }> = {
+  A: { first: 540, cleared: 270 },
+  B: { first: 2160, cleared: 675 },
+  C: { first: 2160, cleared: 630 },
+}
+
+const DUNGEON_TIER_CLASS_MAP: Record<string, DungeonTierClass> = {
+  // Class A: スライムの洞窟, 周辺の森, ゴブリン集落, 廃墟
+  slime_cave: 'A',
+  forest_outskirts: 'A',
+  goblin_village_1: 'A',
+  goblin_village_2: 'A',
+  goblin_village_3: 'A',
+  undead_ruins_1: 'A',
+  undead_ruins_2: 'A',
+  undead_ruins_3: 'A',
+  // Class C: 辺境の村, オークの野営地, ウルフ草原, リザードマンの沼砦, オークの砦, vs討伐軍
+  human_village: 'C',
+  orc_camp_1: 'C',
+  orc_camp_2: 'C',
+  orc_camp_3: 'C',
+  wolf_grassland_1: 'C',
+  lizardman_swamp_1: 'C',
+  lizardman_swamp_2: 'C',
+  lizardman_swamp_3: 'C',
+  orc_fortress_1: 'C',
+  subjugation_force_1: 'C',
+  subjugation_force_2: 'C',
+  subjugation_force_3: 'C',
+}
+
+/** ダンジョン ID から探索時間クラスを取得（未指定は B） */
+export function getDungeonTierClass(dungeonId: string): DungeonTierClass {
+  return DUNGEON_TIER_CLASS_MAP[dungeonId] ?? 'B'
+}
+
+/** ダンジョンと tier からその tier の探索時間を算出 */
+export function computeDungeonExplorationTime(
+  dungeonId: string,
+  baseFirst: number,
+  baseCleared: number,
+  tier: DungeonTier,
+  isTierCleared: boolean,
+): number {
+  const cls = getDungeonTierClass(dungeonId)
+  const delta = DUNGEON_TIER_TIME_DELTA[cls]
+  const factor = DUNGEON_TIER_TIME_FACTOR[tier] ?? 0
+  const base = isTierCleared ? baseCleared : baseFirst
+  const deltaPerUnit = isTierCleared ? delta.cleared : delta.first
+  return Math.round(base + deltaPerUnit * factor)
+}

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -60,12 +60,16 @@ export type {
 // Dungeon related types
 export type { Dungeon } from "./Dungeon"
 export type { DungeonProgressState } from "./DungeonProgress"
-export type { DungeonTier } from "./DungeonTier"
+export type { DungeonTier, DungeonTierClass } from "./DungeonTier"
 export {
   DUNGEON_TIER_LIST,
   DUNGEON_TIER_META,
   DUNGEON_TIER_SCALING,
+  DUNGEON_TIER_TIME_FACTOR,
+  DUNGEON_TIER_TIME_DELTA,
+  computeDungeonExplorationTime,
   getDungeonTierAreaLevel,
+  getDungeonTierClass,
   getDungeonTierDisplayName,
 } from "./DungeonTier"
 


### PR DESCRIPTION
## Summary
- 未クリア Tier に遠征しても、`dungeon.cleared` 全体フラグで判定されていたため踏破済の短縮時間が使われるバグを修正
- 探索時間に Tier スケール（C(tier) = [0, 1, 8/3, 5, 10, 20]）を導入し、tier が上がるほど時間が伸びるように
- ダンジョン探索時間クラス A/B/C を新設し、クラスごとに踏破前/踏破後の delta を定義

## Detail
### バグ修正
`estimateExplorationTime` に `tier` 引数を追加し、`(dungeon.maxClearedTier ?? 0) > tier` で「その tier 自身が踏破済か」を判定するよう変更。
呼び出し側（preparation 画面・startExpedition・startBulkExpedition）から tier を渡す。

### Tier スケール
- 係数: `DUNGEON_TIER_TIME_FACTOR = [0, 1, 8/3, 5, 10, 20]`
- クラスごとの delta（first=踏破前, cleared=踏破後）:
  - A: `{ first: 540, cleared: 270 }`
  - B: `{ first: 2160, cleared: 675 }`
  - C: `{ first: 2160, cleared: 630 }`
- 計算式: `time = base + delta × C(tier)`（base は既存のマスター値）

### クラス割り当て
- **A (8件)**: slime_cave / forest_outskirts / goblin_village_1〜3 / undead_ruins_1〜3
- **C (12件)**: human_village / orc_camp_1〜3 / wolf_grassland_1 / lizardman_swamp_1〜3 / orc_fortress_1 / subjugation_force_1〜3
- **B (25件)**: 上記以外（デフォルト）

### マスターデータ
`exploration_time_sec_first` / `exploration_time_sec` は **tier 0 の base** として既存値を継続利用。JSON 変更なし。

## Test plan
- [ ] 未クリア Tier を選択して遠征準備画面で踏破前の長い時間が表示されること
- [ ] クリア済 Tier を選択して遠征準備画面で踏破後の短縮時間が表示されること
- [ ] Tier 0/1/2/3/4/5 で実際の遠征時間が想定値に一致すること
- [ ] クラス A/B/C それぞれのダンジョンで Tier スケールが正しく適用されること
- [ ] 一括遠征でも Tier に応じた時間が適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)