### PR TITLE
fix(formation): 街道(road_1)を探索時間クラスCに追加

### DIFF
--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -118,7 +118,8 @@ const DUNGEON_TIER_CLASS_MAP: Record<string, DungeonTierClass> = {
   undead_ruins_1: 'A',
   undead_ruins_2: 'A',
   undead_ruins_3: 'A',
-  // Class C: 辺境の村, オークの野営地, ウルフ草原, リザードマンの沼砦, オークの砦, vs討伐軍
+  // Class C: 街道, 辺境の村, オークの野営地, ウルフ草原, リザードマンの沼砦, オークの砦, vs討伐軍
+  road_1: 'C',
   human_village: 'C',
   orc_camp_1: 'C',
   orc_camp_2: 'C',


### PR DESCRIPTION
## Summary
- 12aedca で導入したダンジョンTier探索時間クラス分類から `road_1` (街道) が漏れていたため、中盤帯のクラス C に追加

## Test plan
- [ ] `npx tsc --noEmit` が通ること
- [ ] 街道で Tier ≥ 1 の探索時間が他のクラス C ダンジョン(辺境の村など)と同じ係数で増加していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)