### PR TITLE
feat(studio): マルク・純ゴブリンの基準値と初期スキルをstudio経由で編集可能に

### DIFF
--- a/goblin_native/src/infrastructure/database/migrations/v14.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v14.ts
@@ -1,5 +1,6 @@
 import type * as SQLite from 'expo-sqlite'
 import { getDefaultSkillsForRace } from '../../../shared/data/raceSkills'
+import { founderGoblinSeed } from '../../../shared/data/founderGoblin'
 
 /**
  * v14: 最初のゴブリンを始祖ゴブリン「マルク」として固定する
@@ -16,12 +17,12 @@ export const migrateV14 = async (database: SQLite.SQLiteDatabase): Promise<void>
          updated_at = datetime('now')
      WHERE id = ?`,
     [
-      'マルク',
-      '始祖ゴブリン',
-      'founder',
-      '/src/assets/goblin/marku.png',
-      JSON.stringify(getDefaultSkillsForRace('founder')),
-      0,
+      founderGoblinSeed.name,
+      founderGoblinSeed.race,
+      founderGoblinSeed.raceId,
+      founderGoblinSeed.avatar,
+      JSON.stringify(getDefaultSkillsForRace(founderGoblinSeed.raceId)),
+      founderGoblinSeed.id,
     ],
   )
 }

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -2,6 +2,9 @@
  * SQLiteスキーマ定義
  * 各テーブルのCREATE文を定義
  */
+import { founderGoblinSeed } from '../../shared/data/founderGoblin'
+
+const sqlString = (value: string): string => `'${value.replace(/'/g, "''")}'`
 
 export const SCHEMA = {
   goblins: `
@@ -164,6 +167,6 @@ export const SCHEMA = {
   goblinsInit: `
     INSERT OR IGNORE INTO goblins (id, name, race, race_id, level, experience, avatar, stats_json, skills_json)
     VALUES
-      (0, 'マルク', '始祖ゴブリン', 'founder', 1, 0, '/src/assets/goblin/marku.png', '{"hp":68,"atk":13,"def":11,"attackCount":2,"accuracy":160,"evasion":15}', '[]')
+      (${founderGoblinSeed.id}, ${sqlString(founderGoblinSeed.name)}, ${sqlString(founderGoblinSeed.race)}, ${sqlString(founderGoblinSeed.raceId)}, ${founderGoblinSeed.level}, ${founderGoblinSeed.experience}, ${sqlString(founderGoblinSeed.avatar)}, ${sqlString(JSON.stringify(founderGoblinSeed.stats))}, '[]')
   `,
 }

--- a/goblin_native/src/shared/data/founderGoblin.ts
+++ b/goblin_native/src/shared/data/founderGoblin.ts
@@ -1,0 +1,45 @@
+import type { GoblinRaceId } from '../types/Race'
+
+export type FounderGoblinSeedStats = {
+  hp: number
+  atk: number
+  def: number
+  attackCount: number
+  accuracy: number
+  evasion: number
+}
+
+export type FounderGoblinSeed = {
+  id: number
+  name: string
+  race: string
+  raceId: GoblinRaceId
+  level: number
+  experience: number
+  avatar: string
+  stats: FounderGoblinSeedStats
+  defaultSkillIds: string[]
+}
+
+export const founderGoblinSeed: FounderGoblinSeed = {
+  id: 0,
+  name: "マルク",
+  race: "始祖ゴブリン",
+  raceId: "founder",
+  level: 1,
+  experience: 0,
+  avatar: "/src/assets/goblin/marku.png",
+  stats: {
+    hp: 68,
+    atk: 13,
+    def: 11,
+    attackCount: 2,
+    accuracy: 160,
+    evasion: 15
+  },
+  defaultSkillIds: [
+    "exp_bonus_70",
+    "goblin_pack_tactics",
+    "factor_drop_bonus_50"
+  ]
+}

--- a/goblin_native/src/shared/data/goblinVariants.ts
+++ b/goblin_native/src/shared/data/goblinVariants.ts
@@ -3,6 +3,7 @@ import type { FactorEffect } from '../types/Factor'
 import type { CharacterSkillId } from './skillCatalog'
 import type { GoblinRaceId } from '../types/Race'
 import { normalizeGoblinRaceId } from '../types/Race'
+import { pureGoblinSeed } from './pureGoblin'
 
 export interface GoblinVariantDefinition {
   factorId: string
@@ -20,16 +21,9 @@ export interface GoblinVariantDefinition {
   defaultSkillIds?: CharacterSkillId[]
 }
 
-export const BASE_GOBLIN_BASE_ATTRIBUTES: GoblinBaseAttributes = {
-  power: 10,
-  wisdom: 10,
-  spirit: 10,
-  vitality: 10,
-  agility: 10,
-  luck: 10,
-}
+export const BASE_GOBLIN_BASE_ATTRIBUTES: GoblinBaseAttributes = pureGoblinSeed.baseAttributes
 
-export const BASE_GOBLIN_HP_COEFFICIENT = 0.8
+export const BASE_GOBLIN_HP_COEFFICIENT = pureGoblinSeed.hpCoefficient
 
 export const goblinVariantDefinitions: Record<string, GoblinVariantDefinition> = {
   slime: {

--- a/goblin_native/src/shared/data/pureGoblin.ts
+++ b/goblin_native/src/shared/data/pureGoblin.ts
@@ -1,0 +1,23 @@
+import type { GoblinBaseAttributes } from '../types'
+
+export type PureGoblinSeed = {
+  baseAttributes: GoblinBaseAttributes
+  hpCoefficient: number
+  defaultSkillIds: string[]
+}
+
+export const pureGoblinSeed: PureGoblinSeed = {
+  baseAttributes: {
+    power: 10,
+    wisdom: 10,
+    spirit: 10,
+    vitality: 10,
+    agility: 10,
+    luck: 10
+  },
+  hpCoefficient: 0.8,
+  defaultSkillIds: [
+    "exp_bonus_70",
+    "goblin_pack_tactics"
+  ]
+}

--- a/goblin_native/src/shared/data/raceSkills.ts
+++ b/goblin_native/src/shared/data/raceSkills.ts
@@ -1,21 +1,19 @@
 import type { CharacterSkill } from '../types'
 import { getGoblinVariantByRace } from './goblinVariants'
 import { getCharacterSkills } from './skillCatalog'
-import type { CharacterSkillId } from './skillCatalog'
-import { isBaseGoblinRaceId, normalizeGoblinRaceId } from '../types/Race'
+import { normalizeGoblinRaceId } from '../types/Race'
 import { getRaceSkillIds } from './races'
-
-const PURE_GOBLIN_DEFAULT_SKILL_IDS: CharacterSkillId[] = [
-  'exp_bonus_70',
-  'goblin_pack_tactics',
-]
+import { pureGoblinSeed } from './pureGoblin'
+import { founderGoblinSeed } from './founderGoblin'
 
 export function getDefaultSkillsForRace(race: string): CharacterSkill[] {
   const normalizedRace = normalizeGoblinRaceId(race)
   const raceSkillIds = getRaceSkillIds([normalizedRace])
   const defaultSkillIds =
-    isBaseGoblinRaceId(normalizedRace)
-      ? PURE_GOBLIN_DEFAULT_SKILL_IDS
+    normalizedRace === 'founder'
+      ? founderGoblinSeed.defaultSkillIds
+      : normalizedRace === 'goblin'
+      ? pureGoblinSeed.defaultSkillIds
       : (getGoblinVariantByRace(normalizedRace)?.defaultSkillIds ?? [])
 
   return getCharacterSkills([...new Set([...raceSkillIds, ...defaultSkillIds])])

--- a/tools/studio/src/api/dataPlugin.ts
+++ b/tools/studio/src/api/dataPlugin.ts
@@ -143,6 +143,33 @@ interface PureGoblinSkillManifestationRule {
   skills: BirthSkillLotteryEntry[]
 }
 
+interface PureGoblinSeed {
+  baseAttributes: GoblinBaseAttributes
+  hpCoefficient: number
+  defaultSkillIds: string[]
+}
+
+interface FounderGoblinSeedStats {
+  hp: number
+  atk: number
+  def: number
+  attackCount: number
+  accuracy: number
+  evasion: number
+}
+
+interface FounderGoblinSeed {
+  id: number
+  name: string
+  race: string
+  raceId: string
+  level: number
+  experience: number
+  avatar: string
+  stats: FounderGoblinSeedStats
+  defaultSkillIds: string[]
+}
+
 interface GoblinStudioData {
   races: GoblinRaceEntry[]
   factors: GoblinFactorSeed[]
@@ -150,6 +177,8 @@ interface GoblinStudioData {
   variants: GoblinVariantSeed[]
   factorSkillInheritanceRules: FactorSkillInheritanceRule[]
   pureGoblinSkillManifestationRules: PureGoblinSkillManifestationRule[]
+  pureGoblin: PureGoblinSeed
+  founder: FounderGoblinSeed
 }
 
 export function dataApiPlugin(options: Options): Plugin {
@@ -162,6 +191,8 @@ export function dataApiPlugin(options: Options): Plugin {
   const jobsFile = path.join(options.appSrc, 'shared', 'data', 'goblinJobs.ts')
   const variantsFile = path.join(options.appSrc, 'shared', 'data', 'goblinVariants.ts')
   const skillBirthRulesFile = path.join(options.appSrc, 'shared', 'data', 'skillBirthRules.ts')
+  const founderGoblinFile = path.join(options.appSrc, 'shared', 'data', 'founderGoblin.ts')
+  const pureGoblinFile = path.join(options.appSrc, 'shared', 'data', 'pureGoblin.ts')
   const equipmentPoolFile = path.join(options.appSrc, 'shared', 'data', 'equipmentPool.json')
   const presetsFile = path.join(options.dataDir, 'party-presets.json')
   const libraryFile = path.join(options.dataDir, 'character-library.json')
@@ -367,6 +398,8 @@ export function dataApiPlugin(options: Options): Plugin {
                 jobsFile,
                 variantsFile,
                 skillBirthRulesFile,
+                founderGoblinFile,
+                pureGoblinFile,
               }),
             )
           }
@@ -376,7 +409,15 @@ export function dataApiPlugin(options: Options): Plugin {
               res,
               200,
               await writeGoblinStudioData(
-                { racesFile, factorsFile, jobsFile, variantsFile, skillBirthRulesFile },
+                {
+                  racesFile,
+                  factorsFile,
+                  jobsFile,
+                  variantsFile,
+                  skillBirthRulesFile,
+                  founderGoblinFile,
+                  pureGoblinFile,
+                },
                 body,
               ),
             )
@@ -846,13 +887,25 @@ async function readGoblinStudioData(paths: {
   jobsFile: string
   variantsFile: string
   skillBirthRulesFile: string
+  founderGoblinFile: string
+  pureGoblinFile: string
 }): Promise<GoblinStudioData> {
-  const [racesSource, factorsSource, jobsSource, variantsSource, skillBirthRulesSource] = await Promise.all([
+  const [
+    racesSource,
+    factorsSource,
+    jobsSource,
+    variantsSource,
+    skillBirthRulesSource,
+    founderGoblinSource,
+    pureGoblinSource,
+  ] = await Promise.all([
     fs.readFile(paths.racesFile, 'utf8'),
     fs.readFile(paths.factorsFile, 'utf8'),
     fs.readFile(paths.jobsFile, 'utf8'),
     fs.readFile(paths.variantsFile, 'utf8'),
     fs.readFile(paths.skillBirthRulesFile, 'utf8'),
+    fs.readFile(paths.founderGoblinFile, 'utf8'),
+    fs.readFile(paths.pureGoblinFile, 'utf8'),
   ])
 
   const racesObject = evaluateObjectLiteral<
@@ -885,6 +938,12 @@ async function readGoblinStudioData(paths: {
   )
   const pureGoblinSkillManifestationRules = evaluateObjectLiteral<PureGoblinSkillManifestationRule[]>(
     extractConstArrayLiteral(skillBirthRulesSource, 'pureGoblinSkillManifestationRules'),
+  )
+  const founder = evaluateObjectLiteral<FounderGoblinSeed>(
+    extractConstObjectLiteral(founderGoblinSource, 'founderGoblinSeed'),
+  )
+  const pureGoblin = evaluateObjectLiteral<PureGoblinSeed>(
+    extractConstObjectLiteral(pureGoblinSource, 'pureGoblinSeed'),
   )
   const variantFactors: GoblinFactorSeed[] = Object.values(variantsObject).map((variant) => ({
     id: variant.factorId,
@@ -919,6 +978,8 @@ async function readGoblinStudioData(paths: {
     variants: Object.values(variantsObject),
     factorSkillInheritanceRules: Object.values(factorSkillInheritanceRulesObject),
     pureGoblinSkillManifestationRules,
+    pureGoblin,
+    founder,
   }
 }
 
@@ -929,6 +990,8 @@ async function writeGoblinStudioData(
     jobsFile: string
     variantsFile: string
     skillBirthRulesFile: string
+    founderGoblinFile: string
+    pureGoblinFile: string
   },
   body: unknown,
 ) {
@@ -936,12 +999,22 @@ async function writeGoblinStudioData(
     throw new Error('Invalid goblin data payload')
   }
 
-  const [racesSource, factorsSource, jobsSource, variantsSource, skillBirthRulesSource] = await Promise.all([
+  const [
+    racesSource,
+    factorsSource,
+    jobsSource,
+    variantsSource,
+    skillBirthRulesSource,
+    founderGoblinSource,
+    pureGoblinSource,
+  ] = await Promise.all([
     fs.readFile(paths.racesFile, 'utf8'),
     fs.readFile(paths.factorsFile, 'utf8'),
     fs.readFile(paths.jobsFile, 'utf8'),
     fs.readFile(paths.variantsFile, 'utf8'),
     fs.readFile(paths.skillBirthRulesFile, 'utf8'),
+    fs.readFile(paths.founderGoblinFile, 'utf8'),
+    fs.readFile(paths.pureGoblinFile, 'utf8'),
   ])
 
   const racesObject = Object.fromEntries(
@@ -1025,6 +1098,16 @@ async function writeGoblinStudioData(
     'pureGoblinSkillManifestationRules',
     formatJsValue(body.pureGoblinSkillManifestationRules, 0),
   )
+  const nextFounderGoblin = replaceConstObjectLiteral(
+    founderGoblinSource,
+    'founderGoblinSeed',
+    formatJsValue(body.founder, 0),
+  )
+  const nextPureGoblin = replaceConstObjectLiteral(
+    pureGoblinSource,
+    'pureGoblinSeed',
+    formatJsValue(body.pureGoblin, 0),
+  )
 
   await Promise.all([
     fs.writeFile(paths.racesFile, nextRaces, 'utf8'),
@@ -1032,6 +1115,8 @@ async function writeGoblinStudioData(
     fs.writeFile(paths.jobsFile, nextJobs, 'utf8'),
     fs.writeFile(paths.variantsFile, nextVariants, 'utf8'),
     fs.writeFile(paths.skillBirthRulesFile, nextSkillBirthRules, 'utf8'),
+    fs.writeFile(paths.founderGoblinFile, nextFounderGoblin, 'utf8'),
+    fs.writeFile(paths.pureGoblinFile, nextPureGoblin, 'utf8'),
   ])
 
   return { ok: true }
@@ -1205,6 +1290,64 @@ function isGoblinStudioDataShape(value: unknown): value is GoblinStudioData {
     Array.isArray(record.jobs) &&
     Array.isArray(record.variants) &&
     Array.isArray(record.factorSkillInheritanceRules) &&
-    Array.isArray(record.pureGoblinSkillManifestationRules)
+    Array.isArray(record.pureGoblinSkillManifestationRules) &&
+    isFounderGoblinSeedShape(record.founder) &&
+    isPureGoblinSeedShape(record.pureGoblin)
+  )
+}
+
+function isPureGoblinSeedShape(value: unknown): value is PureGoblinSeed {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  if (typeof record.hpCoefficient !== 'number') return false
+  if (
+    !Array.isArray(record.defaultSkillIds) ||
+    !record.defaultSkillIds.every((id) => typeof id === 'string')
+  ) {
+    return false
+  }
+  const attrs = record.baseAttributes as Record<string, unknown> | undefined
+  if (!attrs || typeof attrs !== 'object') return false
+  return (
+    typeof attrs.power === 'number' &&
+    typeof attrs.wisdom === 'number' &&
+    typeof attrs.spirit === 'number' &&
+    typeof attrs.vitality === 'number' &&
+    typeof attrs.agility === 'number' &&
+    typeof attrs.luck === 'number'
+  )
+}
+
+function isFounderGoblinSeedShape(value: unknown): value is FounderGoblinSeed {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  if (
+    typeof record.id !== 'number' ||
+    typeof record.name !== 'string' ||
+    typeof record.race !== 'string' ||
+    typeof record.raceId !== 'string' ||
+    typeof record.level !== 'number' ||
+    typeof record.experience !== 'number' ||
+    typeof record.avatar !== 'string'
+  ) {
+    return false
+  }
+  const stats = record.stats as Record<string, unknown> | undefined
+  if (!stats || typeof stats !== 'object') return false
+  if (
+    !(
+      typeof stats.hp === 'number' &&
+      typeof stats.atk === 'number' &&
+      typeof stats.def === 'number' &&
+      typeof stats.attackCount === 'number' &&
+      typeof stats.accuracy === 'number' &&
+      typeof stats.evasion === 'number'
+    )
+  ) {
+    return false
+  }
+  return (
+    Array.isArray(record.defaultSkillIds) &&
+    record.defaultSkillIds.every((id) => typeof id === 'string')
   )
 }

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -335,6 +335,33 @@ export const PureGoblinSkillManifestationRuleSchema = z.object({
   skills: z.array(BirthSkillLotteryEntrySchema),
 })
 
+export const PureGoblinSeedSchema = z.object({
+  baseAttributes: GoblinBaseAttributesSchema,
+  hpCoefficient: z.number(),
+  defaultSkillIds: z.array(z.string()),
+})
+
+export const FounderGoblinSeedStatsSchema = z.object({
+  hp: z.number(),
+  atk: z.number(),
+  def: z.number(),
+  attackCount: z.number(),
+  accuracy: z.number(),
+  evasion: z.number(),
+})
+
+export const FounderGoblinSeedSchema = z.object({
+  id: z.number().int().nonnegative(),
+  name: z.string().min(1),
+  race: z.string().min(1),
+  raceId: z.string().min(1),
+  level: z.number().int().nonnegative(),
+  experience: z.number().int().nonnegative(),
+  avatar: z.string(),
+  stats: FounderGoblinSeedStatsSchema,
+  defaultSkillIds: z.array(z.string()),
+})
+
 export const GoblinStudioDataSchema = z.object({
   races: z.array(GoblinRaceEntrySchema),
   factors: z.array(GoblinFactorSeedSchema),
@@ -342,6 +369,8 @@ export const GoblinStudioDataSchema = z.object({
   variants: z.array(GoblinVariantSeedSchema),
   factorSkillInheritanceRules: z.array(FactorSkillInheritanceRuleSchema),
   pureGoblinSkillManifestationRules: z.array(PureGoblinSkillManifestationRuleSchema),
+  pureGoblin: PureGoblinSeedSchema,
+  founder: FounderGoblinSeedSchema,
 })
 
 export type GoblinBaseAttributes = z.infer<typeof GoblinBaseAttributesSchema>
@@ -354,4 +383,7 @@ export type GoblinFactorSeed = z.infer<typeof GoblinFactorSeedSchema>
 export type BirthSkillLotteryEntry = z.infer<typeof BirthSkillLotteryEntrySchema>
 export type FactorSkillInheritanceRule = z.infer<typeof FactorSkillInheritanceRuleSchema>
 export type PureGoblinSkillManifestationRule = z.infer<typeof PureGoblinSkillManifestationRuleSchema>
+export type FounderGoblinSeedStats = z.infer<typeof FounderGoblinSeedStatsSchema>
+export type FounderGoblinSeed = z.infer<typeof FounderGoblinSeedSchema>
+export type PureGoblinSeed = z.infer<typeof PureGoblinSeedSchema>
 export type GoblinStudioData = z.infer<typeof GoblinStudioDataSchema>

--- a/tools/studio/src/pages/GoblinDataPage.tsx
+++ b/tools/studio/src/pages/GoblinDataPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { getGoblinJobDefinition } from '@app/shared/data/goblinJobs'
 
 import type {
+  FounderGoblinSeed,
   GoblinBaseAttributes,
   GoblinFactorSeed,
   GoblinJobSeed,
@@ -11,6 +12,7 @@ import type {
   GoblinVariantSeed,
   BirthSkillLotteryEntry,
   FactorSkillInheritanceRule,
+  PureGoblinSeed,
   PureGoblinSkillManifestationRule,
 } from '../lib/schema'
 import { GoblinStudioDataSchema } from '../lib/schema'
@@ -35,7 +37,14 @@ type SaveState =
   | { kind: 'error'; message: string }
   | { kind: 'success' }
 
-type Tab = 'races' | 'factors' | 'variants' | 'jobs' | 'birthSkills'
+type Tab =
+  | 'races'
+  | 'factors'
+  | 'variants'
+  | 'jobs'
+  | 'birthSkills'
+  | 'pureGoblin'
+  | 'founder'
 
 const EMPTY_ATTRIBUTES: GoblinBaseAttributes = {
   power: 10,
@@ -239,6 +248,18 @@ export function GoblinDataPage() {
           onClick={() => setTab('birthSkills')}
         >
           誕生スキル
+        </button>
+        <button
+          className={tab === 'pureGoblin' ? 'tab active' : 'tab'}
+          onClick={() => setTab('pureGoblin')}
+        >
+          純ゴブリン
+        </button>
+        <button
+          className={tab === 'founder' ? 'tab active' : 'tab'}
+          onClick={() => setTab('founder')}
+        >
+          マルク
         </button>
       </div>
 
@@ -548,6 +569,21 @@ export function GoblinDataPage() {
             onManifestationChange={(pureGoblinSkillManifestationRules) =>
               updateDraft((prev) => ({ ...prev, pureGoblinSkillManifestationRules }))
             }
+          />
+        )}
+
+        {tab === 'pureGoblin' && (
+          <PureGoblinEditor
+            pureGoblin={draft.pureGoblin}
+            onChange={(pureGoblin) => updateDraft((prev) => ({ ...prev, pureGoblin }))}
+          />
+        )}
+
+        {tab === 'founder' && (
+          <FounderEditor
+            founder={draft.founder}
+            races={draft.races}
+            onChange={(founder) => updateDraft((prev) => ({ ...prev, founder }))}
           />
         )}
       </div>
@@ -1058,6 +1094,209 @@ function JobEditor({
         </div>
         <JobSkillListEditor skills={job.skills} onChange={(skills) => onChange({ ...job, skills })} />
         {job.skills.length === 0 && <p className="subtle">未設定</p>}
+      </section>
+    </div>
+  )
+}
+
+function PureGoblinEditor({
+  pureGoblin,
+  onChange,
+}: {
+  pureGoblin: PureGoblinSeed
+  onChange: (pureGoblin: PureGoblinSeed) => void
+}) {
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <h3>基本情報</h3>
+        <p className="subtle">
+          純ゴブリン (raceId: <code>goblin</code>) の基準値です。新規誕生する亜種でない
+          ゴブリンの基礎能力値・HP 係数・初期スキルとして使用されます。
+        </p>
+        <FieldRow>
+          <NumberField
+            size="sm"
+            label="hpCoefficient"
+            value={pureGoblin.hpCoefficient}
+            step={0.05}
+            onChange={(value) => onChange({ ...pureGoblin, hpCoefficient: value })}
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <h3>基本能力値</h3>
+        <AttributeEditor
+          value={pureGoblin.baseAttributes}
+          onChange={(baseAttributes) => onChange({ ...pureGoblin, baseAttributes })}
+        />
+      </section>
+
+      <section className="card">
+        <h3>デフォルトスキル</h3>
+        <p className="subtle">
+          誕生時に付与されるスキルです。raceId の race スキル
+          (例: <code>goblin.skillIds</code>) と重複排除のうえ合成されます。
+        </p>
+        <SkillIdListEditor
+          skillIds={pureGoblin.defaultSkillIds}
+          onChange={(defaultSkillIds) => onChange({ ...pureGoblin, defaultSkillIds })}
+        />
+      </section>
+    </div>
+  )
+}
+
+function FounderEditor({
+  founder,
+  races,
+  onChange,
+}: {
+  founder: FounderGoblinSeed
+  races: GoblinRaceEntry[]
+  onChange: (founder: FounderGoblinSeed) => void
+}) {
+  return (
+    <div className="panel-stack">
+      <section className="card">
+        <h3>基本情報</h3>
+        <p className="subtle">
+          初期ゴブリン「マルク」の固定データです。アプリの初期投入 (schema.ts) と
+          始祖ゴブリン化マイグレーション (v14) の両方で使用されます。
+        </p>
+        <FieldRow>
+          <NumberField
+            size="xs"
+            label="id"
+            value={founder.id}
+            min={0}
+            onChange={(value) => onChange({ ...founder, id: value })}
+          />
+          <TextField
+            size="md"
+            label="name"
+            value={founder.name}
+            onChange={(value) => onChange({ ...founder, name: value })}
+          />
+          <TextField
+            size="md"
+            label="race (表示名)"
+            value={founder.race}
+            onChange={(value) => onChange({ ...founder, race: value })}
+          />
+          <label className="field field-size-md">
+            <span className="field-label">raceId</span>
+            <span className="field-input">
+              <select
+                value={founder.raceId}
+                onChange={(e) => onChange({ ...founder, raceId: e.target.value })}
+              >
+                {!races.some((race) => race.id === founder.raceId) && (
+                  <option value={founder.raceId}>{founder.raceId}</option>
+                )}
+                {races.map((race) => (
+                  <option key={race.id} value={race.id}>
+                    {race.label || race.id} / {race.id}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+        </FieldRow>
+        <FieldRow>
+          <NumberField
+            size="xs"
+            label="level"
+            value={founder.level}
+            min={1}
+            onChange={(value) => onChange({ ...founder, level: value })}
+          />
+          <NumberField
+            size="sm"
+            label="experience"
+            value={founder.experience}
+            min={0}
+            onChange={(value) => onChange({ ...founder, experience: value })}
+          />
+          <TextField
+            size="xl"
+            label="avatar"
+            value={founder.avatar}
+            onChange={(value) => onChange({ ...founder, avatar: value })}
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <h3>ステータス (stats_json)</h3>
+        <p className="subtle">
+          DB の stats_json に書き込まれる値です。スキルは raceId のデフォルトスキル
+          (getDefaultSkillsForRace) から導出されるため、ここでは設定しません。
+        </p>
+        <FieldRow>
+          <NumberField
+            size="sm"
+            label="hp"
+            value={founder.stats.hp}
+            min={0}
+            onChange={(value) => onChange({ ...founder, stats: { ...founder.stats, hp: value } })}
+          />
+          <NumberField
+            size="sm"
+            label="atk"
+            value={founder.stats.atk}
+            min={0}
+            onChange={(value) => onChange({ ...founder, stats: { ...founder.stats, atk: value } })}
+          />
+          <NumberField
+            size="sm"
+            label="def"
+            value={founder.stats.def}
+            min={0}
+            onChange={(value) => onChange({ ...founder, stats: { ...founder.stats, def: value } })}
+          />
+          <NumberField
+            size="sm"
+            label="attackCount"
+            value={founder.stats.attackCount}
+            min={0}
+            onChange={(value) =>
+              onChange({ ...founder, stats: { ...founder.stats, attackCount: value } })
+            }
+          />
+          <NumberField
+            size="sm"
+            label="accuracy"
+            value={founder.stats.accuracy}
+            min={0}
+            onChange={(value) =>
+              onChange({ ...founder, stats: { ...founder.stats, accuracy: value } })
+            }
+          />
+          <NumberField
+            size="sm"
+            label="evasion"
+            value={founder.stats.evasion}
+            min={0}
+            onChange={(value) =>
+              onChange({ ...founder, stats: { ...founder.stats, evasion: value } })
+            }
+          />
+        </FieldRow>
+      </section>
+
+      <section className="card">
+        <h3>デフォルトスキル</h3>
+        <p className="subtle">
+          マルク誕生時に付与されるスキルです。raceId で導出される race スキル
+          (例: <code>founder.skillIds</code> / 継承元 <code>goblin.skillIds</code>) と
+          ここに登録した skillId が重複排除のうえ skills_json に書き込まれます。
+        </p>
+        <SkillIdListEditor
+          skillIds={founder.defaultSkillIds}
+          onChange={(defaultSkillIds) => onChange({ ...founder, defaultSkillIds })}
+        />
       </section>
     </div>
   )


### PR DESCRIPTION
## Summary
- ハードコードされていたマルク (始祖ゴブリン id=0) の固定値を `goblin_native/src/shared/data/founderGoblin.ts` に切り出し、`schema.ts` の初期 INSERT と v14 マイグレーションが同シードを参照するように変更。
- 純ゴブリン (raceId: `goblin`) の基礎能力値・HP 係数・初期スキルを `pureGoblin.ts` に集約し、既存の `BASE_GOBLIN_BASE_ATTRIBUTES` / `BASE_GOBLIN_HP_COEFFICIENT` と `getDefaultSkillsForRace` から参照するように整理。
- Goblin Studio の「ゴブリン」ページに「マルク」「純ゴブリン」タブを追加し、亜種・ジョブと同じ感覚で `SkillIdListEditor` / `AttributeEditor` から編集 → `*.ts` に保存できるよう `/api/goblin-data` を拡張。

## Test plan
- [ ] \`npx tsc --noEmit\` (goblin_native) が通る
- [ ] \`npx tsc -p tsconfig.app.json --noEmit\` / \`tsconfig.node.json\` (tools/studio) が通る
- [ ] Goblin Studio を起動して「マルク」「純ゴブリン」タブで値を編集し、保存後に対応する \`.ts\` ファイルが期待通りに書き換わる
- [ ] 新規 DB 初期化で id=0 のマルクが想定どおりのステータス・スキルで生成される
- [ ] 既存 DB に v14 マイグレーションを適用したケースでもマルクが固定化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)