### PR TITLE
feat(factor): 因子ドロップ率をダンジョンTierでスケール

### DIFF
--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -15,6 +15,7 @@ import type { LevelUpResult } from '../services/ExperienceSystem'
 import { FactorService } from '../services/FactorService'
 import { captureDungeon } from '../services/BaseRankSystem'
 import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
+import { getDungeonTierFactorDropMultiplier } from '../../shared/types/DungeonTier'
 
 export interface ExpeditionCompletionResult {
   levelUps: Map<number, LevelUpResult>
@@ -175,6 +176,8 @@ export class CompleteExpeditionUseCase {
               return drop
             })
 
+          const tierMultiplier = getDungeonTierFactorDropMultiplier(replay.meta.tier ?? 0)
+
           for (const goblin of goblins) {
             if (replay.summary.casualties.includes(goblin.id.toString())) {
               continue
@@ -184,7 +187,7 @@ export class CompleteExpeditionUseCase {
             const factorDropBonusPercent = getFactorDropBonusPercentFromSkills(latest.skills)
             const factorDropMultiplier = getFactorDropMultiplierFromSkills(latest.skills)
             const probabilityMultiplier =
-              (1 + Math.max(0, factorDropBonusPercent) / 100) * factorDropMultiplier
+              (1 + Math.max(0, factorDropBonusPercent) / 100) * factorDropMultiplier * tierMultiplier
             const acquired = FactorService.rollFactorDrops(
               latest,
               allFactorDrops,

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -98,6 +98,34 @@ export function getDungeonTierDisplayName(baseName: string, tier: DungeonTier): 
 /** 探索時間 tier 係数: time(tier) = base + delta × DUNGEON_TIER_TIME_FACTOR[tier] */
 export const DUNGEON_TIER_TIME_FACTOR = [0, 1, 8 / 3, 5, 10, 20] as const
 
+/**
+ * Tier ごとのボス因子ドロップ実効確率（敵JSONの `probability` は基準値 0.015 を想定し、
+ * 実行時に `tierRate / baseRate` の倍率として `probabilityMultiplier` に合成する）
+ *
+ * - 0 通常: 1.5%
+ * - 1 魔性: 2.5%
+ * - 2 宿った: 3.5%
+ * - 3 伝説: 4.5%
+ * - 4 恐ろしい: 5.5%
+ * - 5 壊れた: 6.5%（+1% の等差を延長）
+ */
+export const DUNGEON_TIER_FACTOR_DROP_RATE = [
+  0.015,
+  0.025,
+  0.035,
+  0.045,
+  0.055,
+  0.065,
+] as const
+
+const BASE_FACTOR_DROP_RATE = DUNGEON_TIER_FACTOR_DROP_RATE[0]
+
+/** Tier に応じた因子ドロップ倍率（敵JSON の基準 1.5% に乗算する係数）を返す */
+export function getDungeonTierFactorDropMultiplier(tier: DungeonTier = 0): number {
+  const rate = DUNGEON_TIER_FACTOR_DROP_RATE[tier] ?? BASE_FACTOR_DROP_RATE
+  return rate / BASE_FACTOR_DROP_RATE
+}
+
 /** ダンジョン探索時間クラス */
 export type DungeonTierClass = 'A' | 'B' | 'C'
 


### PR DESCRIPTION
## Summary
- ダンジョン Tier に応じてボスからの因子ドロップ率をスケール
- 通常 1.5% / 魔性 2.5% / 宿った 3.5% / 伝説 4.5% / 恐ろしい 5.5% / 壊れた 6.5%
- 敵JSONの `probability` (基準 1.5%) はそのままで、`probabilityMultiplier` に Tier 倍率を乗算合成

## 設計メモ
- `DUNGEON_TIER_FACTOR_DROP_RATE` テーブルと `getDungeonTierFactorDropMultiplier` を追加
- 既存のスキル補正 (`factor_drop_mult_*` / `factorDropBonusPercent`) と独立に乗算されるため自然に合成可能
  - 例: 魔性Tier(2.5%) × [50%]因子獲得率 = 3.75%
  - 例: 伝説Tier(4.5%) × [1.5]因子獲得 = 6.75%
- Tier 5「壊れた」は +1% 等差を素直に延長 (調整したい場合はテーブル末尾のみ修正)

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest --testPathPatterns="CompleteExpeditionUseCase|FactorService"` (16 tests passed)
- [ ] 実機で各 Tier のボス周回時にドロップ率が想定通りスケールすること
- [ ] スキル `factor_drop_mult_1_5` 装備時に Tier 倍率とスキル倍率が合成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)