### PR TITLE
feat(skill): 魔法威力+20%スキル(spell_damage_20)を追加し魔導士に付与

### DIFF
--- a/goblin_native/src/shared/data/goblinJobs.ts
+++ b/goblin_native/src/shared/data/goblinJobs.ts
@@ -62,10 +62,6 @@ const GOBLIN_JOB_DEFINITION_SEEDS: Record<GoblinJob, GoblinJobDefinitionSeed> = 
       {
         skillId: "rear_guard",
         unlockLevel: 15
-      },
-      {
-        skillId: "mana_recovery",
-        unlockLevel: 15
       }
     ],
     baseAttributes: {
@@ -107,6 +103,12 @@ const GOBLIN_JOB_DEFINITION_SEEDS: Record<GoblinJob, GoblinJobDefinitionSeed> = 
     skills: [
       {
         skillId: "mage_magic_lv7"
+      },
+      {
+        skillId: "mana_recovery"
+      },
+      {
+        skillId: "spell_damage_20"
       }
     ],
     baseAttributes: {
@@ -189,6 +191,9 @@ const GOBLIN_JOB_DEFINITION_SEEDS: Record<GoblinJob, GoblinJobDefinitionSeed> = 
       },
       {
         skillId: "action_order_150"
+      },
+      {
+        skillId: "counter_avoidance_2_3"
       }
     ],
     unlockRequiresReadStory: "story_after_wolf_grassland"

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -562,6 +562,7 @@ export const CHARACTER_SKILL_CATALOG = {
   spell_damage_14: createSpellDamageSkill(14),
   spell_damage_15: createSpellDamageSkill(15),
   spell_damage_16: createSpellDamageSkill(16),
+  spell_damage_20: createSpellDamageSkill(20),
   spell_damage_58: createSpellDamageSkill(58),
   spell_damage_110: createSpellDamageSkill(110),
   spell_damage_175: createSpellDamageSkill(175),


### PR DESCRIPTION
## Summary
- `spell_damage_20` (spellDamagePercent: 20 / 表示「[+20%]魔法威力の増減(%)」) を `CHARACTER_SKILL_CATALOG` に追加
- 魔導士の初期スキルに `spell_damage_20` と `mana_recovery` を割り当て (旧来 `mana_recovery` を持っていたジョブから整理)
- ゲリラに `counter_avoidance_2_3` を付与

## Test plan
- [x] `npx tsc --noEmit` でエラーなし
- [ ] 魔導士のスキル欄に「[+20%]魔法威力の増減(%)」「マナリカバリ」が表示されることを確認
- [ ] ゲリラのスキル欄に「カウンター回避 2/3」が表示されることを確認
- [ ] 魔導士による魔法ダメージが+20%加算されることを戦闘ログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)