### PR TITLE
feat(skill): 会心威力上昇スキルを追加し会心時の物理ダメージを増加

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -6,6 +6,7 @@ import {
   getAdditionalDamageFromSkills,
   getMagicDamageFollowUpFromSkills,
   getCriticalAttackFollowUpFromSkills,
+  getCriticalDamageBonusFromSkills,
   getPhysicalCounterAttackFromSkills,
   getCounterAttackAvoidanceRateFromSkills,
   getPhysicalDamagePercentFromSkills,
@@ -84,6 +85,7 @@ interface BattleUnit {
   magicAtk: number              // 魔法攻撃力
   magicHeal: number             // 魔法回復量
   criticalRate: number          // 必殺率（%）
+  criticalDamageBonusPercent: number // 会心威力上昇（%）
   spellDamagePercent: number    // 魔法威力の増減（%）
   magicFieldDamageMultiplier: number // PT効果による魔法与ダメージ倍率
   shieldBarrierActive?: boolean  // シールドバリア状態
@@ -705,9 +707,12 @@ export class BattleSystem {
         const protectionFactor = this.getRearGuardReductionFactor(attackTarget, allyUnits)
         const defendingFactor = this.getDefendingDamageFactor(attackTarget)
         const physicalDamageFactor = 1 + unit.physicalDamagePercent / 100
+        const criticalDamageFactor = isCritical
+          ? 1 + (unit.criticalDamageBonusPercent ?? 0) / 100
+          : 1
         const damage = Math.max(
           1,
-          Math.floor((baseDamage * dmgMod * rearDamageMultiplier * rowDamageMultiplier + additionalDamage) * physicalDamageFactor * unit.physicalDamageDealtMultiplier * reductionFactor * physicalReductionFactor * shieldBarrierReductionFactor * protectionFactor * defendingFactor * damageMultiplier),
+          Math.floor((baseDamage * dmgMod * rearDamageMultiplier * rowDamageMultiplier + additionalDamage) * physicalDamageFactor * criticalDamageFactor * unit.physicalDamageDealtMultiplier * reductionFactor * physicalReductionFactor * shieldBarrierReductionFactor * protectionFactor * defendingFactor * damageMultiplier),
         )
 
         this.applyDamage(attackTarget, damage)
@@ -1598,6 +1603,7 @@ export class BattleSystem {
       magicAtk: effectiveStats.magicAtk,
       magicHeal: effectiveStats.magicHeal,
       criticalRate: effectiveStats.criticalRate,
+      criticalDamageBonusPercent: getCriticalDamageBonusFromSkills(goblin.skills),
       spellDamagePercent: getSpellDamagePercentFromSkills(goblin.skills),
       magicFieldDamageMultiplier: 1,
       shieldBarrierActive: false,
@@ -1650,6 +1656,7 @@ export class BattleSystem {
       magicAtk: enemy.magicAtk ?? enemy.atk,
       magicHeal: enemy.magicHeal ?? 0,
       criticalRate: enemy.criticalRate ?? 0,
+      criticalDamageBonusPercent: getCriticalDamageBonusFromSkills(skills),
       spellDamagePercent: getSpellDamagePercentFromSkills(skills),
       magicFieldDamageMultiplier: 1,
       shieldBarrierActive: false,

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -798,6 +798,7 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
       magicAtk: 0,
       magicHeal: 0,
       criticalRate: 0,
+      criticalDamageBonusPercent: 0,
       spellDamagePercent: 0,
       magicFieldDamageMultiplier: 1,
       row: 0,
@@ -849,6 +850,93 @@ describe('BattleSystem — 命中判定と複数回攻撃', () => {
     const detail = [...result.targetDetails.values()][0]
     expect(result.totalHitCount).toBe(1)
     expect(detail.totalDamage).toBe(100)
+  })
+
+  it('会心威力スキルは会心時の通常攻撃ダメージを増加させる', () => {
+    const fakeDamageCalculator = {
+      calcDamage: jest.fn(() => 100),
+    }
+    const battle = new BattleSystem(undefined, fakeDamageCalculator as any)
+    const attacker: any = {
+      combatant: {
+        id: '1',
+        name: '攻撃者',
+        atk: 100,
+        def: 0,
+        attackCount: 1,
+        accuracy: 999,
+        evasion: 0,
+        raceTags: ['goblin'],
+      },
+      currentHP: 100,
+      maxHP: 100,
+      power: 10,
+      agility: 10,
+      luck: 10,
+      attackCount: 1,
+      accuracy: 999,
+      evasion: 0,
+      isAlly: true,
+      originalIndex: 0,
+      damageReduction: 0,
+      physicalDamageReduction: 0,
+      magicDamageReduction: 0,
+      breathDamageReduction: 0,
+      shieldBarrierDamageReduction: 0,
+      shieldBarrierBreathDamageReduction: 0,
+      magicBarrierDamageReduction: 0,
+      physicalDamageDealtMultiplier: 1,
+      physicalDamagePercent: 0,
+      magicAtk: 0,
+      magicHeal: 0,
+      criticalRate: 100,
+      criticalDamageBonusPercent: 50,
+      spellDamagePercent: 0,
+      magicFieldDamageMultiplier: 1,
+      row: 0,
+      rowSlot: 0,
+      level: 1,
+      spellCharges: [],
+      skills: [{ id: 'critical_damage_50', criticalDamageBonusPercent: 50 }],
+      battleActionPolicy: {},
+      isDefending: false,
+    }
+    const target: any = {
+      ...attacker,
+      combatant: {
+        id: 'E',
+        name: '対象',
+        atk: 0,
+        def: 0,
+        attackCount: 0,
+        accuracy: 0,
+        evasion: 0,
+        raceTags: ['human'],
+      },
+      currentHP: 1000,
+      maxHP: 1000,
+      isAlly: false,
+      criticalRate: 0,
+      criticalDamageBonusPercent: 0,
+    }
+
+    const result = (battle as any).executeBasicAttack(
+      attacker,
+      [target],
+      [attacker],
+      [attacker],
+      1,
+      [],
+      new Set(),
+      new Set(),
+      () => 0,
+      1,
+      100,
+    )
+
+    const detail = [...result.targetDetails.values()][0]
+    expect(result.isCritical).toBe(true)
+    expect(detail.totalDamage).toBe(150)
   })
 
   it('命中精度0・回避極大でほぼ全ミスになる', () => {
@@ -1641,6 +1729,7 @@ describe('selectTarget — 隊列ターゲット選択', () => {
       magicAtk: 0,
       magicHeal: 0,
       criticalRate: 0,
+      criticalDamageBonusPercent: 0,
       spellDamagePercent: 0,
       magicFieldDamageMultiplier: 1,
       row,

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -9,6 +9,7 @@ import {
   getPartyRareMultiplierFromSkills,
   getPartyTitleMultiplierFromSkills,
   getCharacterSkillEffectDescriptions,
+  getCriticalDamageBonusFromSkills,
   getLearnedSpellsFromSkills,
   getMagicDamageFollowUpFromSkills,
   getMagicDamageReductionFromSkills,
@@ -184,6 +185,25 @@ describe('characterSkills - 物理ダメージ軽減', () => {
     ]
 
     expect(getPhysicalDamagePercentFromSkills(skills)).toBe(10)
+  })
+
+  it('会心威力スキルの値を合算する', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'critical_damage_6', criticalDamageBonusPercent: 6 },
+      { id: 'critical_damage_7', criticalDamageBonusPercent: 7 },
+      { id: 'other', additionalDamage: 13 },
+    ]
+
+    expect(getCriticalDamageBonusFromSkills(skills)).toBe(13)
+  })
+
+  it('同じidの会心威力スキルは重複計算しない', () => {
+    const skills: CharacterSkill[] = [
+      { id: 'critical_damage_shared', criticalDamageBonusPercent: 10 },
+      { id: 'critical_damage_shared', criticalDamageBonusPercent: 10 },
+    ]
+
+    expect(getCriticalDamageBonusFromSkills(skills)).toBe(10)
   })
 
   it('同じidの後列保護スキルは重複計算しない', () => {

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -610,6 +610,13 @@ export function getCriticalRateBonusFromSkills(skills: CharacterSkill[]): number
   )
 }
 
+export function getCriticalDamageBonusFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.criticalDamageBonusPercent ?? 0),
+    0,
+  )
+}
+
 export function getSpellDamagePercentFromSkills(skills: CharacterSkill[]): number {
   return getUniqueSkillsById(skills).reduce(
     (sum, skill) => sum + (skill.spellDamagePercent ?? 0),


### PR DESCRIPTION
## Summary
- `criticalDamageBonusPercent` を `CharacterSkill` から集計する `getCriticalDamageBonusFromSkills` を追加
- BattleSystem の通常物理攻撃ダメージ計算に、会心ヒット時のみ加算される `criticalDamageFactor` を導入
- BattleUnit に `criticalDamageBonusPercent` を保持し、味方・敵双方のスキルから値を読み込むよう拡張

## Test plan
- [ ] `npm test -- CombatStats` で会心威力スキルが会心時の通常攻撃ダメージを増加させることを確認
- [ ] `npm test -- characterSkills` で会心威力スキルの合算と重複除外を確認
- [ ] `npx tsc --noEmit` で型エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)