### PR TITLE
feat(tools): ストア用スクリーンショット作成ツール screenshot-maker を追加

### DIFF
--- a/tools/screenshot-maker/.gitignore
+++ b/tools/screenshot-maker/.gitignore
@@ -1,0 +1,3 @@
+output/
+!public/
+!public/**

--- a/tools/screenshot-maker/public/app.js
+++ b/tools/screenshot-maker/public/app.js
@@ -1,0 +1,805 @@
+"use strict";
+
+const state = {
+  bgSrc: null,
+  canvasWidth: 850,
+  canvasHeight: 1850,
+  zoom: 0.5,
+  layers: [],
+  selectedId: null,
+  nextId: 1,
+};
+
+const $stage = document.getElementById('stage');
+const $layers = document.getElementById('layers');
+const $bgImage = document.getElementById('bgImage');
+const $zoom = document.getElementById('zoom');
+const $zoomLabel = document.getElementById('zoomLabel');
+const $canvasW = document.getElementById('canvasW');
+const $canvasH = document.getElementById('canvasH');
+const $applySize = document.getElementById('applySize');
+const $bgUpload = document.getElementById('bgUpload');
+const $bgPreset = document.getElementById('bgPreset');
+const $localUpload = document.getElementById('localUpload');
+const $assetTree = document.getElementById('assetTree');
+const $assetSearch = document.getElementById('assetSearch');
+const $exportBtn = document.getElementById('exportBtn');
+const $saveBtn = document.getElementById('saveBtn');
+const $resetBtn = document.getElementById('resetBtn');
+const $selectedInfo = document.getElementById('selectedInfo');
+const $stageScroll = document.getElementById('stageScroll');
+
+function applyCanvasSize() {
+  $stage.style.width = state.canvasWidth + 'px';
+  $stage.style.height = state.canvasHeight + 'px';
+  applyZoom();
+}
+
+function applyZoom() {
+  $stage.style.transformOrigin = 'top left';
+  $stage.style.transform = `scale(${state.zoom})`;
+  $stage.style.marginRight = (state.canvasWidth * (state.zoom - 1)) + 'px';
+  $stage.style.marginBottom = (state.canvasHeight * (state.zoom - 1)) + 'px';
+  $zoomLabel.textContent = Math.round(state.zoom * 100) + '%';
+}
+
+function stagePointToCanvas(clientX, clientY) {
+  const rect = $stage.getBoundingClientRect();
+  return {
+    x: (clientX - rect.left) / state.zoom,
+    y: (clientY - rect.top) / state.zoom,
+  };
+}
+
+function nextId() { return state.nextId++; }
+
+function addLayer({ src, naturalWidth, naturalHeight, x, y, width, height }) {
+  const id = nextId();
+  const maxDim = Math.min(state.canvasWidth, state.canvasHeight) * 0.5;
+  let w = width, h = height;
+  if (w == null || h == null) {
+    const aspect = naturalWidth / naturalHeight;
+    if (aspect >= 1) {
+      w = Math.min(naturalWidth, maxDim);
+      h = w / aspect;
+    } else {
+      h = Math.min(naturalHeight, maxDim);
+      w = h * aspect;
+    }
+  }
+  const layer = {
+    id,
+    src,
+    naturalWidth,
+    naturalHeight,
+    x: x ?? state.canvasWidth / 2,
+    y: y ?? state.canvasHeight / 2,
+    width: w,
+    height: h,
+    rotation: 0,
+    flipped: false,
+  };
+  state.layers.push(layer);
+  renderLayers();
+  selectLayer(id);
+  return layer;
+}
+
+function selectLayer(id) {
+  state.selectedId = id;
+  renderLayers();
+  updateSelectedInfo();
+}
+
+function deselect() {
+  state.selectedId = null;
+  renderLayers();
+  updateSelectedInfo();
+}
+
+function deleteLayer(id) {
+  state.layers = state.layers.filter((l) => l.id !== id);
+  if (state.selectedId === id) state.selectedId = null;
+  renderLayers();
+  updateSelectedInfo();
+}
+
+function duplicateLayer(id) {
+  const layer = state.layers.find((l) => l.id === id);
+  if (!layer) return;
+  const copy = { ...layer, id: nextId(), x: layer.x + 20, y: layer.y + 20 };
+  state.layers.push(copy);
+  selectLayer(copy.id);
+}
+
+function bringForward(id) {
+  const idx = state.layers.findIndex((l) => l.id === id);
+  if (idx < 0 || idx === state.layers.length - 1) return;
+  const [l] = state.layers.splice(idx, 1);
+  state.layers.splice(idx + 1, 0, l);
+  renderLayers();
+}
+function sendBackward(id) {
+  const idx = state.layers.findIndex((l) => l.id === id);
+  if (idx <= 0) return;
+  const [l] = state.layers.splice(idx, 1);
+  state.layers.splice(idx - 1, 0, l);
+  renderLayers();
+}
+
+function updateSelectedInfo() {
+  const layer = state.layers.find((l) => l.id === state.selectedId);
+  if (!layer) {
+    $selectedInfo.textContent = `配置レイヤー数: ${state.layers.length} / 未選択`;
+    return;
+  }
+  $selectedInfo.textContent = `#${layer.id} | ${Math.round(layer.width)}×${Math.round(layer.height)} | ${Math.round(layer.rotation)}°`;
+}
+
+function renderLayers() {
+  $layers.innerHTML = '';
+  for (const layer of state.layers) {
+    const el = document.createElement('div');
+    el.className = 'layer';
+    if (layer.id === state.selectedId) el.classList.add('is-selected');
+    el.style.left = (layer.x - layer.width / 2) + 'px';
+    el.style.top = (layer.y - layer.height / 2) + 'px';
+    el.style.width = layer.width + 'px';
+    el.style.height = layer.height + 'px';
+    el.style.transformOrigin = '50% 50%';
+    el.style.transform = `rotate(${layer.rotation}deg)${layer.flipped ? ' scaleX(-1)' : ''}`;
+    el.dataset.layerId = layer.id;
+
+    const img = document.createElement('img');
+    img.src = layer.src;
+    img.draggable = false;
+    el.appendChild(img);
+
+    if (layer.id === state.selectedId) {
+      ['nw','n','ne','w','e','sw','s','se'].forEach((k) => {
+        const h = document.createElement('div');
+        h.className = `handle ${k}`;
+        h.dataset.handle = k;
+        el.appendChild(h);
+      });
+      const rotateLine = document.createElement('div');
+      rotateLine.className = 'rotate-line';
+      el.appendChild(rotateLine);
+      const r = document.createElement('div');
+      r.className = 'handle is-rotate';
+      r.dataset.handle = 'rotate';
+      el.appendChild(r);
+    }
+
+    attachLayerEvents(el, layer);
+    $layers.appendChild(el);
+  }
+  updateSelectedInfo();
+}
+
+function attachLayerEvents(el, layer) {
+  el.addEventListener('pointerdown', (e) => {
+    e.stopPropagation();
+    const target = e.target;
+    const handleKey = target?.dataset?.handle;
+    if (handleKey === 'rotate') {
+      startRotate(e, layer);
+    } else if (handleKey) {
+      startResize(e, layer, handleKey);
+    } else {
+      if (layer.id !== state.selectedId) selectLayer(layer.id);
+      startMove(e, layer);
+    }
+  });
+}
+
+function startMove(e, layer) {
+  e.preventDefault();
+  const start = stagePointToCanvas(e.clientX, e.clientY);
+  const orig = { x: layer.x, y: layer.y };
+  const move = (ev) => {
+    const p = stagePointToCanvas(ev.clientX, ev.clientY);
+    layer.x = orig.x + (p.x - start.x);
+    layer.y = orig.y + (p.y - start.y);
+    renderLayers();
+  };
+  const up = () => {
+    window.removeEventListener('pointermove', move);
+    window.removeEventListener('pointerup', up);
+  };
+  window.addEventListener('pointermove', move);
+  window.addEventListener('pointerup', up);
+}
+
+function handleSigns(k) {
+  return {
+    sx: k.includes('e') ? 1 : k.includes('w') ? -1 : 0,
+    sy: k.includes('s') ? 1 : k.includes('n') ? -1 : 0,
+  };
+}
+
+function startResize(e, layer, k) {
+  e.preventDefault();
+  const θ = layer.rotation * Math.PI / 180;
+  const cos = Math.cos(θ), sin = Math.sin(θ);
+  const { sx, sy } = handleSigns(k);
+  const anchorLocal = { x: -sx * layer.width / 2, y: -sy * layer.height / 2 };
+  const anchorWorld = {
+    x: layer.x + cos * anchorLocal.x - sin * anchorLocal.y,
+    y: layer.y + sin * anchorLocal.x + cos * anchorLocal.y,
+  };
+  const startW = layer.width, startH = layer.height;
+  const ar = startW / startH;
+
+  const move = (ev) => {
+    const p = stagePointToCanvas(ev.clientX, ev.clientY);
+    const dx = p.x - anchorWorld.x;
+    const dy = p.y - anchorWorld.y;
+    const u = dx * cos + dy * sin;
+    const v = -dx * sin + dy * cos;
+    let newW = startW, newH = startH;
+    if (sx !== 0) newW = Math.max(8, Math.abs(u));
+    if (sy !== 0) newH = Math.max(8, Math.abs(v));
+    const isCorner = sx !== 0 && sy !== 0;
+    if (isCorner && !ev.shiftKey) {
+      if (newW / newH > ar) newH = newW / ar;
+      else newW = newH * ar;
+    }
+    const offX = sx * newW / 2;
+    const offY = sy * newH / 2;
+    layer.x = anchorWorld.x + cos * offX - sin * offY;
+    layer.y = anchorWorld.y + sin * offX + cos * offY;
+    layer.width = newW;
+    layer.height = newH;
+    renderLayers();
+  };
+  const up = () => {
+    window.removeEventListener('pointermove', move);
+    window.removeEventListener('pointerup', up);
+  };
+  window.addEventListener('pointermove', move);
+  window.addEventListener('pointerup', up);
+}
+
+function startRotate(e, layer) {
+  e.preventDefault();
+  const p0 = stagePointToCanvas(e.clientX, e.clientY);
+  const startAngle = Math.atan2(p0.y - layer.y, p0.x - layer.x);
+  const startRot = layer.rotation;
+  const move = (ev) => {
+    const p = stagePointToCanvas(ev.clientX, ev.clientY);
+    const ang = Math.atan2(p.y - layer.y, p.x - layer.x);
+    let deg = startRot + (ang - startAngle) * 180 / Math.PI;
+    if (ev.shiftKey) deg = Math.round(deg / 15) * 15;
+    layer.rotation = deg;
+    renderLayers();
+  };
+  const up = () => {
+    window.removeEventListener('pointermove', move);
+    window.removeEventListener('pointerup', up);
+  };
+  window.addEventListener('pointermove', move);
+  window.addEventListener('pointerup', up);
+}
+
+$stage.addEventListener('pointerdown', (e) => {
+  if (e.target === $stage || e.target === $bgImage || e.target === $layers) {
+    deselect();
+  }
+});
+
+window.addEventListener('keydown', (e) => {
+  const tag = (e.target && e.target.tagName) || '';
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+  const layer = state.layers.find((l) => l.id === state.selectedId);
+  if (!layer) return;
+  const step = e.shiftKey ? 10 : 1;
+  let handled = true;
+  switch (e.key) {
+    case 'ArrowLeft': layer.x -= step; break;
+    case 'ArrowRight': layer.x += step; break;
+    case 'ArrowUp': layer.y -= step; break;
+    case 'ArrowDown': layer.y += step; break;
+    case 'Delete':
+    case 'Backspace':
+      deleteLayer(layer.id);
+      return;
+    case ']': bringForward(layer.id); return;
+    case '[': sendBackward(layer.id); return;
+    case 'h': case 'H':
+      layer.flipped = !layer.flipped; break;
+    case 'd': case 'D':
+      if (e.ctrlKey || e.metaKey) { duplicateLayer(layer.id); e.preventDefault(); return; }
+      handled = false; break;
+    case '+': case '=': {
+      const factor = 1.05;
+      layer.width *= factor; layer.height *= factor; break;
+    }
+    case '-': case '_': {
+      const factor = 1 / 1.05;
+      layer.width *= factor; layer.height *= factor; break;
+    }
+    case ',': case '<':
+      layer.rotation -= e.shiftKey ? 15 : 1; break;
+    case '.': case '>':
+      layer.rotation += e.shiftKey ? 15 : 1; break;
+    default: handled = false;
+  }
+  if (handled) {
+    e.preventDefault();
+    renderLayers();
+  }
+});
+
+$zoom.addEventListener('input', () => {
+  state.zoom = Number($zoom.value) / 100;
+  applyZoom();
+});
+
+$applySize.addEventListener('click', () => {
+  state.canvasWidth = Math.max(100, Number($canvasW.value) || 850);
+  state.canvasHeight = Math.max(100, Number($canvasH.value) || 1850);
+  applyCanvasSize();
+});
+
+$resetBtn.addEventListener('click', () => {
+  if (!confirm('配置をすべてリセットしますか？背景は維持されます。')) return;
+  state.layers = [];
+  state.selectedId = null;
+  renderLayers();
+});
+
+$bgUpload.addEventListener('change', () => {
+  const file = $bgUpload.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => setBackground(reader.result);
+  reader.readAsDataURL(file);
+});
+
+$localUpload.addEventListener('change', () => {
+  const files = $localUpload.files;
+  if (!files || files.length === 0) return;
+  Array.from(files).forEach((f) => addImageFromFile(f));
+  $localUpload.value = '';
+});
+
+function addImageFromFile(file) {
+  const reader = new FileReader();
+  reader.onload = () => addImageFromUrl(reader.result);
+  reader.readAsDataURL(file);
+}
+
+function addImageFromUrl(src, opts = {}) {
+  const img = new Image();
+  img.onload = () => {
+    addLayer({
+      src,
+      naturalWidth: img.naturalWidth,
+      naturalHeight: img.naturalHeight,
+      x: opts.x,
+      y: opts.y,
+    });
+  };
+  img.onerror = () => alert('画像を読み込めませんでした');
+  img.src = src;
+}
+
+function setBackground(src) {
+  state.bgSrc = src;
+  $bgImage.src = src;
+  $bgImage.onload = () => {
+    state.canvasWidth = $bgImage.naturalWidth;
+    state.canvasHeight = $bgImage.naturalHeight;
+    $canvasW.value = state.canvasWidth;
+    $canvasH.value = state.canvasHeight;
+    applyCanvasSize();
+  };
+}
+
+function projectUrl(relPath) {
+  return '/project/' + relPath.split('/').map(encodeURIComponent).join('/');
+}
+
+$bgPreset.addEventListener('change', () => {
+  const v = $bgPreset.value;
+  if (!v) return;
+  setBackground(projectUrl(v));
+});
+
+async function loadBackgrounds() {
+  const res = await fetch('/api/backgrounds');
+  const { list } = await res.json();
+  for (const item of list) {
+    const opt = document.createElement('option');
+    opt.value = item.path;
+    opt.textContent = item.name;
+    $bgPreset.appendChild(opt);
+  }
+  const aaaa = list.find((x) => x.path.endsWith('aaaa.png'));
+  if (aaaa) {
+    $bgPreset.value = aaaa.path;
+    setBackground(projectUrl(aaaa.path));
+  }
+}
+
+async function loadAssetTree() {
+  const res = await fetch('/api/assets');
+  const { tree } = await res.json();
+  $assetTree.innerHTML = '';
+  $assetTree.appendChild(renderTree(tree, true));
+}
+
+function renderTree(nodes, isRoot) {
+  const container = document.createElement('div');
+  for (const node of nodes) {
+    container.appendChild(renderNode(node, isRoot));
+  }
+  return container;
+}
+
+function renderNode(node, openByDefault) {
+  if (node.type === 'dir') {
+    const dir = document.createElement('div');
+    dir.className = 'tree-node tree-dir';
+    if (openByDefault) dir.classList.add('is-open');
+    const label = document.createElement('div');
+    label.className = 'tree-dir__label';
+    label.innerHTML = `<span class="tree-dir__chev">▶</span>📁 ${node.name}`;
+    label.addEventListener('click', () => dir.classList.toggle('is-open'));
+    const children = document.createElement('div');
+    children.className = 'tree-dir__children';
+    children.appendChild(renderTree(node.children, false));
+    dir.appendChild(label);
+    dir.appendChild(children);
+    return dir;
+  }
+  const item = document.createElement('div');
+  item.className = 'tree-file';
+  item.draggable = true;
+  const url = '/assets/' + node.path.split('/').map(encodeURIComponent).join('/');
+  const thumb = document.createElement('img');
+  thumb.className = 'tree-file__thumb';
+  thumb.src = url;
+  thumb.draggable = false;
+  const name = document.createElement('span');
+  name.className = 'tree-file__name';
+  name.textContent = node.name;
+  name.title = node.path;
+  item.appendChild(thumb);
+  item.appendChild(name);
+  item.addEventListener('click', () => addImageFromUrl(url));
+  item.addEventListener('dragstart', (e) => {
+    e.dataTransfer.setData('text/asset-url', url);
+    e.dataTransfer.effectAllowed = 'copy';
+  });
+  return item;
+}
+
+$assetSearch.addEventListener('input', () => {
+  const q = $assetSearch.value.toLowerCase().trim();
+  const allFiles = $assetTree.querySelectorAll('.tree-file');
+  const allDirs = $assetTree.querySelectorAll('.tree-dir');
+  if (!q) {
+    allFiles.forEach((el) => (el.style.display = ''));
+    allDirs.forEach((el) => el.classList.remove('is-open'));
+    $assetTree.querySelectorAll(':scope > div > .tree-dir').forEach((el) => el.classList.add('is-open'));
+    return;
+  }
+  allFiles.forEach((el) => {
+    const text = el.querySelector('.tree-file__name').textContent.toLowerCase();
+    el.style.display = text.includes(q) ? '' : 'none';
+  });
+  allDirs.forEach((el) => {
+    const anyVisible = Array.from(el.querySelectorAll('.tree-file')).some((f) => f.style.display !== 'none');
+    if (anyVisible) el.classList.add('is-open');
+    else el.classList.remove('is-open');
+  });
+});
+
+$stage.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'copy';
+});
+$stage.addEventListener('drop', (e) => {
+  e.preventDefault();
+  const p = stagePointToCanvas(e.clientX, e.clientY);
+  const url = e.dataTransfer.getData('text/asset-url');
+  if (url) {
+    addImageFromUrl(url, { x: p.x, y: p.y });
+    return;
+  }
+  const files = e.dataTransfer.files;
+  if (files && files.length) {
+    Array.from(files).forEach((f, i) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => addLayer({
+          src: reader.result,
+          naturalWidth: img.naturalWidth,
+          naturalHeight: img.naturalHeight,
+          x: p.x + i * 16,
+          y: p.y + i * 16,
+        });
+        img.src = reader.result;
+      };
+      reader.readAsDataURL(f);
+    });
+  }
+});
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+async function renderToCanvas() {
+  const canvas = document.createElement('canvas');
+  canvas.width = state.canvasWidth;
+  canvas.height = state.canvasHeight;
+  const ctx = canvas.getContext('2d');
+  if (state.bgSrc) {
+    try {
+      const bg = await loadImage(state.bgSrc);
+      const ar = bg.naturalWidth / bg.naturalHeight;
+      const tar = canvas.width / canvas.height;
+      let sx, sy, sw, sh;
+      if (ar > tar) {
+        sh = bg.naturalHeight;
+        sw = sh * tar;
+        sx = (bg.naturalWidth - sw) / 2;
+        sy = 0;
+      } else {
+        sw = bg.naturalWidth;
+        sh = sw / tar;
+        sx = 0;
+        sy = (bg.naturalHeight - sh) / 2;
+      }
+      ctx.drawImage(bg, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
+    } catch (e) {
+      console.warn('failed to draw background', e);
+    }
+  } else {
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  for (const layer of state.layers) {
+    try {
+      const img = await loadImage(layer.src);
+      ctx.save();
+      ctx.translate(layer.x, layer.y);
+      ctx.rotate(layer.rotation * Math.PI / 180);
+      if (layer.flipped) ctx.scale(-1, 1);
+      ctx.drawImage(img, -layer.width / 2, -layer.height / 2, layer.width, layer.height);
+      ctx.restore();
+    } catch (e) {
+      console.warn('failed to draw layer', layer.id, e);
+    }
+  }
+  return canvas;
+}
+
+$exportBtn.addEventListener('click', async () => {
+  const c = await renderToCanvas();
+  const a = document.createElement('a');
+  a.download = `screenshot-${Date.now()}.png`;
+  a.href = c.toDataURL('image/png');
+  a.click();
+});
+
+$saveBtn.addEventListener('click', async () => {
+  const c = await renderToCanvas();
+  const name = prompt('保存ファイル名 (PNG)', `screenshot-${Date.now()}.png`);
+  if (!name) return;
+  const dataUrl = c.toDataURL('image/png');
+  const res = await fetch('/api/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, dataUrl }),
+  });
+  const json = await res.json();
+  if (json.error) alert('保存失敗: ' + json.error);
+  else alert('保存しました: ' + json.savedTo);
+});
+
+const $processBtn = document.getElementById('processBtn');
+const $processModal = document.getElementById('processModal');
+const $procFile = document.getElementById('procFile');
+const $procPreset = document.getElementById('procPreset');
+const $procTop = document.getElementById('procTop');
+const $procBottom = document.getElementById('procBottom');
+const $procLeft = document.getElementById('procLeft');
+const $procRight = document.getElementById('procRight');
+const $procRadius = document.getElementById('procRadius');
+const $procCanvas = document.getElementById('procCanvas');
+const $procMeta = document.getElementById('procMeta');
+const $procAddLayer = document.getElementById('procAddLayer');
+const $procDownload = document.getElementById('procDownload');
+const $procSaveServer = document.getElementById('procSaveServer');
+
+const procState = { image: null, fileName: '' };
+
+function guessPreset(image) {
+  if (!image) return null;
+  const w = image.naturalWidth;
+  const h = image.naturalHeight;
+  const aspect = h / w;
+  if (aspect > 2.0 && w >= 1100 && w <= 1400) {
+    return { top: 180, radius: 60, label: 'iPhone Pro 3x' };
+  }
+  if (aspect > 2.0 && w >= 1000 && w <= 1180) {
+    return { top: 156, radius: 56, label: 'iPhone 3x' };
+  }
+  if (aspect > 1.9 && w <= 850) {
+    return { top: 88, radius: 36, label: 'iPhone 2x' };
+  }
+  if (aspect < 1.6) {
+    return { top: 80, radius: 40, label: 'タブレット想定' };
+  }
+  return { top: Math.round(h * 0.06), radius: Math.round(w * 0.04), label: 'カスタム概算' };
+}
+
+function applyPresetToFields(preset) {
+  if (!preset) return;
+  $procTop.value = preset.top ?? 0;
+  $procBottom.value = preset.bottom ?? 0;
+  $procLeft.value = preset.left ?? 0;
+  $procRight.value = preset.right ?? 0;
+  $procRadius.value = preset.radius ?? 0;
+}
+
+function presetByKey(key, image) {
+  if (key === 'auto') return guessPreset(image);
+  if (key === 'sim-150-40-100') return { top: 150, bottom: 40, radius: 100, label: 'シミュレータ' };
+  if (key === 'iphone-island') return { top: 180, radius: 60, label: 'Dynamic Island 3x' };
+  if (key === 'iphone-notch') return { top: 132, radius: 56, label: 'ノッチ 3x' };
+  if (key === 'iphone-classic') return { top: 40, radius: 0, label: 'Touch ID 2x' };
+  return null;
+}
+
+function pathRoundedRect(ctx, x, y, w, h, r) {
+  const rr = Math.max(0, Math.min(r, w / 2, h / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.lineTo(x + w - rr, y);
+  ctx.arcTo(x + w, y, x + w, y + rr, rr);
+  ctx.lineTo(x + w, y + h - rr);
+  ctx.arcTo(x + w, y + h, x + w - rr, y + h, rr);
+  ctx.lineTo(x + rr, y + h);
+  ctx.arcTo(x, y + h, x, y + h - rr, rr);
+  ctx.lineTo(x, y + rr);
+  ctx.arcTo(x, y, x + rr, y, rr);
+  ctx.closePath();
+}
+
+function processScreenshot() {
+  const img = procState.image;
+  if (!img) return null;
+  const top = Math.max(0, Number($procTop.value) || 0);
+  const bottom = Math.max(0, Number($procBottom.value) || 0);
+  const left = Math.max(0, Number($procLeft.value) || 0);
+  const right = Math.max(0, Number($procRight.value) || 0);
+  const radius = Math.max(0, Number($procRadius.value) || 0);
+  const sw = Math.max(1, img.naturalWidth - left - right);
+  const sh = Math.max(1, img.naturalHeight - top - bottom);
+  const canvas = document.createElement('canvas');
+  canvas.width = sw;
+  canvas.height = sh;
+  const ctx = canvas.getContext('2d');
+  ctx.save();
+  pathRoundedRect(ctx, 0, 0, sw, sh, radius);
+  ctx.clip();
+  ctx.drawImage(img, left, top, sw, sh, 0, 0, sw, sh);
+  ctx.restore();
+  return canvas;
+}
+
+function updateProcPreview() {
+  if (!procState.image) {
+    const ctx = $procCanvas.getContext('2d');
+    $procCanvas.width = 1;
+    $procCanvas.height = 1;
+    ctx.clearRect(0, 0, 1, 1);
+    return;
+  }
+  const out = processScreenshot();
+  $procCanvas.width = out.width;
+  $procCanvas.height = out.height;
+  $procCanvas.getContext('2d').drawImage(out, 0, 0);
+  $procMeta.innerHTML = `元: ${procState.image.naturalWidth}×${procState.image.naturalHeight}<br>出力: ${out.width}×${out.height}<br>ファイル: ${procState.fileName || '—'}`;
+}
+
+function openProcessModal() {
+  $processModal.hidden = false;
+}
+function closeProcessModal() {
+  $processModal.hidden = true;
+}
+
+$processBtn.addEventListener('click', openProcessModal);
+$processModal.addEventListener('click', (e) => {
+  if (e.target.dataset && e.target.dataset.close != null) closeProcessModal();
+});
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && !$processModal.hidden) closeProcessModal();
+});
+
+$procFile.addEventListener('change', () => {
+  const file = $procFile.files?.[0];
+  if (!file) return;
+  procState.fileName = file.name;
+  const reader = new FileReader();
+  reader.onload = () => {
+    const img = new Image();
+    img.onload = () => {
+      procState.image = img;
+      const preset = presetByKey($procPreset.value, img);
+      applyPresetToFields(preset || guessPreset(img));
+      updateProcPreview();
+      $procAddLayer.disabled = false;
+      $procDownload.disabled = false;
+      $procSaveServer.disabled = false;
+    };
+    img.src = reader.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+$procPreset.addEventListener('change', () => {
+  if ($procPreset.value === 'custom') return;
+  const preset = presetByKey($procPreset.value, procState.image);
+  if (preset) applyPresetToFields(preset);
+  updateProcPreview();
+});
+
+[$procTop, $procBottom, $procLeft, $procRight, $procRadius].forEach((el) => {
+  el.addEventListener('input', () => {
+    $procPreset.value = 'custom';
+    updateProcPreview();
+  });
+});
+
+$procAddLayer.addEventListener('click', () => {
+  const out = processScreenshot();
+  if (!out) return;
+  const dataUrl = out.toDataURL('image/png');
+  addImageFromUrl(dataUrl, { x: state.canvasWidth / 2, y: state.canvasHeight / 2 });
+  closeProcessModal();
+});
+
+$procDownload.addEventListener('click', () => {
+  const out = processScreenshot();
+  if (!out) return;
+  const a = document.createElement('a');
+  const base = (procState.fileName || `screenshot-${Date.now()}.png`).replace(/\.[^.]+$/, '');
+  a.download = `${base}-cropped.png`;
+  a.href = out.toDataURL('image/png');
+  a.click();
+});
+
+$procSaveServer.addEventListener('click', async () => {
+  const out = processScreenshot();
+  if (!out) return;
+  const base = (procState.fileName || `screenshot-${Date.now()}.png`).replace(/\.[^.]+$/, '');
+  const name = prompt('保存ファイル名 (PNG)', `${base}-cropped.png`);
+  if (!name) return;
+  const dataUrl = out.toDataURL('image/png');
+  const res = await fetch('/api/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, dataUrl }),
+  });
+  const json = await res.json();
+  if (json.error) alert('保存失敗: ' + json.error);
+  else alert('保存しました: ' + json.savedTo);
+});
+
+applyCanvasSize();
+loadBackgrounds().catch((e) => console.warn('backgrounds load failed', e));
+loadAssetTree().catch((e) => console.warn('assets load failed', e));

--- a/tools/screenshot-maker/public/index.html
+++ b/tools/screenshot-maker/public/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280, initial-scale=1" />
+<title>ストア用スクリーンショット メーカー</title>
+<link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+<header class="topbar">
+  <div class="topbar__left">
+    <strong>Store Screenshot Maker</strong>
+    <span class="topbar__hint">画像をクリック / ドラッグで配置 → ハンドルで拡縮・回転</span>
+  </div>
+  <div class="topbar__right">
+    <label class="btn">
+      背景を読み込む
+      <input id="bgUpload" type="file" accept="image/*" hidden />
+    </label>
+    <select id="bgPreset" title="プロジェクト直下の画像から背景を選ぶ">
+      <option value="">— 背景プリセット —</option>
+    </select>
+    <label class="btn">
+      PC画像を追加
+      <input id="localUpload" type="file" accept="image/*" multiple hidden />
+    </label>
+    <button id="processBtn" class="btn" title="スクショの上下カット＋角丸加工">スクショ加工</button>
+    <button id="resetBtn" class="btn btn--ghost" title="配置を全てリセット">リセット</button>
+    <button id="exportBtn" class="btn btn--primary">PNG書き出し</button>
+    <button id="saveBtn" class="btn btn--primary" title="output/ ディレクトリに保存">サーバ保存</button>
+  </div>
+</header>
+
+<div id="processModal" class="modal" hidden>
+  <div class="modal__backdrop" data-close></div>
+  <div class="modal__panel">
+    <header class="modal__header">
+      <strong>スクリーンショット加工</strong>
+      <button class="modal__close btn btn--ghost" data-close aria-label="閉じる">×</button>
+    </header>
+    <div class="modal__body">
+      <div class="proc-controls">
+        <label class="btn">
+          画像を選択
+          <input id="procFile" type="file" accept="image/*" hidden />
+        </label>
+        <select id="procPreset" title="デバイス別カットプリセット">
+          <option value="auto">プリセット: 自動 (iPhone ステータスバー)</option>
+          <option value="sim-150-40-100">シミュレータ (上150/下40/角丸100)</option>
+          <option value="iphone-island">iPhone (Dynamic Island, 3x)</option>
+          <option value="iphone-notch">iPhone (ノッチ, 3x)</option>
+          <option value="iphone-classic">iPhone (Touch ID, 2x)</option>
+          <option value="custom">手動指定</option>
+        </select>
+        <label class="proc-field">
+          <span>上カット (px)</span>
+          <input id="procTop" type="number" value="180" min="0" />
+        </label>
+        <label class="proc-field">
+          <span>下カット (px)</span>
+          <input id="procBottom" type="number" value="0" min="0" />
+        </label>
+        <label class="proc-field">
+          <span>左カット (px)</span>
+          <input id="procLeft" type="number" value="0" min="0" />
+        </label>
+        <label class="proc-field">
+          <span>右カット (px)</span>
+          <input id="procRight" type="number" value="0" min="0" />
+        </label>
+        <label class="proc-field">
+          <span>角丸 (px)</span>
+          <input id="procRadius" type="number" value="60" min="0" />
+        </label>
+        <div class="proc-meta" id="procMeta">画像未選択</div>
+      </div>
+      <div class="proc-preview">
+        <canvas id="procCanvas"></canvas>
+      </div>
+    </div>
+    <footer class="modal__footer">
+      <button id="procAddLayer" class="btn btn--primary" disabled>レイヤーに追加</button>
+      <button id="procDownload" class="btn" disabled>PNGダウンロード</button>
+      <button id="procSaveServer" class="btn" disabled title="output/ に保存">サーバ保存</button>
+    </footer>
+  </div>
+</div>
+
+<main class="layout">
+  <aside class="sidebar">
+    <div class="sidebar__search">
+      <input id="assetSearch" type="search" placeholder="アセットを検索 (例: goblin)" />
+    </div>
+    <div id="assetTree" class="asset-tree"></div>
+  </aside>
+
+  <section class="stage-wrap">
+    <div class="stage-toolbar">
+      <span>キャンバスサイズ:</span>
+      <input id="canvasW" type="number" value="850" min="100" max="4000" />
+      <span>×</span>
+      <input id="canvasH" type="number" value="1850" min="100" max="4000" />
+      <button id="applySize" class="btn btn--sm">適用</button>
+      <span class="divider"></span>
+      <span>表示倍率:</span>
+      <input id="zoom" type="range" min="20" max="120" value="50" />
+      <span id="zoomLabel">50%</span>
+      <span class="divider"></span>
+      <span id="selectedInfo" class="selected-info">未選択</span>
+    </div>
+    <div class="stage-scroll" id="stageScroll">
+      <div id="stage" class="stage">
+        <img id="bgImage" class="stage__bg" alt="background" />
+        <div id="layers" class="stage__layers"></div>
+      </div>
+    </div>
+    <div class="status-bar">
+      <span>選択中の操作: 移動=ドラッグ / 拡縮=四隅ハンドル(縦横比固定・Shiftで解除) / 単軸=四辺ハンドル / 回転=上の◯ハンドル / 削除=Delete / 複製=Ctrl+D / 前面=]/背面=[ / 反転=H</span>
+    </div>
+  </section>
+</main>
+
+<script src="/app.js"></script>
+</body>
+</html>

--- a/tools/screenshot-maker/public/style.css
+++ b/tools/screenshot-maker/public/style.css
@@ -1,0 +1,329 @@
+*, *::before, *::after { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic", sans-serif;
+  background: #1f1f24;
+  color: #e8e8ec;
+  overflow: hidden;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: #15151a;
+  border-bottom: 1px solid #2a2a32;
+  gap: 12px;
+  height: 52px;
+}
+.topbar__left { display: flex; align-items: baseline; gap: 12px; }
+.topbar__hint { color: #8a8a96; font-size: 12px; }
+.topbar__right { display: flex; align-items: center; gap: 8px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid #3a3a44;
+  background: #25252d;
+  color: #e8e8ec;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  user-select: none;
+}
+.btn:hover { background: #2f2f38; }
+.btn--primary { background: #3464d6; border-color: #3464d6; }
+.btn--primary:hover { background: #2b58c4; }
+.btn--ghost { background: transparent; }
+.btn--sm { padding: 4px 8px; font-size: 12px; }
+
+select, input[type="number"], input[type="search"] {
+  background: #1c1c22;
+  color: #e8e8ec;
+  border: 1px solid #3a3a44;
+  border-radius: 6px;
+  padding: 5px 8px;
+  font-size: 13px;
+}
+input[type="number"] { width: 64px; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  height: calc(100% - 52px);
+}
+
+.sidebar {
+  background: #181820;
+  border-right: 1px solid #2a2a32;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.sidebar__search { padding: 8px; border-bottom: 1px solid #2a2a32; }
+.sidebar__search input { width: 100%; }
+.asset-tree {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+  font-size: 13px;
+}
+.tree-node { user-select: none; }
+.tree-dir__label {
+  padding: 4px 10px;
+  cursor: pointer;
+  color: #c0c0cc;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.tree-dir__label:hover { background: #22222b; }
+.tree-dir__chev { display: inline-block; width: 10px; transition: transform 0.15s; }
+.tree-dir.is-open > .tree-dir__label > .tree-dir__chev { transform: rotate(90deg); }
+.tree-dir__children { display: none; padding-left: 14px; }
+.tree-dir.is-open > .tree-dir__children { display: block; }
+
+.tree-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 10px 3px 24px;
+  cursor: grab;
+  color: #d4d4dc;
+  border-radius: 4px;
+}
+.tree-file:hover { background: #2a2a34; color: #fff; }
+.tree-file:active { cursor: grabbing; }
+.tree-file__thumb {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  background: #0e0e12;
+  border: 1px solid #2a2a32;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.tree-file__name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stage-wrap {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #0c0c10;
+}
+.stage-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: #15151a;
+  border-bottom: 1px solid #2a2a32;
+  font-size: 13px;
+  color: #b8b8c4;
+}
+.stage-toolbar .divider {
+  width: 1px;
+  height: 18px;
+  background: #2a2a32;
+  margin: 0 4px;
+}
+.selected-info { margin-left: auto; color: #8a8a96; font-size: 12px; }
+
+.stage-scroll {
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 30px;
+  background:
+    linear-gradient(45deg, #16161c 25%, transparent 25%),
+    linear-gradient(-45deg, #16161c 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #16161c 75%),
+    linear-gradient(-45deg, transparent 75%, #16161c 75%);
+  background-size: 24px 24px;
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0;
+  background-color: #0c0c10;
+}
+
+.stage {
+  position: relative;
+  background: #fff;
+  box-shadow: 0 16px 60px rgba(0,0,0,0.6);
+  transform-origin: top center;
+  flex-shrink: 0;
+}
+.stage__bg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+  pointer-events: none;
+  user-select: none;
+}
+.stage__layers {
+  position: absolute;
+  inset: 0;
+}
+
+.layer {
+  position: absolute;
+  cursor: move;
+  user-select: none;
+}
+.layer img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+.layer.is-selected { outline: 2px solid #3da4ff; outline-offset: 0; }
+
+.handle {
+  position: absolute;
+  background: #fff;
+  border: 2px solid #3da4ff;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+  z-index: 2;
+}
+.handle.is-rotate {
+  background: #3da4ff;
+  border-color: #fff;
+}
+.handle.nw { left: 0; top: 0; cursor: nwse-resize; }
+.handle.ne { left: 100%; top: 0; cursor: nesw-resize; }
+.handle.sw { left: 0; top: 100%; cursor: nesw-resize; }
+.handle.se { left: 100%; top: 100%; cursor: nwse-resize; }
+.handle.n  { left: 50%; top: 0; cursor: ns-resize; }
+.handle.s  { left: 50%; top: 100%; cursor: ns-resize; }
+.handle.w  { left: 0; top: 50%; cursor: ew-resize; }
+.handle.e  { left: 100%; top: 50%; cursor: ew-resize; }
+.handle.is-rotate { left: 50%; top: -28px; cursor: grab; }
+.handle.is-rotate:active { cursor: grabbing; }
+.rotate-line {
+  position: absolute;
+  left: 50%;
+  top: -28px;
+  width: 0;
+  height: 28px;
+  border-left: 1px dashed #3da4ff;
+  pointer-events: none;
+}
+
+.status-bar {
+  padding: 6px 14px;
+  background: #15151a;
+  border-top: 1px solid #2a2a32;
+  font-size: 11px;
+  color: #8a8a96;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal[hidden] { display: none; }
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+.modal__panel {
+  position: relative;
+  width: min(960px, 92vw);
+  max-height: 86vh;
+  background: #1c1c22;
+  border: 1px solid #2a2a32;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2a2a32;
+}
+.modal__close { font-size: 18px; padding: 2px 10px; }
+.modal__body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  padding: 16px;
+  overflow: auto;
+}
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid #2a2a32;
+  background: #181820;
+}
+.proc-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.proc-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  color: #b8b8c4;
+}
+.proc-field input { width: 88px; }
+.proc-meta {
+  font-size: 11px;
+  color: #8a8a96;
+  margin-top: 4px;
+  line-height: 1.5;
+}
+.proc-preview {
+  background:
+    linear-gradient(45deg, #16161c 25%, transparent 25%),
+    linear-gradient(-45deg, #16161c 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #16161c 75%),
+    linear-gradient(-45deg, transparent 75%, #16161c 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+  background-color: #0c0c10;
+  border: 1px solid #2a2a32;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  min-height: 360px;
+  overflow: auto;
+}
+#procCanvas {
+  max-width: 100%;
+  max-height: 70vh;
+  display: block;
+  filter: drop-shadow(0 8px 24px rgba(0,0,0,0.45));
+}

--- a/tools/screenshot-maker/server.js
+++ b/tools/screenshot-maker/server.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const APP_ROOT = path.join(REPO_ROOT, 'goblin_native');
+const ASSETS_DIR = path.join(APP_ROOT, 'assets');
+const PROJECT_ROOT = REPO_ROOT;
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const OUTPUT_DIR = path.join(__dirname, 'output');
+
+const PORT = Number(process.env.PORT) || 4321;
+const HOST = '127.0.0.1';
+
+const IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg']);
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+};
+
+function safeJoin(root, rel) {
+  const resolved = path.resolve(root, '.' + path.sep + rel);
+  if (!resolved.startsWith(root)) return null;
+  return resolved;
+}
+
+function listAssetsTree(dir, relBase = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  const dirs = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const rel = relBase ? `${relBase}/${entry.name}` : entry.name;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      dirs.push({ type: 'dir', name: entry.name, path: rel, children: listAssetsTree(abs, rel) });
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (IMAGE_EXT.has(ext)) {
+        files.push({ type: 'file', name: entry.name, path: rel });
+      }
+    }
+  }
+  dirs.sort((a, b) => a.name.localeCompare(b.name));
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return [...dirs, ...files];
+}
+
+function listProjectBackgrounds() {
+  const sources = [
+    { dir: REPO_ROOT, prefix: '' },
+    { dir: APP_ROOT, prefix: 'goblin_native/' },
+  ];
+  const result = [];
+  for (const { dir, prefix } of sources) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (_) { continue; }
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!IMAGE_EXT.has(ext)) continue;
+      const label = prefix ? `${entry.name}  (${prefix.replace(/\/$/, '')})` : entry.name;
+      result.push({ name: label, path: prefix + entry.name });
+    }
+  }
+  result.sort((a, b) => a.name.localeCompare(b.name));
+  return result;
+}
+
+function sendJson(res, status, body) {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+function sendFile(res, filePath, contentType) {
+  fs.stat(filePath, (err, stat) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = contentType || MIME[ext] || 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': type,
+      'Content-Length': stat.size,
+      'Cache-Control': 'no-cache',
+    });
+    fs.createReadStream(filePath).pipe(res);
+  });
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    const limit = 50 * 1024 * 1024;
+    req.on('data', (c) => {
+      total += c.length;
+      if (total > limit) {
+        reject(new Error('payload too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const parsed = url.parse(req.url, true);
+  const pathname = decodeURIComponent(parsed.pathname || '/');
+
+  try {
+    if (pathname === '/api/assets') {
+      const tree = listAssetsTree(ASSETS_DIR);
+      sendJson(res, 200, { tree });
+      return;
+    }
+    if (pathname === '/api/backgrounds') {
+      const list = listProjectBackgrounds();
+      sendJson(res, 200, { list });
+      return;
+    }
+    if (pathname === '/api/save' && req.method === 'POST') {
+      const body = await readBody(req);
+      let json;
+      try { json = JSON.parse(body.toString('utf8')); } catch (_) {
+        sendJson(res, 400, { error: 'invalid json' });
+        return;
+      }
+      const dataUrl = json.dataUrl;
+      const name = (json.name || `screenshot-${Date.now()}.png`).replace(/[^a-zA-Z0-9._-]/g, '_');
+      if (!dataUrl || !/^data:image\/png;base64,/.test(dataUrl)) {
+        sendJson(res, 400, { error: 'invalid dataUrl' });
+        return;
+      }
+      const b64 = dataUrl.replace(/^data:image\/png;base64,/, '');
+      ensureDir(OUTPUT_DIR);
+      const outPath = path.join(OUTPUT_DIR, name);
+      fs.writeFileSync(outPath, Buffer.from(b64, 'base64'));
+      sendJson(res, 200, { savedTo: path.relative(PROJECT_ROOT, outPath) });
+      return;
+    }
+
+    if (pathname.startsWith('/assets/')) {
+      const rel = pathname.slice('/assets/'.length);
+      const abs = safeJoin(ASSETS_DIR, rel);
+      if (!abs) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
+      sendFile(res, abs);
+      return;
+    }
+    if (pathname.startsWith('/project/')) {
+      const rel = pathname.slice('/project/'.length);
+      const abs = safeJoin(PROJECT_ROOT, rel);
+      if (!abs) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+      }
+      sendFile(res, abs);
+      return;
+    }
+
+    let rel = pathname === '/' ? '/index.html' : pathname;
+    const abs = safeJoin(PUBLIC_DIR, rel);
+    if (!abs) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+    if (fs.existsSync(abs) && fs.statSync(abs).isFile()) {
+      sendFile(res, abs);
+      return;
+    }
+    res.writeHead(404);
+    res.end('Not Found');
+  } catch (err) {
+    console.error(err);
+    res.writeHead(500);
+    res.end('Internal Server Error');
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`screenshot-maker: http://${HOST}:${PORT}`);
+  console.log(`  project root: ${PROJECT_ROOT}`);
+  console.log(`  assets dir:   ${ASSETS_DIR}`);
+  console.log(`  output dir:   ${OUTPUT_DIR}`);
+});


### PR DESCRIPTION
## Summary
- `tools/screenshot-maker/` にブラウザ製のストア用スクリーンショット作成ツールを追加
- 背景画像（プロジェクト直下の画像 / PC画像）に `goblin_native/assets/` 内の画像をスタンプ配置可能
- 配置レイヤーは移動・回転・拡縮（四隅は縦横比固定、四辺は単軸、Shiftで挙動切替）に対応
- シミュレータ/実機スクショの上下カット＋角丸加工パネルを内蔵（プリセット & 手動調整）
- 外部依存なし（Node 組み込み `http` のみ）。`node tools/screenshot-maker/server.js` で起動

## 起動方法
\`\`\`bash
node tools/screenshot-maker/server.js
# → http://127.0.0.1:4321
\`\`\`

## Test plan
- [ ] サーバが起動する
- [ ] 背景プリセットから画像を選び、キャンバスサイズが自動追従する
- [ ] アセットツリーから画像をクリック / ドラッグで配置できる
- [ ] レイヤーの移動・回転・拡縮（縦横比固定 / Shiftで自由変形）が動作する
- [ ] 「スクショ加工」モーダルで上下カット＋角丸プレビューが反映される
- [ ] 「PNG書き出し」「サーバ保存」でファイルが出力される

🤖 Generated with [Claude Code](https://claude.com/claude-code)