### PR TITLE
feat(factor): ラタトスク因子を追加し金のドングリ討伐で獲得可能に

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -35,8 +35,13 @@ import { getEffectiveStats } from '../../shared/utils/goblinStats'
 import { calculateEnemyExp } from '../../shared/utils/enemyExp'
 import { applyDungeonTierScalingToEnemy } from '../../shared/utils/enemyTierScaling'
 
-const GOLDEN_ACORN_CLEAR_ENCOUNTER_ID = 'golden_acorn_ratatoskr'
+export const GOLDEN_ACORN_CLEAR_ENCOUNTER_ID = 'golden_acorn_ratatoskr'
 const GOLDEN_ACORN_CLEAR_ENCOUNTER_EXP = 998
+export const GOLDEN_ACORN_CLEAR_FACTOR_DROPS = [{
+  factorId: 'ratatoskr',
+  probability: 0.015,
+  minDungeonTier: 3,
+} satisfies NonNullable<Enemy['factorDrops']>[number]]
 
 const GOLDEN_ACORN_CLEAR_ENCOUNTER: Enemy[][] = [[{
   id: GOLDEN_ACORN_CLEAR_ENCOUNTER_ID,
@@ -60,6 +65,7 @@ const GOLDEN_ACORN_CLEAR_ENCOUNTER: Enemy[][] = [[{
   evasion: 1000,
   exp: GOLDEN_ACORN_CLEAR_ENCOUNTER_EXP,
   gold: 998,
+  factorDrops: GOLDEN_ACORN_CLEAR_FACTOR_DROPS,
   skills: [
     {
       id: 'ratatoskr_magic_reduction_99',

--- a/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
+++ b/goblin_native/src/core/usecases/CompleteExpeditionUseCase.ts
@@ -12,8 +12,10 @@ import { GoblinEntity } from '../domain'
 import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../repositories'
 import type { IEquipmentRepository } from '../repositories/IEquipmentRepository'
 import type { LevelUpResult } from '../services/ExperienceSystem'
+import type { FactorDropConfig } from '../../shared/types/Factor'
 import { FactorService } from '../services/FactorService'
 import { captureDungeon } from '../services/BaseRankSystem'
+import { GOLDEN_ACORN_CLEAR_ENCOUNTER_ID, GOLDEN_ACORN_CLEAR_FACTOR_DROPS } from '../services/ExpeditionEngine'
 import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
 import { getDungeonTierFactorDropMultiplier } from '../../shared/types/DungeonTier'
 
@@ -151,10 +153,22 @@ export class CompleteExpeditionUseCase {
         !baseStateBefore.capturedDungeons.includes(replay.meta.areaId)
     }
 
-    if (!isAbort && bossEvent && bossEvent.combat.outcome === 'win') {
+    if (!isAbort) {
+      const allFactorDrops: FactorDropConfig[] = []
+
+      const ratatoskrEvent = replay.events.find(
+        (e): e is Extract<TimelineEvent, { type: 'battle' }> =>
+          e.type === 'battle' &&
+          e.enemy.id === GOLDEN_ACORN_CLEAR_ENCOUNTER_ID &&
+          e.combat.outcome === 'win'
+      )
+      if (ratatoskrEvent) {
+        allFactorDrops.push(...GOLDEN_ACORN_CLEAR_FACTOR_DROPS)
+      }
+
       const enemyDatabase = getEnemyDatabase(replay.meta.areaId)
 
-      if (enemyDatabase) {
+      if (bossEvent && bossEvent.combat.outcome === 'win' && enemyDatabase) {
         const bossPattern = enemyDatabase.patterns.find(p => p.isBoss)
         const bossEnemyIds = bossPattern?.enemies.flat() ?? [bossEvent.enemy.id]
         const enemiesWithFactorDrops = enemyDatabase.enemies.filter(
@@ -162,7 +176,7 @@ export class CompleteExpeditionUseCase {
         )
 
         if (enemiesWithFactorDrops.length > 0) {
-          const allFactorDrops = enemiesWithFactorDrops
+          allFactorDrops.push(...enemiesWithFactorDrops
             .flatMap(e => e.factorDrops!)
             .map(drop => {
               // チュートリアル: スライム洞窟初回クリア時はスライム因子を確定獲得
@@ -174,41 +188,47 @@ export class CompleteExpeditionUseCase {
                 return { ...drop, probability: 1 }
               }
               return drop
-            })
+            }))
+        }
+      } else if (bossEvent && bossEvent.combat.outcome === 'win' && !enemyDatabase) {
+        console.warn(`Enemy data not found for area: ${replay.meta.areaId}`)
+      }
 
-          const tierMultiplier = getDungeonTierFactorDropMultiplier(replay.meta.tier ?? 0)
+      if (allFactorDrops.length > 0) {
+        const tier = replay.meta.tier ?? 0
+        const tierAdjustedFactorDrops = allFactorDrops.map(drop => ({
+          ...drop,
+          probability: drop.probability * getDungeonTierFactorDropMultiplier(tier, drop.minDungeonTier ?? 0),
+        }))
 
-          for (const goblin of goblins) {
-            if (replay.summary.casualties.includes(goblin.id.toString())) {
-              continue
-            }
+        for (const goblin of goblins) {
+          if (replay.summary.casualties.includes(goblin.id.toString())) {
+            continue
+          }
 
-            const latest = latestGoblins.get(goblin.id)!
-            const factorDropBonusPercent = getFactorDropBonusPercentFromSkills(latest.skills)
-            const factorDropMultiplier = getFactorDropMultiplierFromSkills(latest.skills)
-            const probabilityMultiplier =
-              (1 + Math.max(0, factorDropBonusPercent) / 100) * factorDropMultiplier * tierMultiplier
-            const acquired = FactorService.rollFactorDrops(
-              latest,
-              allFactorDrops,
-              replay.meta.seed,
-              probabilityMultiplier
-            )
+          const latest = latestGoblins.get(goblin.id)!
+          const factorDropBonusPercent = getFactorDropBonusPercentFromSkills(latest.skills)
+          const factorDropMultiplier = getFactorDropMultiplierFromSkills(latest.skills)
+          const probabilityMultiplier =
+            (1 + Math.max(0, factorDropBonusPercent) / 100) * factorDropMultiplier
+          const acquired = FactorService.rollFactorDrops(
+            latest,
+            tierAdjustedFactorDrops,
+            replay.meta.seed,
+            probabilityMultiplier
+          )
 
-            if (acquired.length > 0) {
-              const withFactors = FactorService.addFactors(latest, acquired)
-              // 因子と実効ステータスだけをUPDATEし、レベルアップ等の他データを上書きしない
-              await this.goblinRepository.updateGoblinFactors(goblin.id, withFactors.factors!, withFactors.effectiveStats!)
-              factorAcquisitions.set(goblin.id, acquired)
+          if (acquired.length > 0) {
+            const withFactors = FactorService.addFactors(latest, acquired)
+            // 因子と実効ステータスだけをUPDATEし、レベルアップ等の他データを上書きしない
+            await this.goblinRepository.updateGoblinFactors(goblin.id, withFactors.factors!, withFactors.effectiveStats!)
+            factorAcquisitions.set(goblin.id, acquired)
 
-              if (!updatedGoblinIds.includes(goblin.id)) {
-                updatedGoblinIds.push(goblin.id)
-              }
+            if (!updatedGoblinIds.includes(goblin.id)) {
+              updatedGoblinIds.push(goblin.id)
             }
           }
         }
-      } else {
-        console.warn(`Enemy data not found for area: ${replay.meta.areaId}`)
       }
     }
 

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -1,8 +1,10 @@
 import { CompleteExpeditionUseCase } from '../CompleteExpeditionUseCase'
+import { GOLDEN_ACORN_CLEAR_ENCOUNTER_ID } from '../../services/ExpeditionEngine'
 import type { IGoblinRepository, IPartyRepository, IBaseStateRepository } from '../../repositories'
 import { getCharacterSkill } from '../../../shared/data/skillCatalog'
 import { getDefaultSkillsForRace } from '../../../shared/data/raceSkills'
 import { DEFAULT_PARTY_REWARD_MULTIPLIERS } from '../../../shared/types'
+import { getDungeonTierFactorDropMultiplier } from '../../../shared/types/DungeonTier'
 import type { Goblin, GoblinStats, Party, BaseState, ExpeditionReplay, TimelineEvent } from '../../../shared/types'
 
 // --- テストヘルパー ---
@@ -411,6 +413,75 @@ describe('CompleteExpeditionUseCase', () => {
         1,
         ['human'],
         expect.objectContaining({ hp: expect.any(Number) }),
+      )
+    })
+
+    it('上位Tier解禁因子は解禁Tierを1.5%起点として獲得判定される', async () => {
+      expect(0.015 * getDungeonTierFactorDropMultiplier(3, 3)).toBeCloseTo(0.015)
+      expect(0.015 * getDungeonTierFactorDropMultiplier(4, 3)).toBeCloseTo(0.025)
+      expect(0.015 * getDungeonTierFactorDropMultiplier(5, 3)).toBeCloseTo(0.035)
+      expect(getDungeonTierFactorDropMultiplier(2, 3)).toBe(0)
+
+      const party = createTestParty({ id: 1, memberIds: [1] })
+      const baseState = createTestBaseState({ capturedDungeons: ['slime_cave'] })
+      const events: TimelineEvent[] = [
+        { type: 'move_start', at: 0, floor: 1 },
+        createBossEvent('B_SLIME', 5, [-1], 30, 2),
+        {
+          type: 'battle',
+          at: 30,
+          floor: 2,
+          enemy: { id: GOLDEN_ACORN_CLEAR_ENCOUNTER_ID, name: 'ラタトスク', lvl: 10, count: 1, gold: 998 },
+          combat: { rounds: 1, outcome: 'win', allyHPDelta: [0], enemyDefeated: 1 },
+          xp: 998,
+        },
+        { type: 'return', at: 30, reason: 'completed' },
+      ]
+      const replayBase = {
+        meta: {
+          expeditionId: 'exp-1',
+          areaId: 'slime_cave',
+          areaName: 'スライムの洞窟',
+          floors: 2,
+          baseDurationSec: 30,
+          party: ['1'],
+          partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
+          returnPolicy: 'never' as const,
+          seed: 1971,
+        },
+        events,
+        summary: { success: true, maxFloorReached: 3, xpGained: 5, goldGained: 0, casualties: [] },
+      }
+
+      const tier2Goblin = createTestGoblin()
+      const tier2Usecase = new CompleteExpeditionUseCase(
+        createMockGoblinRepository([tier2Goblin]),
+        createMockPartyRepository([party]),
+        createMockBaseStateRepository(baseState),
+      )
+      const tier2Result = await tier2Usecase.execute(1, createTestReplay({
+        ...replayBase,
+        meta: { ...replayBase.meta, tier: 2 },
+      }))
+
+      const tier3Goblin = createTestGoblin()
+      const tier3GoblinRepo = createMockGoblinRepository([tier3Goblin])
+      const tier3Usecase = new CompleteExpeditionUseCase(
+        tier3GoblinRepo,
+        createMockPartyRepository([party]),
+        createMockBaseStateRepository(baseState),
+      )
+      const tier3Result = await tier3Usecase.execute(1, createTestReplay({
+        ...replayBase,
+        meta: { ...replayBase.meta, tier: 3 },
+      }))
+
+      expect(tier2Result.factorAcquisitions.get(1)).toBeUndefined()
+      expect(tier3Result.factorAcquisitions.get(1)).toEqual(['ratatoskr'])
+      expect(tier3GoblinRepo.updateGoblinFactors).toHaveBeenCalledWith(
+        1,
+        ['ratatoskr'],
+        expect.objectContaining({ accuracy: expect.any(Number) }),
       )
     })
 

--- a/goblin_native/src/shared/data/factors.ts
+++ b/goblin_native/src/shared/data/factors.ts
@@ -1,7 +1,18 @@
 import type { Factor } from '../types/Factor'
 import { goblinVariantDefinitions } from './goblinVariants'
 
-const standaloneFactorDatabase: Record<string, Factor> = {}
+const standaloneFactorDatabase: Record<string, Factor> = {
+  ratatoskr: {
+    id: 'ratatoskr',
+    name: 'ラタトスク因子',
+    description: 'ラタトスクの特性を宿した因子。命中精度と回避能力が増す。',
+    inheritProbability: 0.18,
+    effects: [
+      { type: 'stat_bonus', target: 'accuracy', value: 10 },
+      { type: 'stat_bonus', target: 'evasion', value: 10 },
+    ],
+  },
+}
 
 /**
  * 因子マスターデータ

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -625,6 +625,7 @@ const en = {
       elf: { name: 'Elf Factor', description: 'A factor infused with elf traits. Increases agility and spirit.' },
       lizardman: { name: 'Lizardman Factor', description: 'A factor infused with lizardman traits. Improves overall resistance and HP.' },
       troll: { name: 'Troll Factor', description: 'A factor infused with troll traits. Greatly increases HP and also raises defense.' },
+      ratatoskr: { name: 'Ratatoskr Factor', description: 'A factor infused with Ratatoskr traits. Increases accuracy and evasion.' },
     },
     equipment: equipmentEn,
     job: {

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -625,6 +625,7 @@ const ja = {
       elf: { name: 'エルフ因子', description: 'エルフの特性を宿した因子。敏捷性と精神力が増す。' },
       lizardman: { name: 'リザードマン因子', description: 'リザードマンの特性を宿した因子。全体的な耐性とHPが増す。' },
       troll: { name: 'トロル因子', description: 'トロルの特性を宿した因子。HPが大幅に増し、防御力も上がる。' },
+      ratatoskr: { name: 'ラタトスク因子', description: 'ラタトスクの特性を宿した因子。命中精度と回避能力が増す。' },
     },
     equipment: equipmentJa,
     job: {

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -616,6 +616,7 @@ const ko = {
       elf: { name: '엘프 인자', description: '엘프의 특성을 지닌 인자. 민첩성과 정신력이 증가합니다.' },
       lizardman: { name: '리자드맨 인자', description: '리자드맨의 특성을 지닌 인자. 전반적인 저항성과 HP가 증가합니다.' },
       troll: { name: '트롤 인자', description: '트롤의 특성을 지닌 인자. HP가 크게 증가하고 방어력도 상승합니다.' },
+      ratatoskr: { name: '라타토스크 인자', description: '라타토스크의 특성을 지닌 인자. 명중 정확도와 회피가 증가합니다.' },
     },
     equipment: equipmentKo,
     job: {

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -121,8 +121,16 @@ export const DUNGEON_TIER_FACTOR_DROP_RATE = [
 const BASE_FACTOR_DROP_RATE = DUNGEON_TIER_FACTOR_DROP_RATE[0]
 
 /** Tier に応じた因子ドロップ倍率（敵JSON の基準 1.5% に乗算する係数）を返す */
-export function getDungeonTierFactorDropMultiplier(tier: DungeonTier = 0): number {
-  const rate = DUNGEON_TIER_FACTOR_DROP_RATE[tier] ?? BASE_FACTOR_DROP_RATE
+export function getDungeonTierFactorDropMultiplier(tier: DungeonTier = 0, minTier: DungeonTier = 0): number {
+  if (tier < minTier) {
+    return 0
+  }
+
+  const rate =
+    minTier === 0
+      ? DUNGEON_TIER_FACTOR_DROP_RATE[tier] ?? BASE_FACTOR_DROP_RATE
+      : BASE_FACTOR_DROP_RATE + (tier - minTier) * 0.01
+
   return rate / BASE_FACTOR_DROP_RATE
 }
 

--- a/goblin_native/src/shared/types/Factor.ts
+++ b/goblin_native/src/shared/types/Factor.ts
@@ -1,4 +1,5 @@
 import type { GoblinRaceId } from './Race'
+import type { DungeonTier } from './DungeonTier'
 
 /**
  * 因子の基本定義
@@ -37,4 +38,5 @@ export interface FactorVariantConfig {
 export interface FactorDropConfig {
   factorId: string     // 獲得できる因子のID
   probability: number  // 獲得確率 (0.0 ~ 1.0)  例: 0.03 = 3%
+  minDungeonTier?: DungeonTier // 獲得可能になる最低ダンジョンTier。未指定は通常Tierから
 }

--- a/goblin_native/src/shared/utils/factorImages.ts
+++ b/goblin_native/src/shared/utils/factorImages.ts
@@ -34,6 +34,7 @@ const factorImages: Record<string, React.FC<SvgProps>> = {
   vampire: FactorVampire,
   dragon: FactorDragon,
   shadow: FactorWolf,
+  ratatoskr: FactorWolf,
 }
 
 // デフォルト画像（スライム）


### PR DESCRIPTION
## Summary
- ラタトスク因子（命中+10/回避+10）を新規追加し、i18n と画像マッピングを整備
- 金のドングリの「黄金の遭遇」勝利時に専用の因子ドロップ判定（基準1.5%、Tier3解禁）を実行
- `FactorDropConfig.minDungeonTier` を追加し、解禁Tierを起点として確率を増加させるロジックに `getDungeonTierFactorDropMultiplier` を拡張
- ボス勝利時の既存ドロップ処理とラタトスクの専用ドロップを統合し、Tier別の獲得テストを追加

## Test plan
- [ ] `npx tsc --noEmit` が通ること
- [ ] `npm test -- CompleteExpeditionUseCase` で追加テストが通ること
- [ ] Tier2 ではラタトスク因子が獲得不可、Tier3以上で獲得可能になることを確認
- [ ] 既存ボス因子ドロップが従来通り動作することを実機で確認