### PR TITLE
feat(battle): 攻撃対象の戦闘ログを列番号順に並び替え

### DIFF
--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -462,7 +462,7 @@ export class BattleSystem {
             actorMaxHP: unit.maxHP,
             isAlly: unit.isAlly,
             actionEffect: spellAction.effect ?? 'damage',
-            targets: [...targetDetails.values()],
+            targets: this.getSortedTargetDetails(targetDetails),
           })
           this.tryMagicSupportFollowUps(
             unit,
@@ -504,7 +504,7 @@ export class BattleSystem {
             actorMaxHP: unit.maxHP,
             isAlly: unit.isAlly,
             isCritical,
-            targets: [...targetDetails.values()],
+            targets: this.getSortedTargetDetails(targetDetails),
           })
           if (isCritical) {
             this.tryCriticalAttackFollowUps(
@@ -807,7 +807,7 @@ export class BattleSystem {
         isAlly: defender.isAlly,
         isCritical,
         actionEffect: 'damage',
-        targets: [...targetDetails.values()],
+        targets: this.getSortedTargetDetails(targetDetails),
       })
 
       this.tryPhysicalCounterAttacks(
@@ -873,7 +873,7 @@ export class BattleSystem {
         isAlly: supporter.isAlly,
         isCritical,
         actionEffect: 'damage',
-        targets: [...targetDetails.values()],
+        targets: this.getSortedTargetDetails(targetDetails),
       })
       this.tryPhysicalCounterAttacks(
         supporter,
@@ -942,7 +942,7 @@ export class BattleSystem {
         isAlly: supporter.isAlly,
         isCritical,
         actionEffect: 'damage',
-        targets: [...targetDetails.values()],
+        targets: this.getSortedTargetDetails(targetDetails),
       })
       this.tryPhysicalCounterAttacks(
         supporter,
@@ -1372,6 +1372,20 @@ export class BattleSystem {
     }
   }
 
+  private getSortedTargetDetails(
+    details: Map<string, AttackTargetDetail>,
+  ): AttackTargetDetail[] {
+    return [...details.values()]
+      .map((detail, index) => ({ detail, index }))
+      .sort((a, b) => {
+        if (a.detail.targetRow !== b.detail.targetRow) {
+          return a.detail.targetRow - b.detail.targetRow
+        }
+        return a.index - b.index
+      })
+      .map(({ detail }) => detail)
+  }
+
   private applyDamage(target: BattleUnit, damage: number): void {
     const nextHP = target.currentHP - damage
 
@@ -1466,7 +1480,7 @@ export class BattleSystem {
       actionEffect: 'heal',
       attackCount: targetDetails.size,
       hitCount: targetDetails.size,
-      targets: [...targetDetails.values()],
+      targets: this.getSortedTargetDetails(targetDetails),
     })
   }
 

--- a/goblin_native/src/core/services/__tests__/CombatStats.test.ts
+++ b/goblin_native/src/core/services/__tests__/CombatStats.test.ts
@@ -136,6 +136,45 @@ describe('getHitRateRandomModifier', () => {
   })
 })
 
+describe('BattleSystem — 戦闘ログ', () => {
+  it('攻撃対象の詳細を列番号の小さい順に並べる', () => {
+    const battle = new BattleSystem()
+    const details = new Map([
+      ['row3', {
+        targetId: 'row3',
+        targetName: '列3',
+        targetRow: 3,
+        totalDamage: 10,
+        hitCount: 1,
+        defeated: false,
+        targetHP: 90,
+      }],
+      ['row1', {
+        targetId: 'row1',
+        targetName: '列1',
+        targetRow: 1,
+        totalDamage: 20,
+        hitCount: 2,
+        defeated: false,
+        targetHP: 80,
+      }],
+      ['row2', {
+        targetId: 'row2',
+        targetName: '列2',
+        targetRow: 2,
+        totalDamage: 10,
+        hitCount: 1,
+        defeated: false,
+        targetHP: 90,
+      }],
+    ])
+
+    const sorted = (battle as any).getSortedTargetDetails(details)
+
+    expect(sorted.map((detail: { targetName: string }) => detail.targetName)).toEqual(['列1', '列2', '列3'])
+  })
+})
+
 // =========================================================================
 // GoblinBirthService — 新ステータスの生成
 // =========================================================================


### PR DESCRIPTION
## Summary
- 戦闘ログの `targets` を列番号 (`targetRow`) の昇順で並び替え、同じ列内では元の挿入順を維持
- 共通処理 `getSortedTargetDetails` を `BattleSystem` に追加し、攻撃・反撃・支援・回復など各種ログで利用
- 並び替えロジックを検証する単体テストを `CombatStats.test.ts` に追加

## Test plan
- [ ] `npx tsc --noEmit` で型チェックを通す
- [ ] `npm test -- CombatStats` でテストが通ることを確認
- [ ] 戦闘画面で複数列にまたがる攻撃ログ表示順が想定通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)