### PR TITLE
feat(expedition): 目標階層を選択可能にし帰還ポリシーを整理

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -347,7 +347,7 @@ export default function FormationScreen() {
 
   const handleBulkLaunch = useCallback(() => {
     const skippedReasons: string[] = []
-    const inputs: Array<{ party: Party; dungeon: Dungeon; returnPolicy: ExpeditionRequest['returnPolicy']; tier: DungeonTier }> = []
+    const inputs: Array<{ party: Party; dungeon: Dungeon; returnPolicy: ExpeditionRequest['returnPolicy']; targetFloor?: number | null; tier: DungeonTier }> = []
 
     for (const party of parties) {
       if ((party.status ?? 'idle') === 'expedition') {
@@ -371,6 +371,7 @@ export default function FormationScreen() {
         party,
         dungeon,
         returnPolicy: party.returnPolicy ?? 'never',
+        targetFloor: party.targetFloor ?? null,
         tier: party.dungeonTier ?? 0,
       })
     }

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -122,6 +122,7 @@ export default function ExpeditionPreparationScreen() {
   const [selectedReturnPolicy, setSelectedReturnPolicy] = useState<ReturnPolicy>(party?.returnPolicy ?? 'never')
   const [selectedTargetFloor, setSelectedTargetFloor] = useState<number | null>(party?.targetFloor ?? null)
   const [isDungeonModalVisible, setIsDungeonModalVisible] = useState(false)
+  const [isTargetFloorModalVisible, setIsTargetFloorModalVisible] = useState(false)
   const [isReturnPolicyModalVisible, setIsReturnPolicyModalVisible] = useState(false)
   const [isPartyNameModalVisible, setIsPartyNameModalVisible] = useState(false)
   const [editingPartyName, setEditingPartyName] = useState('')
@@ -226,8 +227,8 @@ export default function ExpeditionPreparationScreen() {
 
   const estimatedExplorationTime = useMemo(() => {
     if (!selectedDungeon) return null
-    return estimateExplorationTime(selectedDungeon, selectedReturnPolicy, 1, false, selectedTier)
-  }, [estimateExplorationTime, selectedDungeon, selectedReturnPolicy, selectedTier])
+    return estimateExplorationTime(selectedDungeon, selectedReturnPolicy, selectedTargetFloor, 1, false, selectedTier)
+  }, [estimateExplorationTime, selectedDungeon, selectedReturnPolicy, selectedTargetFloor, selectedTier])
 
   const handleEditParty = useCallback(() => {
     void advanceTutorial('select_party_member')
@@ -303,8 +304,14 @@ export default function ExpeditionPreparationScreen() {
     if (partyId) {
       void setDungeon(parseInt(partyId, 10), dungeon.id)
     }
+    if (selectedTargetFloor !== null && selectedTargetFloor > dungeon.floors) {
+      setSelectedTargetFloor(null)
+      if (partyId) {
+        void setTargetFloor(parseInt(partyId, 10), null)
+      }
+    }
     autoSelectTier(dungeon)
-  }, [partyId, setDungeon, autoSelectTier])
+  }, [partyId, selectedTargetFloor, setDungeon, setTargetFloor, autoSelectTier])
 
   const handleSelectTier = useCallback((tier: DungeonTier) => {
     setSelectedTier(tier)
@@ -319,6 +326,13 @@ export default function ExpeditionPreparationScreen() {
       void setReturnPolicy(parseInt(partyId, 10), policy)
     }
   }, [partyId, setReturnPolicy])
+
+  const handleSelectTargetFloor = useCallback((floor: number | null) => {
+    setSelectedTargetFloor(floor)
+    if (partyId) {
+      void setTargetFloor(parseInt(partyId, 10), floor)
+    }
+  }, [partyId, setTargetFloor])
 
   const handleStartExpedition = useCallback(() => {
     if (!selectedDungeonId) {
@@ -342,6 +356,7 @@ export default function ExpeditionPreparationScreen() {
           party,
           dungeon: selectedDungeon,
           returnPolicy: selectedReturnPolicy,
+          targetFloor: selectedTargetFloor,
           tier: selectedTier,
           useGoldenAcorn,
         })
@@ -587,11 +602,15 @@ export default function ExpeditionPreparationScreen() {
             {/* 目標階数 */}
             <View style={styles.settingItem}>
               <Text style={styles.settingLabel}>{t('ui.formation.preparation.targetFloor')}</Text>
-              <View style={styles.settingValue}>
+              <TouchableOpacity
+                style={styles.settingValue}
+                onPress={() => setIsTargetFloorModalVisible(true)}
+                disabled={!selectedDungeon}
+              >
                 <Text style={styles.settingValueText}>
                   {selectedTargetFloor === null ? t('ui.formation.preparation.targetFloorDeepest') : t('ui.formation.preparation.targetFloorUntil', { floor: selectedTargetFloor })}
                 </Text>
-              </View>
+              </TouchableOpacity>
             </View>
 
             {/* 帰還条件 */}
@@ -721,6 +740,61 @@ export default function ExpeditionPreparationScreen() {
 
       <Modal
         transparent
+        visible={isTargetFloorModalVisible}
+        animationType="fade"
+        onRequestClose={() => setIsTargetFloorModalVisible(false)}
+      >
+        <Pressable style={styles.modalOverlay} onPress={() => setIsTargetFloorModalVisible(false)}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>{t('ui.formation.preparation.selectTargetFloorTitle')}</Text>
+            <ScrollView style={styles.modalList} contentContainerStyle={styles.modalListContent}>
+              <TouchableOpacity
+                style={[
+                  styles.modalOption,
+                  selectedTargetFloor === null && styles.modalOptionSelected,
+                ]}
+                onPress={() => {
+                  handleSelectTargetFloor(null)
+                  setIsTargetFloorModalVisible(false)
+                }}
+              >
+                <Text style={[
+                  styles.modalOptionTitle,
+                  selectedTargetFloor === null && styles.modalOptionTitleSelected,
+                ]}>
+                  {t('ui.formation.preparation.targetFloorDeepest')}
+                </Text>
+              </TouchableOpacity>
+              {selectedDungeon ? Array.from({ length: selectedDungeon.floors }, (_, index) => index + 1).map(floor => (
+                <TouchableOpacity
+                  key={floor}
+                  style={[
+                    styles.modalOption,
+                    selectedTargetFloor === floor && styles.modalOptionSelected,
+                  ]}
+                  onPress={() => {
+                    handleSelectTargetFloor(floor)
+                    setIsTargetFloorModalVisible(false)
+                  }}
+                >
+                  <Text style={[
+                    styles.modalOptionTitle,
+                    selectedTargetFloor === floor && styles.modalOptionTitleSelected,
+                  ]}>
+                    {t('ui.formation.preparation.targetFloorUntil', { floor })}
+                  </Text>
+                </TouchableOpacity>
+              )) : null}
+            </ScrollView>
+            <TouchableOpacity style={styles.modalCloseButton} onPress={() => setIsTargetFloorModalVisible(false)}>
+              <Text style={styles.modalCloseButtonText}>{t('ui.formation.common.close')}</Text>
+            </TouchableOpacity>
+          </View>
+        </Pressable>
+      </Modal>
+
+      <Modal
+        transparent
         visible={isReturnPolicyModalVisible}
         animationType="fade"
         onRequestClose={() => setIsReturnPolicyModalVisible(false)}
@@ -729,7 +803,7 @@ export default function ExpeditionPreparationScreen() {
           <View style={styles.modalContent}>
             <Text style={styles.modalTitle}>{t('ui.formation.preparation.selectReturnPolicyTitle')}</Text>
             <ScrollView style={styles.modalList} contentContainerStyle={styles.modalListContent}>
-              {(['never', 'until_floor2', 'until_floor3', 'if_any_ko', 'last_one'] as ReturnPolicy[]).map(policy => (
+              {(['if_any_ko', 'if_two_ko', 'last_one', 'never'] as ReturnPolicy[]).map(policy => (
                 <TouchableOpacity
                   key={policy}
                   style={[

--- a/goblin_native/docs/expedition_system.md
+++ b/goblin_native/docs/expedition_system.md
@@ -10,7 +10,7 @@
 
 ```
 【準備画面】
-  パーティ選択 → ダンジョン選択 → 帰還ポリシー選択
+  パーティ選択 → ダンジョン選択 → 目標階層選択 → 帰還ポリシー選択
   ↓
 【遠征開始】StartExpeditionUseCase
   パーティ状態確認 → ゴブリンロード → ExpeditionEngine.generateExpedition()
@@ -101,18 +101,24 @@ eventTime = max(floorStart + 1, baseTime + jitter)
 | `treasure` | 宝箱ドロップ時 | `items`: TreasureDrop[] |
 | `return` | 遠征終了時 | `reason`: 終了理由 |
 
+## 目標階層
+
+パーティ派遣時に、どの階層まで探索するかを帰還ポリシーとは別に選択する。
+未指定の場合は最下層まで探索する。
+
+- 目標階層が最下層未満の場合、対象階層のイベント処理後に `policy_return` として帰還する
+- 最下層を目標にした場合のみ、ボス戦と制圧判定へ進む
+
 ## 帰還ポリシー
 
-パーティ派遣時に6種類から選択。戦闘勝利後に判定される。
+パーティ派遣時に4種類から選択。戦闘勝利後に判定される。
 
 | ポリシー | 条件 | 判定内容 |
 |---------|------|---------|
+| `if_any_ko` | 1人でも死亡したら帰還 | `partyState.some(m => m.isKO)` |
+| `if_two_ko` | 2人が死亡したら帰還 | `partyState.filter(m => m.isKO).length >= 2` |
+| `last_one` | 最後の1人になったら帰還 | `aliveMembers <= 1` |
 | `never` | 帰還しない | ボスクリアまたは全滅まで続行 |
-| `until_floor2` | 2階到達で帰還 | `currentFloor >= 2` |
-| `until_floor3` | 3階到達で帰還 | `currentFloor >= 3` |
-| `if_any_ko` | 1体でも戦闘不能 | `partyState.some(m => m.isKO)` |
-| `if_two_ko` | 2体以上戦闘不能 | `partyState.filter(m => m.isKO).length >= 2` |
-| `last_one` | 生存1体以下 | `aliveMembers <= 1` |
 
 ### 帰還判定のタイミング
 
@@ -122,13 +128,12 @@ eventTime = max(floorStart + 1, baseTime + jitter)
 
 ### 推定探索時間への影響
 
-帰還ポリシーごとに時間倍率が異なる:
+目標階層に応じて `目標階層 / ダンジョン階層数` の倍率がかかる。
+さらに帰還ポリシーごとに時間倍率が異なる:
 
 | ポリシー | 倍率 |
 |---------|------|
 | never | ×1.0 |
-| until_floor2 | ×0.4 |
-| until_floor3 | ×0.6 |
 | if_any_ko | ×0.7 |
 | if_two_ko | ×0.75 |
 | last_one | ×0.9 |

--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -142,6 +142,7 @@ export class ExpeditionEngine {
       throw new Error(`Area not found: ${request.areaId} (mapped to: ${areaId})`)
     }
     const effectiveAreaLevel = getDungeonTierAreaLevel(area.areaLevel, tier)
+    const targetFloor = this.normalizeTargetFloor(request.targetFloor, area.floors)
 
     // 敵データを取得
     const enemyDatabase = getEnemyDatabase(areaId)
@@ -178,14 +179,14 @@ export class ExpeditionEngine {
     let loopCount = 0
     const MAX_LOOPS = 1000 // 安全装置
 
-    while (currentFloor <= area.floors && !shouldReturn) {
+    while (currentFloor <= targetFloor && !shouldReturn) {
       loopCount++
       if (loopCount > MAX_LOOPS) {
         console.error('ExpeditionEngine: Loop safety limit reached!')
         break
       }
       console.log(`Loop ${loopCount}: Floor ${currentFloor}/${area.floors}, shouldReturn: ${shouldReturn}`)
-      const floorEvents = this.generateFloorEvents(area, currentFloor, adjustedDuration)
+      const floorEvents = this.generateFloorEvents(area, currentFloor, adjustedDuration, targetFloor)
 
       console.log(`Floor ${currentFloor} events:`, floorEvents)
       for (const eventTime of floorEvents) {
@@ -316,6 +317,11 @@ export class ExpeditionEngine {
         }
       }
 
+      if (currentFloor >= targetFloor && targetFloor < area.floors && !shouldReturn) {
+        shouldReturn = true
+        returnReason = 'policy_return'
+      }
+
       // 階層移動
       if (currentFloor < area.floors && !shouldReturn) {
         currentFloor++
@@ -333,7 +339,7 @@ export class ExpeditionEngine {
     }
 
     // ボス戦（最上階到達時）
-    if (currentFloor > area.floors && !shouldReturn) {
+    if (targetFloor >= area.floors && currentFloor > area.floors && !shouldReturn) {
       const bossPatterns = enemyDatabase.patterns.filter(p => p.isBoss && p.floors.includes(area.floors))
 
       if (bossPatterns.length > 0) {
@@ -495,8 +501,8 @@ export class ExpeditionEngine {
     )
   }
 
-  private generateFloorEvents(area: AreaConfig, floor: number, totalDuration: number): number[] {
-    const floorDuration = totalDuration / area.floors
+  private generateFloorEvents(area: AreaConfig, floor: number, totalDuration: number, explorationFloors: number): number[] {
+    const floorDuration = totalDuration / explorationFloors
     const floorStart = (floor - 1) * floorDuration
     const events: number[] = []
 
@@ -668,7 +674,7 @@ export class ExpeditionEngine {
     })
   }
 
-  private checkReturnConditions(partyState: PartyState[], returnPolicy: ExpeditionRequest["returnPolicy"], currentFloor: number): { shouldReturn: boolean; reason: ExpeditionEndReason | null } {
+  private checkReturnConditions(partyState: PartyState[], returnPolicy: ExpeditionRequest["returnPolicy"], _currentFloor: number): { shouldReturn: boolean; reason: ExpeditionEndReason | null } {
     const aliveMembers = partyState.filter(member => !member.isKO).length
 
     switch (returnPolicy) {
@@ -687,22 +693,19 @@ export class ExpeditionEngine {
           return { shouldReturn: true, reason: "policy_return" }
         }
         break
-      case "until_floor2":
-        if (currentFloor >= 2) {
-          return { shouldReturn: true, reason: "policy_return" }
-        }
-        break
-      case "until_floor3":
-        if (currentFloor >= 3) {
-          return { shouldReturn: true, reason: "policy_return" }
-        }
-        break
       case "never":
         // 帰還条件なし - 最後まで探索（ボスクリアまたは全滅まで続行）
         break
     }
 
     return { shouldReturn: false, reason: null }
+  }
+
+  private normalizeTargetFloor(targetFloor: number | null | undefined, areaFloors: number): number {
+    if (typeof targetFloor !== 'number' || !Number.isFinite(targetFloor)) {
+      return areaFloors
+    }
+    return Math.max(1, Math.min(areaFloors, Math.floor(targetFloor)))
   }
 
   /**

--- a/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
+++ b/goblin_native/src/core/usecases/__tests__/CompleteExpeditionUseCase.test.ts
@@ -305,7 +305,7 @@ describe('CompleteExpeditionUseCase', () => {
           baseDurationSec: 30,
           party: ['1'],
           partyRewardMultipliers: DEFAULT_PARTY_REWARD_MULTIPLIERS,
-          returnPolicy: 'until_floor2',
+          returnPolicy: 'if_any_ko',
           seed: 12345,
         },
         events,

--- a/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLitePartyRepository.ts
@@ -25,6 +25,21 @@ interface PartyRow {
   updated_at: string
 }
 
+function normalizeReturnPolicy(value: string | null): ExpeditionRequest['returnPolicy'] | undefined {
+  switch (value) {
+    case 'if_any_ko':
+    case 'if_two_ko':
+    case 'last_one':
+    case 'never':
+      return value
+    case 'until_floor2':
+    case 'until_floor3':
+      return 'never'
+    default:
+      return undefined
+  }
+}
+
 export class SQLitePartyRepository implements IPartyRepository {
   private static instance: SQLitePartyRepository | null = null
 
@@ -131,7 +146,7 @@ export class SQLitePartyRepository implements IPartyRepository {
       dungeonId: row.dungeon_id ?? undefined,
       dungeonTier: (row.dungeon_tier ?? 0) as DungeonTier,
       targetFloor: row.target_floor ?? undefined,
-      returnPolicy: (row.return_policy as ExpeditionRequest['returnPolicy']) ?? undefined,
+      returnPolicy: normalizeReturnPolicy(row.return_policy),
       rewardMultipliers: normalizePartyRewardMultipliers({
         gold: row.gold_multiplier ?? undefined,
         rare: row.rare_multiplier ?? undefined,

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -50,6 +50,7 @@ interface StartExpeditionInput {
   party: Party
   dungeon: Dungeon
   returnPolicy: ExpeditionRequest['returnPolicy']
+  targetFloor?: number | null
   tier?: DungeonTier
   /** 出発時に金のドングリを消費するか */
   useGoldenAcorn?: boolean
@@ -200,6 +201,7 @@ export const useExpeditionFlow = ({
   const estimateExplorationTime = useCallback((
     dungeon: Dungeon,
     returnPolicy: ExpeditionRequest['returnPolicy'],
+    targetFloor: number | null = null,
     partyExpeditionTimeMultiplier: number = 1,
     goldenAcornUsed: boolean = false,
     tier: DungeonTier = 0,
@@ -218,17 +220,19 @@ export const useExpeditionFlow = ({
     )
     const multiplierMap: Record<ExpeditionRequest['returnPolicy'], number> = {
       never: 1.0,
-      until_floor2: 0.4,
-      until_floor3: 0.6,
       if_any_ko: 0.7,
       if_two_ko: 0.75,
       last_one: 0.9,
     }
     const multiplier = multiplierMap[returnPolicy] ?? 1.0
+    const normalizedTargetFloor = typeof targetFloor === 'number' && Number.isFinite(targetFloor)
+      ? Math.max(1, Math.min(dungeon.floors, Math.floor(targetFloor)))
+      : dungeon.floors
+    const floorMultiplier = normalizedTargetFloor / dungeon.floors
     const speedMultiplier = getSpeedMultiplier()
     const goldenAcornSpeed = goldenAcornUsed ? GOLDEN_ACORN_SPEED_MULTIPLIER : 1
     return Math.floor(
-      baseTime * multiplier * speedMultiplier * partyExpeditionTimeMultiplier * goldenAcornSpeed,
+      baseTime * floorMultiplier * multiplier * speedMultiplier * partyExpeditionTimeMultiplier * goldenAcornSpeed,
     )
   }, [instantDungeonExploration])
 
@@ -269,7 +273,7 @@ export const useExpeditionFlow = ({
   }, [])
 
   const startExpedition = useCallback(
-    async ({ party, dungeon, returnPolicy, tier, useGoldenAcorn = false }: StartExpeditionInput): Promise<StartExpeditionResult> => {
+    async ({ party, dungeon, returnPolicy, targetFloor = null, tier, useGoldenAcorn = false }: StartExpeditionInput): Promise<StartExpeditionResult> => {
       setIsProcessing(true)
       const debugInstantAcorn = useDebugSettingsStore.getState().instantGoldenAcorn
       let acornConsumed = false
@@ -294,6 +298,7 @@ export const useExpeditionFlow = ({
         const durationSec = isTutorialSlimeLaunch ? 3 : estimateExplorationTime(
           dungeon,
           returnPolicy,
+          targetFloor,
           partyExpeditionTimeMultiplier,
           useGoldenAcorn,
           tier ?? 0,
@@ -302,6 +307,7 @@ export const useExpeditionFlow = ({
           partyId: party.id.toString(),
           areaId: dungeon.id,
           tier,
+          targetFloor,
           returnPolicy,
           clientVersion: 'native',
           durationSec,
@@ -377,7 +383,7 @@ export const useExpeditionFlow = ({
       let acornsConsumed = 0
 
       try {
-        for (const { party, dungeon, returnPolicy, tier, useGoldenAcorn = false } of inputs) {
+        for (const { party, dungeon, returnPolicy, targetFloor = null, tier, useGoldenAcorn = false } of inputs) {
           let acornAppliedForThisInput = false
           if (useGoldenAcorn) {
             if (debugInstantAcorn) {
@@ -398,6 +404,7 @@ export const useExpeditionFlow = ({
           const durationSec = estimateExplorationTime(
             dungeon,
             returnPolicy,
+            targetFloor,
             partyExpeditionTimeMultiplier,
             acornAppliedForThisInput,
             tier ?? 0,
@@ -406,6 +413,7 @@ export const useExpeditionFlow = ({
             partyId: party.id.toString(),
             areaId: dungeon.id,
             tier,
+            targetFloor,
             returnPolicy,
             clientVersion: 'native',
             durationSec,

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -364,6 +364,7 @@ const en = {
         estimatedTime: 'Estimated Duration',
         seconds: '{{value}} sec',
         selectDungeonTitle: 'Select Destination',
+        selectTargetFloorTitle: 'Select Target Floor',
         noDungeon: 'No dungeons available',
         renameTitle: 'Rename Party',
         renamePlaceholder: 'Enter party name',
@@ -670,11 +671,9 @@ const en = {
     },
     returnPolicy: {
       never: 'Never Return',
-      until_floor2: 'Return on Floor 2',
-      until_floor3: 'Return on Floor 3',
       if_any_ko: 'Return if Anyone Falls',
       if_two_ko: 'Return if Two Fall',
-      last_one: 'Until the Last One',
+      last_one: 'Return When Only One Remains',
     },
     skill: {
       abnormal_marku: {

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -364,6 +364,7 @@ const ja = {
         estimatedTime: '推定探索時間',
         seconds: '{{value}}秒',
         selectDungeonTitle: '遠征先を選択',
+        selectTargetFloorTitle: '目標階層を選択',
         noDungeon: '選択できるダンジョンがありません',
         renameTitle: 'パーティ名を変更',
         renamePlaceholder: 'パーティ名を入力',
@@ -669,12 +670,10 @@ const ja = {
       damage_reduction: '被ダメ軽減',
     },
     returnPolicy: {
-      never: '帰還しない',
-      until_floor2: '2階で帰還',
-      until_floor3: '3階で帰還',
-      if_any_ko: '誰か倒れたら',
-      if_two_ko: '2人倒れたら',
-      last_one: '最後の1人まで',
+      never: '帰還しない（どんな状態でも進む）',
+      if_any_ko: '1人でも死亡したら帰還',
+      if_two_ko: '2人が死亡したら帰還',
+      last_one: '最後の1人になったら帰還',
     },
     skill: {
       abnormal_marku: {

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -359,6 +359,7 @@ const ko = {
         estimatedTime: '예상 탐색 시간',
         seconds: '{{value}}초',
         selectDungeonTitle: '원정지 선택',
+        selectTargetFloorTitle: '목표 층 선택',
         noDungeon: '선택 가능한 던전이 없습니다',
         renameTitle: '파티 이름 변경',
         renamePlaceholder: '파티 이름 입력',
@@ -661,11 +662,9 @@ const ko = {
     },
     returnPolicy: {
       never: '귀환 안 함',
-      until_floor2: '2층에서 귀환',
-      until_floor3: '3층에서 귀환',
       if_any_ko: '누군가 쓰러지면',
       if_two_ko: '2명 쓰러지면',
-      last_one: '마지막 1명까지',
+      last_one: '마지막 1명만 남으면 귀환',
     },
     skill: {
       abnormal_marku: {

--- a/goblin_native/src/shared/types/Expedition.ts
+++ b/goblin_native/src/shared/types/Expedition.ts
@@ -9,7 +9,8 @@ export interface ExpeditionRequest {
   partyId: string
   areaId: string
   tier?: DungeonTier
-  returnPolicy: "until_floor2" | "until_floor3" | "if_any_ko" | "if_two_ko" | "last_one" | "never"
+  targetFloor?: number | null
+  returnPolicy: "if_any_ko" | "if_two_ko" | "last_one" | "never"
   clientVersion: string
   durationSec?: number
 }

--- a/tools/studio/src/lib/runExpedition.ts
+++ b/tools/studio/src/lib/runExpedition.ts
@@ -222,10 +222,8 @@ export async function runSingleExpedition(
 }
 
 export const RETURN_POLICIES: { value: ReturnPolicy; label: string }[] = [
-  { value: 'never', label: '帰還しない（到達階まで進む）' },
-  { value: 'until_floor2', label: '2F到達で帰還' },
-  { value: 'until_floor3', label: '3F到達で帰還' },
-  { value: 'if_any_ko', label: '誰か気絶したら帰還' },
-  { value: 'if_two_ko', label: '2名気絶したら帰還' },
-  { value: 'last_one', label: '最後の一人になったら帰還' },
+  { value: 'if_any_ko', label: '1人でも死亡したら帰還' },
+  { value: 'if_two_ko', label: '2人が死亡したら帰還' },
+  { value: 'last_one', label: '最後の1人になったら帰還' },
+  { value: 'never', label: '帰還しない（どんな状態でも進む）' },
 ]


### PR DESCRIPTION
## Summary
- 遠征準備に目標階層 (targetFloor) の選択を追加し、ExpeditionRequest にフィールド追加
- 帰還ポリシーから `until_floor2` / `until_floor3` を削除し、`never` / `if_any_ko` / `if_two_ko` / `last_one` の4種に整理
- ExpeditionEngine と SQLitePartyRepository を新フィールドに対応させ、ja/en/ko の文言を更新

## Test plan
- [ ] `npx tsc --noEmit` 通過確認
- [ ] `npm test`（特に CompleteExpeditionUseCase）通過確認
- [ ] パーティ編成画面から目標階層と帰還ポリシーが期待どおり選択でき、遠征に反映されることを実機/シミュレータで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)