### PR TITLE
feat(i18n): 編成タブの表示名を「遠征」に変更

### DIFF
--- a/goblin_native/app/(tabs)/_layout.tsx
+++ b/goblin_native/app/(tabs)/_layout.tsx
@@ -34,6 +34,8 @@ const TabIcon = memo(function TabIcon({ Icon, color, size = 24 }: TabIconProps) 
   )
 })
 
+// Expo Router の内部ルート名は formation のまま維持する。
+// 表示上のタブ名は i18n 側で「遠征 / Quest」として扱う。
 // (tabs)/_layout.tsx 内の Tabs.Screen 定義順と一致させる
 const TAB_INDEX_BY_STEP: Partial<Record<TutorialStep, number>> = {
   // story=0, index=1, formation=2, base=3, encyclopedia=4, settings=5

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -17,7 +17,7 @@ const en = {
     tabs: {
       story: 'Story',
       goblinList: 'Goblins',
-      formation: 'Formation',
+      formation: 'Quest',
       base: 'Base',
       encyclopedia: 'Codex',
       settings: 'Settings',
@@ -528,9 +528,9 @@ const en = {
       banner: {
         readPrologue: 'Read "Awakening" to begin the story.',
         afterPrologue: 'Open the "List" tab to check on your awakened goblin.',
-        seeFirstGoblin: 'A goblin has awakened. Open the "Formation" tab to prepare for an expedition.',
-        viewFirstGoblin: 'Your awakened goblin "Marku". Continue to formation first.',
-        openFormationTab: 'Open the "Formation" tab to start preparing your expedition.',
+        seeFirstGoblin: 'A goblin has awakened. Open the "Quest" tab to prepare for an expedition.',
+        viewFirstGoblin: 'Your awakened goblin "Marku". Continue to the quest first.',
+        openFormationTab: 'Open the "Quest" tab to start preparing your expedition.',
         openFormation: 'Tap a party card to start preparing your expedition.',
         editParty: 'Tap "Edit Members" and add a goblin to your party.',
         selectPartyMember: 'Tap a goblin card to add them to the party.',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -17,7 +17,7 @@ const ja = {
     tabs: {
       story: '物語',
       goblinList: '一覧',
-      formation: '編成',
+      formation: '遠征',
       base: '拠点',
       encyclopedia: '図鑑',
       settings: '設定',
@@ -528,9 +528,9 @@ const ja = {
       banner: {
         readPrologue: 'まずは「目覚め」を読んで、物語を始めよう。',
         afterPrologue: '「一覧」タブを開いて、目覚めたゴブリンを確認しよう。',
-        seeFirstGoblin: '仲間のゴブリンが目覚めた。次は「編成」タブで遠征の準備をしよう。',
-        viewFirstGoblin: '目覚めたゴブリン「マルク」だ。まずは編成に進もう。',
-        openFormationTab: '「編成」タブを開いて、遠征の準備を始めよう。',
+        seeFirstGoblin: '仲間のゴブリンが目覚めた。次は「遠征」タブで準備をしよう。',
+        viewFirstGoblin: '目覚めたゴブリン「マルク」だ。まずは遠征に進もう。',
+        openFormationTab: '「遠征」タブを開いて、準備を始めよう。',
         openFormation: 'パーティのカードをタップして、遠征の準備を始めよう。',
         editParty: '「メンバー編成」を押して、ゴブリンをパーティに加えよう。',
         selectPartyMember: 'ゴブリンカードをタップして、パーティに加えよう。',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -16,7 +16,7 @@ const ko = {
     tabs: {
       story: '이야기',
       goblinList: '고블린',
-      formation: '편성',
+      formation: '원정',
       base: '거점',
       encyclopedia: '도감',
       settings: '설정',
@@ -519,9 +519,9 @@ const ko = {
       banner: {
         readPrologue: '먼저 "각성"을 읽고 이야기를 시작해 보세요.',
         afterPrologue: '"목록" 탭을 열어 깨어난 고블린을 확인하세요.',
-        seeFirstGoblin: '동료 고블린이 깨어났습니다. "편성" 탭에서 원정을 준비합시다.',
-        viewFirstGoblin: '깨어난 고블린 "마르쿠"입니다. 먼저 편성으로 이동하세요.',
-        openFormationTab: '"편성" 탭을 열어 원정 준비를 시작하세요.',
+        seeFirstGoblin: '동료 고블린이 깨어났습니다. "원정" 탭에서 준비합시다.',
+        viewFirstGoblin: '깨어난 고블린 "마르쿠"입니다. 먼저 원정으로 이동하세요.',
+        openFormationTab: '"원정" 탭을 열어 준비를 시작하세요.',
         openFormation: '파티 카드를 탭해 원정 준비를 시작하세요.',
         editParty: '"멤버 편성" 버튼을 눌러 파티에 고블린을 추가하세요.',
         selectPartyMember: '고블린 카드를 탭해 파티에 추가하세요.',


### PR DESCRIPTION
## Summary
- タブ「編成」の表示ラベルを「遠征」(EN: Quest / KO: 원정) に変更
- チュートリアルバナーの文言を新しいタブ名に合わせて更新
- Expo Router の内部ルート名は `formation` のまま維持し、表示は i18n で吸収する旨をコメントで明記

## Test plan
- [ ] アプリ起動時、タブバーに「遠征」と表示されること（ja/en/ko）
- [ ] チュートリアルのバナーが新しいタブ名で表示されること
- [ ] 遠征タブ（旧編成タブ）への遷移・遠征フローに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)