### PR TITLE
feat(formation): パーティ枠が1つの時に冒険チュートリアルを表示

### DIFF
--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -462,6 +462,8 @@ export default function FormationScreen() {
     })
   }, [dungeons, parties])
 
+  const showSinglePartyTutorial = maxPartyCount === 1
+
   if (partiesLoading || goblinsLoading || dungeonsLoading || baseLoading) {
     return (
       <SafeAreaView style={styles.loadingContainer} edges={['left', 'right', 'bottom']}>
@@ -537,6 +539,13 @@ export default function FormationScreen() {
         renderItem={renderPartyItem}
         contentContainerStyle={styles.contentContainer}
         ListHeaderComponent={<Text style={styles.prepTitle}>{t('ui.formation.index.prepTitle')}</Text>}
+        ListFooterComponent={showSinglePartyTutorial ? (
+          <View style={styles.singlePartyTutorial}>
+            <Text style={styles.singlePartyTutorialText}>{t('ui.formation.index.singlePartyTutorial.details')}</Text>
+            <Text style={styles.singlePartyTutorialText}>{t('ui.formation.index.singlePartyTutorial.hpRecovery')}</Text>
+            <Text style={styles.singlePartyTutorialText}>{t('ui.formation.index.singlePartyTutorial.injured')}</Text>
+          </View>
+        ) : null}
       />
     </SafeAreaView>
   )
@@ -557,6 +566,17 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#6B7280',
     marginBottom: 8,
+  },
+  singlePartyTutorial: {
+    marginTop: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    gap: 8,
+  },
+  singlePartyTutorialText: {
+    fontSize: 13,
+    lineHeight: 19,
+    color: '#6B7280',
   },
   loadingContainer: {
     flex: 1,

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -346,6 +346,11 @@ const en = {
         bulkLaunchConfirmTitle: 'Parties to Dispatch',
         bulkLaunchConfirmBody: '{{names}}',
         bulkLaunchGoldenAcornButton: '★ Use Golden Acorns',
+        singlePartyTutorial: {
+          details: 'Tap the > on the right to view adventure details.',
+          hpRecovery: 'Character HP automatically recovers when entering a dungeon.',
+          injured: 'Characters whose HP reaches 0 must recover at the base infirmary.',
+        },
       },
       preparation: {
         title: 'Expedition Prep',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -346,6 +346,11 @@ const ja = {
         bulkLaunchConfirmTitle: '出撃するパーティ',
         bulkLaunchConfirmBody: '{{names}}',
         bulkLaunchGoldenAcornButton: '★金のドングリを使用',
+        singlePartyTutorial: {
+          details: '右の > をタップすると冒険の詳細を見ることができます',
+          hpRecovery: 'キャラクターのHPはダンジョンに入る時に自動的に回復します。',
+          injured: 'HPが0になったキャラクターは拠点の治療所で回復させる必要があります。',
+        },
       },
       preparation: {
         title: '冒険準備',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -341,6 +341,11 @@ const ko = {
         bulkLaunchConfirmTitle: '출격할 파티',
         bulkLaunchConfirmBody: '{{names}}',
         bulkLaunchGoldenAcornButton: '★금 도토리 사용',
+        singlePartyTutorial: {
+          details: '오른쪽의 > 를 누르면 모험 상세를 볼 수 있습니다.',
+          hpRecovery: '캐릭터 HP는 던전에 들어갈 때 자동으로 회복됩니다.',
+          injured: 'HP가 0이 된 캐릭터는 거점 치료소에서 회복해야 합니다.',
+        },
       },
       preparation: {
         title: '원정 준비',


### PR DESCRIPTION
## Summary
- 編成画面でパーティ枠が 1 つしかない状況（=ゲーム序盤）に、冒険詳細の見方・HP 自動回復・治療所での回復という基本操作を案内するチュートリアル文をリストフッターに追加
- 上記文言を日本語・英語・韓国語の i18n リソースへ追加

## Test plan
- [ ] パーティ枠が 1 つの状態で編成画面を開き、チュートリアル文が 3 行表示されることを確認
- [ ] パーティ枠が 2 つ以上の状態でチュートリアル文が表示されないことを確認
- [ ] 言語を ja / en / ko に切り替えて表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)