### PR TITLE
feat(expedition): ダンジョン選択可能ティア上限を3に制限

### DIFF
--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -17,13 +17,17 @@ import {
   getPartyRareMultiplierFromSkills,
   getPartyTitleMultiplierFromSkills,
 } from '@/shared/data/characterSkills'
-import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '@/shared/types'
+import { normalizePartyRewardMultipliers, DUNGEON_TIER_META, DUNGEON_TIER_SELECTABLE_MAX, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '@/shared/types'
 import type { ExpeditionRequest, Goblin, Dungeon, Party, DungeonTier } from '@/shared/types'
 import { getDungeonDescription, getDungeonName, getReturnPolicyLabel } from '@/shared/i18n/entityLocalization'
 
 type ReturnPolicy = ExpeditionRequest['returnPolicy']
 
 const MAX_PARTY_SLOTS = 6
+
+function clampSelectableTier(tier: number | undefined): DungeonTier {
+  return Math.min(Math.max(tier ?? 0, 0), DUNGEON_TIER_SELECTABLE_MAX) as DungeonTier
+}
 
 function formatDungeonLabel(dungeon: Dungeon, tier: DungeonTier = 0): string {
   if (dungeon.areaLevel === undefined) return getDungeonName(dungeon)
@@ -118,7 +122,7 @@ export default function ExpeditionPreparationScreen() {
   }, [party, partiesLoading, partyId, retryCount, refreshParties])
 
   const [selectedDungeonId, setSelectedDungeonId] = useState<string | undefined>(party?.dungeonId)
-  const [selectedTier, setSelectedTier] = useState<DungeonTier>(party?.dungeonTier ?? 0)
+  const [selectedTier, setSelectedTier] = useState<DungeonTier>(clampSelectableTier(party?.dungeonTier))
   const [selectedReturnPolicy, setSelectedReturnPolicy] = useState<ReturnPolicy>(party?.returnPolicy ?? 'never')
   const [selectedTargetFloor, setSelectedTargetFloor] = useState<number | null>(party?.targetFloor ?? null)
   const [isDungeonModalVisible, setIsDungeonModalVisible] = useState(false)
@@ -132,7 +136,7 @@ export default function ExpeditionPreparationScreen() {
   useEffect(() => {
     if (party) {
       setSelectedDungeonId(party.dungeonId)
-      setSelectedTier(party.dungeonTier ?? 0)
+      setSelectedTier(clampSelectableTier(party.dungeonTier))
       setSelectedReturnPolicy(party.returnPolicy ?? 'never')
       setSelectedTargetFloor(party.targetFloor ?? null)
       setEditingPartyName(party.name)
@@ -285,14 +289,14 @@ export default function ExpeditionPreparationScreen() {
     const maxCleared = selectedDungeon.maxClearedTier ?? 0
     // maxClearedTier=1 → 通常クリア済み → 魔性(tier=1)まで解放
     // maxClearedTier=0 → 未クリア → 通常(tier=0)のみ
-    return Math.min(maxCleared, 5) as DungeonTier
+    return clampSelectableTier(maxCleared)
   }, [selectedDungeon])
 
   // ダンジョン変更時にティアをデフォルト選択（クリア済みの最高ティア）
   const autoSelectTier = useCallback((dungeon: Dungeon) => {
     const maxCleared = dungeon.maxClearedTier ?? 0
     // maxClearedTier は「次に解放されるティア番号」なので、クリア済み最高は -1
-    const defaultTier = Math.min(Math.max(maxCleared - 1, 0), 5) as DungeonTier
+    const defaultTier = clampSelectableTier(maxCleared - 1)
     setSelectedTier(defaultTier)
     if (partyId) {
       void setDungeonTier(parseInt(partyId, 10), defaultTier)
@@ -314,9 +318,10 @@ export default function ExpeditionPreparationScreen() {
   }, [partyId, selectedTargetFloor, setDungeon, setTargetFloor, autoSelectTier])
 
   const handleSelectTier = useCallback((tier: DungeonTier) => {
-    setSelectedTier(tier)
+    const selectableTier = clampSelectableTier(tier)
+    setSelectedTier(selectableTier)
     if (partyId) {
-      void setDungeonTier(parseInt(partyId, 10), tier)
+      void setDungeonTier(parseInt(partyId, 10), selectableTier)
     }
   }, [partyId, setDungeonTier])
 

--- a/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
+++ b/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
@@ -2,7 +2,7 @@ import { getEnemyDatabase } from '@/shared/data/enemy'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
 import { getFactor } from '@/shared/data/factors'
 import { getEquipmentLabel, getFactorName } from '@/shared/i18n/entityLocalization'
-import { DUNGEON_TIER_LIST, type DungeonTier } from '@/shared/types/DungeonTier'
+import { DUNGEON_TIER_LIST, DUNGEON_TIER_SELECTABLE_MAX, type DungeonTier } from '@/shared/types/DungeonTier'
 import type { Dungeon, Enemy } from '@/shared/types'
 
 export type EnemyEntry = {
@@ -34,7 +34,7 @@ export const ATTRIBUTE_ROWS: Array<{ key: keyof Enemy['baseAttributes']; label: 
 ]
 
 export function getUnlockedMaxTier(dungeon: Dungeon): DungeonTier {
-  return Math.min(Math.max(dungeon.maxClearedTier ?? 0, 0), 5) as DungeonTier
+  return Math.min(Math.max(dungeon.maxClearedTier ?? 0, 0), DUNGEON_TIER_SELECTABLE_MAX) as DungeonTier
 }
 
 export function getUnlockedTiers(dungeon: Dungeon): DungeonTier[] {

--- a/goblin_native/src/shared/types/DungeonTier.ts
+++ b/goblin_native/src/shared/types/DungeonTier.ts
@@ -2,6 +2,7 @@
 export type DungeonTier = 0 | 1 | 2 | 3 | 4 | 5
 
 export const DUNGEON_TIER_LIST = [0, 1, 2, 3, 4, 5] as const
+export const DUNGEON_TIER_SELECTABLE_MAX = 3 as const
 
 export const DUNGEON_TIER_META = [
   { tier: 0 as const, prefix: '', labelKey: 'dungeonTier.normal' },

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -64,6 +64,7 @@ export type { DungeonTier, DungeonTierClass } from "./DungeonTier"
 export {
   DUNGEON_TIER_LIST,
   DUNGEON_TIER_META,
+  DUNGEON_TIER_SELECTABLE_MAX,
   DUNGEON_TIER_SCALING,
   DUNGEON_TIER_TIME_FACTOR,
   DUNGEON_TIER_TIME_DELTA,


### PR DESCRIPTION
## Summary
- 選択可能な最大ティアを `DUNGEON_TIER_SELECTABLE_MAX` として定数化（3）
- 編成画面（`preparation.tsx`）と図鑑画面（`encyclopediaData.ts`）の上限ロジックを定数経由に統一
- `clampSelectableTier` ヘルパーで初期値・選択・自動選択時のクランプを共通化

## Test plan
- [ ] 編成画面でティア4・5が選択できないことを確認
- [ ] ティア3まではクリア状況に応じて解放されることを確認
- [ ] 図鑑のティア表示上限が3になっていることを確認
- [ ] `npx tsc --noEmit` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)