### PR TITLE
feat(expedition): 敵にTier別レアドロップ設定を追加

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -784,8 +784,9 @@ export class ExpeditionEngine {
    *    そのランクの装備プールから1点を均等抽選する。
    *
    * レアドロップ:
-   *  - 敵に `rareEquipmentDrops` が設定されているときのみ判定する。
-   *  - rareEquipmentDrops の **アイテム1つごとに** `100 - effectiveRare * 0.1 < 運乱数` で当落判定。
+   *  - 敵に `rareEquipmentDrops` / `tierRareEquipmentDrops` が設定されているときのみ判定する。
+   *  - Tier 追加分は `tier <= 現在Tier` の候補を `rareEquipmentDrops` に足して判定する。
+   *  - レア候補の **アイテム1つごとに** `100 - effectiveRare * 0.1 < 運乱数` で当落判定。
    *  - effectiveRare = `rare * rareDropMultiplierBoost`（boost は課金アイテム等で 2 倍化）。
    *  - 当選したアイテムをそれぞれドロップに追加する（同じ敵から複数種ドロップ可能）。
    *
@@ -836,11 +837,17 @@ export class ExpeditionEngine {
       pendingDroppedIds.add(selected.id)
     }
 
-    // レアドロップ判定（rareEquipmentDrops のアイテム1つごとに当落判定）
+    // レアドロップ判定（通常候補 + Tier 追加候補のアイテム1つごとに当落判定）
     for (const enemy of enemies) {
-      if (!enemy.rareEquipmentDrops || enemy.rareEquipmentDrops.length === 0) continue
+      const rareEquipmentDrops = [
+        ...(enemy.rareEquipmentDrops ?? []),
+        ...(enemy.tierRareEquipmentDrops ?? [])
+          .filter(tierDrops => tierDrops.tier <= tier)
+          .flatMap(tierDrops => tierDrops.drops),
+      ]
+      if (rareEquipmentDrops.length === 0) continue
 
-      for (const drop of enemy.rareEquipmentDrops) {
+      for (const drop of rareEquipmentDrops) {
         if (
           expeditionDroppedIds.has(drop.templateId) ||
           pendingDroppedIds.has(drop.templateId) ||

--- a/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
+++ b/goblin_native/src/core/services/__tests__/TreasureDrop.test.ts
@@ -598,5 +598,32 @@ describe('rollTreasureDrops', () => {
         }
       }
     })
+
+    it('tierRareEquipmentDrops は指定Tier以上で追加される', () => {
+      const enemy = createDummyEnemy({
+        level: 1,
+        rareEquipmentDrops: [{ templateId: 'sword_royal' }],
+        tierRareEquipmentDrops: [
+          { tier: 1, drops: [{ templateId: 'sword_kaiser' }] },
+          { tier: 3, drops: [{ templateId: 'sword_ancient' }] },
+        ],
+      })
+
+      const hasDrop = (tier: number, templateId: string) => {
+        for (let seed = 0; seed < 500; seed++) {
+          const engine = createEngine(seed)
+          const result = callRollTreasureDrops(engine, [enemy], new Set(), 35, { rare: 99 }, 1, 1, tier)
+          if (result.some((drop: any) => drop.templateId === templateId)) return true
+        }
+        return false
+      }
+
+      expect(hasDrop(0, 'sword_royal')).toBe(true)
+      expect(hasDrop(0, 'sword_kaiser')).toBe(false)
+      expect(hasDrop(1, 'sword_kaiser')).toBe(true)
+      expect(hasDrop(2, 'sword_kaiser')).toBe(true)
+      expect(hasDrop(2, 'sword_ancient')).toBe(false)
+      expect(hasDrop(3, 'sword_ancient')).toBe(true)
+    })
   })
 })

--- a/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
+++ b/goblin_native/src/presentation/encyclopedia/encyclopediaData.ts
@@ -92,7 +92,11 @@ export function formatStatValue(value: Enemy[keyof Enemy]): string {
 }
 
 export function getRareDropNames(enemy: Enemy): string[] {
-  return (enemy.rareEquipmentDrops ?? []).map((drop) => {
+  const drops = [
+    ...(enemy.rareEquipmentDrops ?? []),
+    ...(enemy.tierRareEquipmentDrops ?? []).flatMap((entry) => entry.drops),
+  ]
+  return drops.map((drop) => {
     const template = getEquipmentTemplate(drop.templateId)
     return template ? getEquipmentLabel(template) : drop.templateId
   })

--- a/goblin_native/src/shared/data/enemy/slime_cave.json
+++ b/goblin_native/src/shared/data/enemy/slime_cave.json
@@ -28,6 +28,16 @@
         {
           "templateId": "accessory_split_core"
         }
+      ],
+      "tierRareEquipmentDrops": [
+        {
+          "tier": 1,
+          "drops": [
+            {
+              "templateId": "accessory_luck_medal"
+            }
+          ]
+        }
       ]
     },
     {

--- a/goblin_native/src/shared/types/Enemy.ts
+++ b/goblin_native/src/shared/types/Enemy.ts
@@ -3,9 +3,15 @@ import type { CharacterSkill } from './CharacterSkill'
 import type { FactorDropConfig } from './Factor'
 import type { LearnedSpell } from './Spell'
 import type { BattleActionPolicy } from './Battle'
+import type { DungeonTier } from './DungeonTier'
 
 export interface EquipmentDropConfig {
   templateId: string   // EquipmentTemplate.id
+}
+
+export interface TierEquipmentDropConfig {
+  tier: DungeonTier
+  drops: EquipmentDropConfig[]
 }
 
 export interface Enemy {
@@ -32,7 +38,8 @@ export interface Enemy {
   isBoss?: boolean // この敵自身がボスか。ボスパターンに含まれる随伴敵には付けない。
   gold: number
   factorDrops?: FactorDropConfig[]      // この敵を倒すと得られる可能性のある因子
-  rareEquipmentDrops?: EquipmentDropConfig[] // この敵固有のレアドロップ候補（運乱数によるレア抽選で当選した場合に1点抽選）
+  rareEquipmentDrops?: EquipmentDropConfig[] // 通常Tierから落ちるレアドロップ候補
+  tierRareEquipmentDrops?: TierEquipmentDropConfig[] // 指定Tier以上で追加されるレアドロップ候補
   skills?: CharacterSkill[]              // パッシブ/呪文付与スキル
   spells?: LearnedSpell[]               // この敵が使える呪文リスト
   battleActionPolicy?: BattleActionPolicy // 戦闘時の行動率設定

--- a/goblin_native/src/shared/types/index.ts
+++ b/goblin_native/src/shared/types/index.ts
@@ -7,7 +7,7 @@ export type { Party, PartyStatus, PartyState, PartyRewardMultipliers } from "./P
 export { DEFAULT_PARTY_REWARD_MULTIPLIERS, normalizePartyRewardMultipliers } from "./Party"
 
 // Enemy related types
-export type { Enemy, EnemyPattern, EnemyDatabase, EnemySnap, EquipmentDropConfig } from "./Enemy"
+export type { Enemy, EnemyPattern, EnemyDatabase, EnemySnap, EquipmentDropConfig, TierEquipmentDropConfig } from "./Enemy"
 
 // Factor related types
 export type { Factor, FactorEffect, FactorVariantConfig, FactorDropConfig } from "./Factor"

--- a/tools/studio/src/App.tsx
+++ b/tools/studio/src/App.tsx
@@ -12,6 +12,7 @@ import { EquipmentPoolPage } from './pages/EquipmentPoolPage'
 import { DungeonUnlockFlowPage } from './pages/DungeonUnlockFlowPage'
 import { BalanceReferencePage } from './pages/BalanceReferencePage'
 import { TipsPage } from './pages/TipsPage'
+import { RareDropsPage } from './pages/RareDropsPage'
 import { PartyStoreProvider } from './stores/partyStore'
 
 export function App() {
@@ -28,6 +29,7 @@ export function App() {
             <Link to="/stories">ストーリー</Link>
             <Link to="/goblins">ゴブリン</Link>
             <Link to="/equipment">アイテム</Link>
+            <Link to="/rare-drops">レアドロップ</Link>
             <Link to="/tips">TIPS</Link>
             <Link to="/skills">Skill</Link>
             <Link to="/party">PT編成</Link>
@@ -45,6 +47,7 @@ export function App() {
             <Route path="/stories/:storyId" element={<StoryDetailPage />} />
             <Route path="/goblins" element={<GoblinDataPage />} />
             <Route path="/equipment" element={<EquipmentPoolPage />} />
+            <Route path="/rare-drops" element={<RareDropsPage />} />
             <Route path="/tips" element={<TipsPage />} />
             <Route path="/skills" element={<SkillCatalogPage />} />
             <Route path="/party" element={<PartyPage />} />

--- a/tools/studio/src/components/DungeonDropsView.tsx
+++ b/tools/studio/src/components/DungeonDropsView.tsx
@@ -115,14 +115,26 @@ export function DungeonDropsView({ enemy }: { enemy: EnemyDatabase | null }) {
   }, [templates])
 
   const rareDropEntries = useMemo(() => {
-    const entries: Array<{ enemyId: string; enemyName: string; templateIds: string[] }> = []
+    const entries: Array<{
+      enemyId: string
+      enemyName: string
+      baseTemplateIds: string[]
+      tierTemplateIds: Array<{ tier: DungeonTier; templateIds: string[] }>
+    }> = []
     for (const e of enemies) {
       const drops = (e as { rareEquipmentDrops?: Array<{ templateId: string }> }).rareEquipmentDrops
-      if (!drops || drops.length === 0) continue
+      const tierDrops =
+        (e as { tierRareEquipmentDrops?: Array<{ tier: DungeonTier; drops: Array<{ templateId: string }> }> })
+          .tierRareEquipmentDrops ?? []
+      if ((!drops || drops.length === 0) && tierDrops.length === 0) continue
       entries.push({
         enemyId: e.id,
         enemyName: e.name,
-        templateIds: drops.map((d) => d.templateId),
+        baseTemplateIds: (drops ?? []).map((d) => d.templateId),
+        tierTemplateIds: tierDrops.map((entry) => ({
+          tier: entry.tier,
+          templateIds: entry.drops.map((drop) => drop.templateId),
+        })),
       })
     }
     return entries
@@ -155,9 +167,9 @@ export function DungeonDropsView({ enemy }: { enemy: EnemyDatabase | null }) {
       </section>
 
       <section className="card">
-        <h3>レアドロップ (ティア共通)</h3>
+        <h3>レアドロップ</h3>
         <p className="subtle">
-          各敵に登録された <code>rareEquipmentDrops</code> のアイテム一覧です。ティアによる増減はありません。
+          各敵に登録された <code>rareEquipmentDrops</code> と、Tierで追加される <code>tierRareEquipmentDrops</code> の一覧です。
         </p>
         {rareDropEntries.length === 0 && <p className="subtle">レアドロップは登録されていません。</p>}
         {rareDropEntries.map((entry) => (
@@ -165,31 +177,61 @@ export function DungeonDropsView({ enemy }: { enemy: EnemyDatabase | null }) {
             <h4>
               {entry.enemyName} <span className="subtle">/ <code>{entry.enemyId}</code></span>
             </h4>
-            <ul className="drop-list">
-              {entry.templateIds.map((templateId) => {
-                const t = templateMap.get(templateId)
-                return (
-                  <li key={templateId} className={t ? '' : 'invalid-cell'}>
-                    {t ? (
-                      <>
-                        <strong>{t.name}</strong>{' '}
-                        <span className="subtle">
-                          <code>{t.id}</code> · {t.category}
-                          {t.subCategory ? ` / ${t.subCategory}` : ''}
-                          {t.rank !== undefined ? ` · rank ${t.rank}` : ''}
-                        </span>
-                      </>
-                    ) : (
-                      <span>未登録の templateId: {templateId}</span>
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
+            <RareDropList label="通常" templateIds={entry.baseTemplateIds} templateMap={templateMap} />
+            {entry.tierTemplateIds.map((tierEntry) => {
+              const meta = DUNGEON_TIER_META[tierEntry.tier]
+              const label = meta.prefix ? `${meta.prefix} 追加` : '通常追加'
+              return (
+                <RareDropList
+                  key={tierEntry.tier}
+                  label={label}
+                  templateIds={tierEntry.templateIds}
+                  templateMap={templateMap}
+                />
+              )
+            })}
           </div>
         ))}
       </section>
     </div>
+  )
+}
+
+function RareDropList({
+  label,
+  templateIds,
+  templateMap,
+}: {
+  label: string
+  templateIds: string[]
+  templateMap: Map<string, EquipmentTemplate>
+}) {
+  if (templateIds.length === 0) return null
+  return (
+    <>
+      <p className="subtle">{label}</p>
+      <ul className="drop-list">
+        {templateIds.map((templateId) => {
+          const t = templateMap.get(templateId)
+          return (
+            <li key={templateId} className={t ? '' : 'invalid-cell'}>
+              {t ? (
+                <>
+                  <strong>{t.name}</strong>{' '}
+                  <span className="subtle">
+                    <code>{t.id}</code> · {t.category}
+                    {t.subCategory ? ` / ${t.subCategory}` : ''}
+                    {t.rank !== undefined ? ` · rank ${t.rank}` : ''}
+                  </span>
+                </>
+              ) : (
+                <span>未登録の templateId: {templateId}</span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </>
   )
 }
 

--- a/tools/studio/src/components/EnemyEditor.tsx
+++ b/tools/studio/src/components/EnemyEditor.tsx
@@ -13,6 +13,7 @@ import { calculateEnemyExp } from '@app/shared/utils/enemyExp'
 import { races } from '@app/shared/data/races'
 import { getRaceResistanceTotals } from '@app/shared/data/races'
 import type { CharacterSkill } from '@app/shared/types/CharacterSkill'
+import type { DungeonTier } from '@app/shared/types/DungeonTier'
 
 import type { EnemyDatabase } from '../lib/schema'
 import {
@@ -24,6 +25,7 @@ import {
 } from './fields'
 import { EnemySkillListEditor } from './SkillEditors'
 import { RareEquipmentDropsEditor } from './RareEquipmentDropsEditor'
+import { TierRareEquipmentDropsEditor } from './TierRareEquipmentDropsEditor'
 
 type Enemy = EnemyDatabase['enemies'][number]
 const raceEntries = Object.entries(races).sort((a, b) => a[1].label.localeCompare(b[1].label, 'ja'))
@@ -451,6 +453,26 @@ function EnemyForm({
               delete next.rareEquipmentDrops
             } else {
               next.rareEquipmentDrops = rareEquipmentDrops
+            }
+            return next as Enemy
+          })
+        }
+        maxEntries={1}
+      />
+      <TierRareEquipmentDropsEditor
+        tierRareEquipmentDrops={
+          (enemy as Enemy & { tierRareEquipmentDrops?: Array<{ tier: DungeonTier; drops: Array<{ templateId: string }> }> })
+            .tierRareEquipmentDrops
+        }
+        onChange={(tierRareEquipmentDrops) =>
+          onChange((prev) => {
+            const next = { ...prev } as Enemy & {
+              tierRareEquipmentDrops?: Array<{ tier: DungeonTier; drops: Array<{ templateId: string }> }>
+            }
+            if (!tierRareEquipmentDrops || tierRareEquipmentDrops.length === 0) {
+              delete next.tierRareEquipmentDrops
+            } else {
+              next.tierRareEquipmentDrops = tierRareEquipmentDrops
             }
             return next as Enemy
           })

--- a/tools/studio/src/components/RareEquipmentDropsEditor.tsx
+++ b/tools/studio/src/components/RareEquipmentDropsEditor.tsx
@@ -6,14 +6,14 @@ import {
   type EquipmentTemplate,
 } from '../lib/schema'
 
-interface RareDropEntry {
+export interface RareDropEntry {
   templateId: string
 }
 
 let cachedPool: EquipmentTemplate[] | null = null
 let cachedPoolPromise: Promise<EquipmentTemplate[]> | null = null
 
-async function loadEquipmentTemplates(): Promise<EquipmentTemplate[]> {
+export async function loadEquipmentTemplates(): Promise<EquipmentTemplate[]> {
   if (cachedPool) return cachedPool
   if (cachedPoolPromise) return cachedPoolPromise
   cachedPoolPromise = (async () => {
@@ -39,9 +39,13 @@ export function invalidateEquipmentPoolCache() {
 export function RareEquipmentDropsEditor({
   rareEquipmentDrops,
   onChange,
+  title = 'レアドロップ (rareEquipmentDrops)',
+  maxEntries,
 }: {
   rareEquipmentDrops: RareDropEntry[] | undefined
   onChange: (next: RareDropEntry[] | undefined) => void
+  title?: string
+  maxEntries?: number
 }) {
   const entries = rareEquipmentDrops ?? []
   const [templates, setTemplates] = useState<EquipmentTemplate[] | null>(cachedPool)
@@ -83,20 +87,27 @@ export function RareEquipmentDropsEditor({
     onChange(next.length > 0 ? next : undefined)
   }
   const addEntry = () => {
+    if (maxEntries !== undefined && entries.length >= maxEntries) return
     onChange([...entries, { templateId: '' }])
   }
 
   return (
     <section className="card">
       <div className="section-head">
-        <h4>レアドロップ (rareEquipmentDrops)</h4>
-        <button className="btn ghost small" onClick={addEntry}>
+        <h4>{title}</h4>
+        <button
+          className="btn ghost small"
+          onClick={addEntry}
+          disabled={maxEntries !== undefined && entries.length >= maxEntries}
+        >
           + 追加
         </button>
       </div>
       <p className="subtle">
         登録したアイテム1つごとに運値ベースの当落判定が走ります（確率指定なし）。
-        同じ敵から複数種のレアアイテムがドロップする可能性があります。
+        {maxEntries === 1
+          ? 'この画面では候補を1個まで設定できます。'
+          : '同じ敵から複数種のレアアイテムがドロップする可能性があります。'}
         セレクトには <strong>isRare=true のアイテムのみ</strong> 表示されます（アイテム管理画面のチェックでON可）。
       </p>
       {loadError && <p className="save-error">{loadError}</p>}
@@ -144,7 +155,7 @@ export function RareEquipmentDropsEditor({
   )
 }
 
-function TemplateSelect({
+export function TemplateSelect({
   value,
   templates,
   onChange,

--- a/tools/studio/src/components/TierRareEquipmentDropsEditor.tsx
+++ b/tools/studio/src/components/TierRareEquipmentDropsEditor.tsx
@@ -1,0 +1,75 @@
+import {
+  DUNGEON_TIER_META,
+  type DungeonTier,
+} from '@app/shared/types/DungeonTier'
+
+import {
+  RareEquipmentDropsEditor,
+  type RareDropEntry,
+} from './RareEquipmentDropsEditor'
+
+export interface TierRareDropEntry {
+  tier: DungeonTier
+  drops: RareDropEntry[]
+}
+
+const EDITABLE_EXTRA_TIERS: DungeonTier[] = [1, 3]
+
+function normalizeTierDrops(entries: TierRareDropEntry[] | undefined): Map<DungeonTier, RareDropEntry[]> {
+  const map = new Map<DungeonTier, RareDropEntry[]>()
+  for (const entry of entries ?? []) {
+    map.set(entry.tier, entry.drops ?? [])
+  }
+  return map
+}
+
+function buildTierDrops(map: Map<DungeonTier, RareDropEntry[]>): TierRareDropEntry[] | undefined {
+  const next = EDITABLE_EXTRA_TIERS.flatMap((tier) => {
+    const drops = map.get(tier)?.filter((drop) => drop.templateId.trim() !== '') ?? []
+    return drops.length > 0 ? [{ tier, drops }] : []
+  })
+  return next.length > 0 ? next : undefined
+}
+
+export function TierRareEquipmentDropsEditor({
+  tierRareEquipmentDrops,
+  onChange,
+}: {
+  tierRareEquipmentDrops: TierRareDropEntry[] | undefined
+  onChange: (next: TierRareDropEntry[] | undefined) => void
+}) {
+  const tierDropMap = normalizeTierDrops(tierRareEquipmentDrops)
+
+  const updateTier = (tier: DungeonTier, drops: RareDropEntry[] | undefined) => {
+    const nextMap = new Map(tierDropMap)
+    if (!drops || drops.length === 0) {
+      nextMap.delete(tier)
+    } else {
+      nextMap.set(tier, drops)
+    }
+    onChange(buildTierDrops(nextMap))
+  }
+
+  return (
+    <section className="tier-rare-editor">
+      <h4>Tier追加レアドロップ</h4>
+      <p className="subtle">
+        通常Tierの候補に、指定Tier以上で追加される候補です。宿った(Tier 2)は追加なしの仕様です。
+      </p>
+      <div className="tier-rare-grid">
+        {EDITABLE_EXTRA_TIERS.map((tier) => {
+          const meta = DUNGEON_TIER_META[tier]
+          return (
+            <RareEquipmentDropsEditor
+              key={tier}
+              rareEquipmentDrops={tierDropMap.get(tier)}
+              onChange={(drops) => updateTier(tier, drops)}
+              title={`${meta.prefix} 追加 (Tier ${tier})`}
+              maxEntries={1}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/tools/studio/src/lib/schema.ts
+++ b/tools/studio/src/lib/schema.ts
@@ -9,6 +9,22 @@ export const GoblinBaseAttributesSchema = z.object({
   luck: z.number(),
 })
 
+export const RareEquipmentDropSchema = z.object({
+  templateId: z.string(),
+})
+
+export const TierRareEquipmentDropSchema = z.object({
+  tier: z.union([
+    z.literal(0),
+    z.literal(1),
+    z.literal(2),
+    z.literal(3),
+    z.literal(4),
+    z.literal(5),
+  ]),
+  drops: z.array(RareEquipmentDropSchema),
+})
+
 export const AreaConfigSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -71,6 +87,8 @@ export const EnemySchema = z
     exp: z.number().int().nonnegative(),
     isBoss: z.boolean().optional(),
     gold: z.number().int().nonnegative(),
+    rareEquipmentDrops: z.array(RareEquipmentDropSchema).optional(),
+    tierRareEquipmentDrops: z.array(TierRareEquipmentDropSchema).optional(),
   })
   .passthrough()
 

--- a/tools/studio/src/pages/RareDropsPage.tsx
+++ b/tools/studio/src/pages/RareDropsPage.tsx
@@ -1,0 +1,419 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  DUNGEON_TIER_META,
+  type DungeonTier,
+} from '@app/shared/types/DungeonTier'
+
+import {
+  AreaConfigSchema,
+  EnemyDatabaseSchema,
+  type DungeonDetailDto,
+  type DungeonSummary,
+  type EnemyDatabase,
+} from '../lib/schema'
+import {
+  loadEquipmentTemplates,
+  TemplateSelect,
+  type RareDropEntry,
+} from '../components/RareEquipmentDropsEditor'
+
+type SaveState =
+  | { kind: 'idle' }
+  | { kind: 'saving' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success' }
+
+type DetailState = {
+  summary: DungeonSummary
+  detail: DungeonDetailDto
+}
+
+type TierRareDropEntry = {
+  tier: DungeonTier
+  drops: RareDropEntry[]
+}
+
+const EDITABLE_EXTRA_TIERS: DungeonTier[] = [1, 3]
+
+export function RareDropsPage() {
+  const [details, setDetails] = useState<DetailState[]>([])
+  const [selectedAreaId, setSelectedAreaId] = useState<string>('')
+  const [query, setQuery] = useState('')
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const originalRef = useRef<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        setLoadState('loading')
+        const listRes = await fetch('/api/dungeons')
+        if (!listRes.ok) throw new Error(`dungeons 取得失敗: HTTP ${listRes.status}`)
+        const summaries = (await listRes.json()) as DungeonSummary[]
+        const loaded = await Promise.all(
+          summaries.map(async (summary) => {
+            const res = await fetch(`/api/dungeons/${summary.areaId}`)
+            if (!res.ok) throw new Error(`${summary.areaId} 取得失敗: HTTP ${res.status}`)
+            return { summary, detail: (await res.json()) as DungeonDetailDto }
+          }),
+        )
+        if (cancelled) return
+        setDetails(loaded)
+        setSelectedAreaId(loaded[0]?.summary.areaId ?? '')
+        originalRef.current = stableStringify(loaded)
+        setLoadState('ready')
+      } catch (err) {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : String(err))
+        setLoadState('error')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = useMemo(
+    () => loadState === 'ready' && stableStringify(details) !== originalRef.current,
+    [details, loadState],
+  )
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  const selected = details.find((entry) => entry.summary.areaId === selectedAreaId) ?? null
+
+  const filteredEnemies = useMemo(() => {
+    const enemies = selected?.detail.enemy?.enemies ?? []
+    const q = query.trim().toLowerCase()
+    if (q === '') return enemies
+    return enemies.filter(
+      (enemy) =>
+        enemy.id.toLowerCase().includes(q) ||
+        enemy.name.toLowerCase().includes(q) ||
+        enemy.raceTags.some((tag) => tag.toLowerCase().includes(q)),
+    )
+  }, [selected, query])
+
+  const updateEnemy = useCallback(
+    (
+      areaId: string,
+      enemyId: string,
+      updater: (enemy: EnemyDatabase['enemies'][number]) => EnemyDatabase['enemies'][number],
+    ) => {
+      setDetails((prev) =>
+        prev.map((entry) => {
+          if (entry.summary.areaId !== areaId || !entry.detail.enemy) return entry
+          return {
+            ...entry,
+            detail: {
+              ...entry.detail,
+              enemy: {
+                ...entry.detail.enemy,
+                enemies: entry.detail.enemy.enemies.map((enemy) =>
+                  enemy.id === enemyId ? updater(enemy) : enemy,
+                ),
+              },
+            },
+          }
+        }),
+      )
+      setSaveState({ kind: 'idle' })
+    },
+    [],
+  )
+
+  const saveAll = useCallback(async () => {
+    const dirtyEntries = details.filter((entry) => {
+      const original = (JSON.parse(originalRef.current || '[]') as DetailState[]).find(
+        (item) => item.summary.areaId === entry.summary.areaId,
+      )
+      return stableStringify(original) !== stableStringify(entry)
+    })
+    if (dirtyEntries.length === 0) return
+
+    for (const entry of dirtyEntries) {
+      const areaResult = AreaConfigSchema.safeParse(entry.detail.area)
+      const enemyResult = entry.detail.enemy ? EnemyDatabaseSchema.safeParse(entry.detail.enemy) : null
+      if (!areaResult.success) {
+        setSaveState({ kind: 'error', message: `${entry.summary.areaId}: area 検証失敗` })
+        return
+      }
+      if (enemyResult && !enemyResult.success) {
+        setSaveState({
+          kind: 'error',
+          message: `${entry.summary.areaId}: enemy 検証失敗 ${enemyResult.error.issues.map((i) => i.path.join('.')).join(' / ')}`,
+        })
+        return
+      }
+    }
+
+    setSaveState({ kind: 'saving' })
+    try {
+      await Promise.all(
+        dirtyEntries.map(async (entry) => {
+          const res = await fetch(`/api/dungeons/${entry.summary.areaId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              area: entry.detail.area,
+              enemy: entry.detail.enemy,
+            }),
+          })
+          if (!res.ok) {
+            const body = await res.json().catch(() => null)
+            throw new Error(`${entry.summary.areaId}: ${body?.error ?? `HTTP ${res.status}`}`)
+          }
+        }),
+      )
+      originalRef.current = stableStringify(details)
+      setSaveState({ kind: 'success' })
+    } catch (err) {
+      setSaveState({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
+    }
+  }, [details])
+
+  const revert = useCallback(() => {
+    setDetails(JSON.parse(originalRef.current || '[]') as DetailState[])
+    setSaveState({ kind: 'idle' })
+  }, [])
+
+  if (loadState === 'loading') return <p className="state-msg">読み込み中…</p>
+  if (loadState === 'error') return <p className="state-msg error">読み込みに失敗しました: {loadError}</p>
+
+  return (
+    <div className="rare-drops-page">
+      <div className="detail-head">
+        <div>
+          <h2>レアアイテム管理</h2>
+          <p className="subtle">
+            通常は0〜1個、魔性と伝説は追加候補を設定できます。宿ったは追加なしです。
+          </p>
+        </div>
+        <div className="save-bar">
+          {saveState.kind === 'saving' && <span className="subtle">保存中…</span>}
+          {saveState.kind === 'success' && !isDirty && <span className="saved">保存しました</span>}
+          {saveState.kind === 'error' && <span className="save-error">{saveState.message}</span>}
+          <button className="btn ghost" disabled={!isDirty || saveState.kind === 'saving'} onClick={revert}>
+            取り消し
+          </button>
+          <button className="btn primary" disabled={!isDirty || saveState.kind === 'saving'} onClick={saveAll}>
+            まとめて保存
+          </button>
+        </div>
+      </div>
+
+      <div className="rare-drops-layout">
+        <aside className="card rare-drops-sidebar">
+          <h3>ダンジョン</h3>
+          <div className="rare-drops-area-list">
+            {details.map((entry) => {
+              const enemyCount = entry.detail.enemy?.enemies.length ?? 0
+              return (
+                <button
+                  key={entry.summary.areaId}
+                  type="button"
+                  className={selectedAreaId === entry.summary.areaId ? 'area-list-button active' : 'area-list-button'}
+                  onClick={() => setSelectedAreaId(entry.summary.areaId)}
+                >
+                  <span>{entry.summary.name}</span>
+                  <small>
+                    Lv {entry.summary.areaLevel} / 敵 {enemyCount}
+                  </small>
+                </button>
+              )
+            })}
+          </div>
+        </aside>
+
+        <section className="card rare-drops-main">
+          <div className="rare-drops-toolbar">
+            <div>
+              <h3>{selected?.summary.name ?? '未選択'}</h3>
+              {selected && (
+                <p className="subtle">
+                  <code>{selected.summary.areaId}</code> · Lv {selected.summary.areaLevel}
+                </p>
+              )}
+            </div>
+            <input
+              className="search-input"
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="敵 id / name / raceTag で絞り込み"
+            />
+          </div>
+
+          {!selected?.detail.enemy && <p className="subtle">敵データがありません。</p>}
+          {selected?.detail.enemy && (
+            <table className="enemy-table rare-drops-table">
+              <thead>
+                <tr>
+                  <th>敵</th>
+                  <th>通常</th>
+                  <th>魔性 追加</th>
+                  <th>宿った</th>
+                  <th>伝説 追加</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredEnemies.map((enemy) => (
+                  <RareDropRow
+                    key={enemy.id}
+                    enemy={enemy}
+                    onChange={(updater) => updateEnemy(selected.summary.areaId, enemy.id, updater)}
+                  />
+                ))}
+                {filteredEnemies.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="subtle">該当する敵がいません</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function RareDropRow({
+  enemy,
+  onChange,
+}: {
+  enemy: EnemyDatabase['enemies'][number]
+  onChange: (updater: (enemy: EnemyDatabase['enemies'][number]) => EnemyDatabase['enemies'][number]) => void
+}) {
+  const typedEnemy = enemy as EnemyDatabase['enemies'][number] & {
+    rareEquipmentDrops?: RareDropEntry[]
+    tierRareEquipmentDrops?: TierRareDropEntry[]
+  }
+  const tierDrops = normalizeTierDrops(typedEnemy.tierRareEquipmentDrops)
+
+  const setBaseDrop = (templateId: string) => {
+    onChange((prev) => {
+      const next = { ...prev } as typeof typedEnemy
+      if (templateId === '') {
+        delete next.rareEquipmentDrops
+      } else {
+        next.rareEquipmentDrops = [{ templateId }]
+      }
+      return next
+    })
+  }
+
+  const setTierDrop = (tier: DungeonTier, templateId: string) => {
+    onChange((prev) => {
+      const next = { ...prev } as typeof typedEnemy
+      const nextMap = normalizeTierDrops(next.tierRareEquipmentDrops)
+      if (templateId === '') {
+        nextMap.delete(tier)
+      } else {
+        nextMap.set(tier, [{ templateId }])
+      }
+      const tierRareEquipmentDrops = buildTierDrops(nextMap)
+      if (tierRareEquipmentDrops) {
+        next.tierRareEquipmentDrops = tierRareEquipmentDrops
+      } else {
+        delete next.tierRareEquipmentDrops
+      }
+      return next
+    })
+  }
+
+  return (
+    <tr>
+      <td className="rare-drops-enemy-cell">
+        <strong>{enemy.name}</strong>
+        <span className="subtle"><code>{enemy.id}</code> / Lv {enemy.level}</span>
+      </td>
+      <td>
+        <RareTemplateCell
+          value={typedEnemy.rareEquipmentDrops?.[0]?.templateId ?? ''}
+          onChange={setBaseDrop}
+        />
+      </td>
+      <td>
+        <RareTemplateCell
+          value={tierDrops.get(1)?.[0]?.templateId ?? ''}
+          onChange={(value) => setTierDrop(1, value)}
+        />
+      </td>
+      <td className="subtle">{DUNGEON_TIER_META[2].prefix}は追加なし</td>
+      <td>
+        <RareTemplateCell
+          value={tierDrops.get(3)?.[0]?.templateId ?? ''}
+          onChange={(value) => setTierDrop(3, value)}
+        />
+      </td>
+    </tr>
+  )
+}
+
+function RareTemplateCell({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (value: string) => void
+}) {
+  const [templates, setTemplates] = useState<Awaited<ReturnType<typeof loadEquipmentTemplates>> | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadEquipmentTemplates()
+      .then((loaded) => {
+        if (!cancelled) setTemplates(loaded.filter((template) => template.isRare === true))
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (loadError) return <span className="save-error">{loadError}</span>
+  if (!templates) return <span className="subtle">読み込み中…</span>
+
+  return <TemplateSelect value={value} templates={templates} onChange={onChange} />
+}
+
+function normalizeTierDrops(entries: TierRareDropEntry[] | undefined): Map<DungeonTier, RareDropEntry[]> {
+  const map = new Map<DungeonTier, RareDropEntry[]>()
+  for (const entry of entries ?? []) map.set(entry.tier, entry.drops ?? [])
+  return map
+}
+
+function buildTierDrops(map: Map<DungeonTier, RareDropEntry[]>): TierRareDropEntry[] | undefined {
+  const entries = EDITABLE_EXTRA_TIERS.flatMap((tier) => {
+    const drops = map.get(tier)?.filter((drop) => drop.templateId.trim() !== '') ?? []
+    return drops.length > 0 ? [{ tier, drops }] : []
+  })
+  return entries.length > 0 ? entries : undefined
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {}
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k]
+      }
+      return sorted
+    }
+    return val
+  })
+}

--- a/tools/studio/src/styles.css
+++ b/tools/studio/src/styles.css
@@ -1380,6 +1380,110 @@ code {
   min-width: 0;
 }
 
+.tier-rare-editor {
+  margin-top: 1rem;
+}
+
+.tier-rare-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rare-drops-layout {
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  gap: 1rem;
+  align-items: flex-start;
+  margin-top: 1rem;
+}
+
+.rare-drops-sidebar {
+  position: sticky;
+  top: 5rem;
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
+}
+
+.rare-drops-area-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.area-list-button {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  padding: 0.55rem 0.65rem;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.area-list-button:hover,
+.area-list-button.active {
+  background: var(--surface-muted);
+  border-color: var(--border-strong);
+}
+
+.area-list-button small {
+  color: var(--text-sub);
+}
+
+.rare-drops-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.rare-drops-toolbar .search-input {
+  width: min(26rem, 100%);
+}
+
+.rare-drops-table th:first-child {
+  width: 14rem;
+}
+
+.rare-drops-table td {
+  vertical-align: top;
+}
+
+.rare-drops-table tbody tr {
+  cursor: default;
+}
+
+.rare-drops-enemy-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.rare-drops-table .rare-drop-select {
+  min-width: 14rem;
+}
+
+@media (max-width: 1024px) {
+  .rare-drops-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .rare-drops-sidebar {
+    position: static;
+    max-height: none;
+  }
+
+  .rare-drops-toolbar {
+    flex-direction: column;
+  }
+}
+
 .sortable {
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
## Summary
- 敵に `tierRareEquipmentDrops` を追加し、指定Tier以上で追加レアドロップ候補が抽選対象になるよう拡張
- `ExpeditionEngine` のレアドロップ判定と図鑑表示を Tier 統合に対応、テスト追加
- studio に Tier 別レアドロップ編集 UI（`TierRareEquipmentDropsEditor` / `RareDropsPage`）を追加

## Test plan
- [ ] `npx tsc --noEmit` が通る
- [ ] `npm test -- TreasureDrop` が通る
- [ ] studio で Tier 別レアドロップを編集し、JSON に正しく反映される
- [ ] アプリで Tier 1 以上のダンジョンに該当装備のドロップ候補が現れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)