### PR TITLE
feat(expedition): ダンジョン進行状況にtier別の最大クリア済みフロアを追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -13,7 +13,7 @@ import type { ExpeditionRecord, Goblin, Story, TimelineEvent, TreasureDrop } fro
 import { getDungeonTierDisplayName } from '@/shared/types'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
-import { isDungeonCompleted } from '@/shared/utils/expeditionClear'
+import { getMaxClearedFloorFromReplay, isDungeonCompleted } from '@/shared/utils/expeditionClear'
 
 function resolveTreasureName(drop: TreasureDrop): string {
   const template = getEquipmentTemplate(drop.templateId)
@@ -30,6 +30,7 @@ export default function ExpeditionResultScreen() {
   const dungeons = useDungeonStore((state) => state.dungeons)
   const progress = useDungeonStore((state) => state.progress)
   const markDungeonCleared = useDungeonStore((state) => state.markDungeonCleared)
+  const markDungeonFloorCleared = useDungeonStore((state) => state.markDungeonFloorCleared)
   const markUnlockNotified = useDungeonStore((state) => state.markUnlockNotified)
   const {
     expeditionRecords,
@@ -133,7 +134,12 @@ export default function ExpeditionResultScreen() {
 
   useEffect(() => {
     if (!replay || !dungeon) return
-    const cleared = isDungeonCompleted(replay) && replay.summary.maxFloorReached >= dungeon.floors
+    const maxClearedFloor = getMaxClearedFloorFromReplay(replay)
+    const currentClearedFloor = progress[dungeon.id]?.maxClearedFloorsByTier?.[replay.meta.tier ?? 0] ?? 0
+    if (maxClearedFloor > currentClearedFloor) {
+      void markDungeonFloorCleared(dungeon, maxClearedFloor, replay.meta.tier)
+    }
+    const cleared = isDungeonCompleted(replay) && maxClearedFloor >= dungeon.floors
     if (cleared && !dungeon.cleared) {
       void (async () => {
         await markDungeonCleared(dungeon, true, replay.meta.tier)
@@ -143,7 +149,7 @@ export default function ExpeditionResultScreen() {
         }
       })()
     }
-  }, [dungeon, markDungeonCleared, checkAndUnlockStories, replay])
+  }, [dungeon, markDungeonCleared, markDungeonFloorCleared, checkAndUnlockStories, progress, replay])
 
   const area = replay ? areasData.find(a => a.id === replay.meta.areaId) : dungeon
   const unlockTargets = useMemo(() => {

--- a/goblin_native/src/infrastructure/database/index.ts
+++ b/goblin_native/src/infrastructure/database/index.ts
@@ -18,9 +18,10 @@ import { migrateV12 } from './migrations/v12'
 import { migrateV13 } from './migrations/v13'
 import { migrateV14 } from './migrations/v14'
 import { migrateV15 } from './migrations/v15'
+import { migrateV16 } from './migrations/v16'
 
 const DB_NAME = 'goblin_kingdom.db'
-export const CURRENT_SCHEMA_VERSION = 15
+export const CURRENT_SCHEMA_VERSION = 16
 
 let db: SQLite.SQLiteDatabase | null = null
 let initializationPromise: Promise<SQLite.SQLiteDatabase> | null = null
@@ -186,6 +187,13 @@ const runMigrations = async (database: SQLite.SQLiteDatabase): Promise<void> => 
     await migrateV15(database)
     await setSchemaVersion(database, 15)
     console.log('[DB] Migration v15 completed')
+  }
+
+  if (currentVersion < 16) {
+    console.log('[DB] Running migration v16...')
+    await migrateV16(database)
+    await setSchemaVersion(database, 16)
+    console.log('[DB] Migration v16 completed')
   }
 }
 

--- a/goblin_native/src/infrastructure/database/migrations/v16.ts
+++ b/goblin_native/src/infrastructure/database/migrations/v16.ts
@@ -1,0 +1,38 @@
+import type * as SQLite from 'expo-sqlite'
+import { areasData } from '../../../shared/data'
+
+/**
+ * v16: ダンジョン進行状況に tier 別の最大クリア済みフロアを追加
+ */
+export const migrateV16 = async (database: SQLite.SQLiteDatabase): Promise<void> => {
+  const columns = await database.getAllAsync<{ name: string }>('PRAGMA table_info(dungeon_progress)')
+  if (!columns.some(column => column.name === 'cleared_floors_json')) {
+    await database.execAsync("ALTER TABLE dungeon_progress ADD COLUMN cleared_floors_json TEXT NOT NULL DEFAULT '{}'")
+  }
+
+  const rows = await database.getAllAsync<{
+    dungeon_id: string
+    cleared: number
+    max_cleared_tier: number
+    cleared_floors_json: string | null
+  }>('SELECT dungeon_id, cleared, max_cleared_tier, cleared_floors_json FROM dungeon_progress')
+
+  for (const row of rows) {
+    if (row.cleared_floors_json && row.cleared_floors_json !== '{}') continue
+    if (row.cleared !== 1) continue
+
+    const dungeon = areasData.find(area => area.id === row.dungeon_id)
+    if (!dungeon) continue
+
+    const maxClearedTier = Math.max(1, row.max_cleared_tier ?? 1)
+    const maxClearedFloorsByTier: Record<number, number> = {}
+    for (let tier = 0; tier < maxClearedTier; tier++) {
+      maxClearedFloorsByTier[tier] = dungeon.floors
+    }
+
+    await database.runAsync(
+      'UPDATE dungeon_progress SET cleared_floors_json = ? WHERE dungeon_id = ?',
+      [JSON.stringify(maxClearedFloorsByTier), row.dungeon_id],
+    )
+  }
+}

--- a/goblin_native/src/infrastructure/database/schema.ts
+++ b/goblin_native/src/infrastructure/database/schema.ts
@@ -132,6 +132,7 @@ export const SCHEMA = {
       cleared INTEGER NOT NULL DEFAULT 0,
       unlock_notified INTEGER NOT NULL DEFAULT 0,
       max_cleared_tier INTEGER NOT NULL DEFAULT 0,
+      cleared_floors_json TEXT NOT NULL DEFAULT '{}',
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `,

--- a/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
+++ b/goblin_native/src/infrastructure/repositories/SQLiteDungeonProgressRepository.ts
@@ -11,6 +11,7 @@ interface DungeonProgressRow {
   cleared: number
   unlock_notified: number
   max_cleared_tier: number
+  cleared_floors_json: string | null
   updated_at: string
 }
 
@@ -19,6 +20,7 @@ interface DungeonProgress {
   cleared: boolean
   unlockNotified: boolean
   maxClearedTier: number
+  maxClearedFloorsByTier: Record<number, number>
 }
 
 export interface IDungeonProgressRepository {
@@ -28,6 +30,28 @@ export interface IDungeonProgressRepository {
   unlock(dungeonId: string): Promise<void>
   markCleared(dungeonId: string, tier?: number): Promise<void>
 }
+
+const parseClearedFloors = (value: string | null | undefined): Record<number, number> => {
+  if (!value) return {}
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([tier, floor]) => [Number(tier), Number(floor)] as const)
+        .filter(([tier, floor]) => Number.isInteger(tier) && Number.isFinite(floor) && floor > 0),
+    )
+  } catch {
+    return {}
+  }
+}
+
+const defaultProgress = (): DungeonProgress => ({
+  unlocked: false,
+  cleared: false,
+  unlockNotified: false,
+  maxClearedTier: 0,
+  maxClearedFloorsByTier: {},
+})
 
 export class SQLiteDungeonProgressRepository implements IDungeonProgressRepository {
   private static instance: SQLiteDungeonProgressRepository | null = null
@@ -50,6 +74,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
         cleared: row.cleared === 1,
         unlockNotified: row.unlock_notified === 1,
         maxClearedTier: row.max_cleared_tier ?? 0,
+        maxClearedFloorsByTier: parseClearedFloors(row.cleared_floors_json),
       }
     }
     return result
@@ -69,6 +94,7 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
       cleared: row.cleared === 1,
       unlockNotified: row.unlock_notified === 1,
       maxClearedTier: row.max_cleared_tier ?? 0,
+      maxClearedFloorsByTier: parseClearedFloors(row.cleared_floors_json),
     }
   }
 
@@ -76,25 +102,26 @@ export class SQLiteDungeonProgressRepository implements IDungeonProgressReposito
     const db = await getDatabase()
     await db.runAsync(
       `INSERT OR REPLACE INTO dungeon_progress
-       (dungeon_id, unlocked, cleared, unlock_notified, max_cleared_tier, updated_at)
-       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+       (dungeon_id, unlocked, cleared, unlock_notified, max_cleared_tier, cleared_floors_json, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
       [
         dungeonId,
         progress.unlocked ? 1 : 0,
         progress.cleared ? 1 : 0,
         progress.unlockNotified ? 1 : 0,
         progress.maxClearedTier,
+        JSON.stringify(progress.maxClearedFloorsByTier ?? {}),
       ]
     )
   }
 
   async unlock(dungeonId: string): Promise<void> {
-    const current = await this.get(dungeonId) ?? { unlocked: false, cleared: false, unlockNotified: false, maxClearedTier: 0 }
+    const current = await this.get(dungeonId) ?? defaultProgress()
     await this.save(dungeonId, { ...current, unlocked: true })
   }
 
   async markCleared(dungeonId: string, tier?: number): Promise<void> {
-    const current = await this.get(dungeonId) ?? { unlocked: true, cleared: false, unlockNotified: false, maxClearedTier: 0 }
+    const current = await this.get(dungeonId) ?? { ...defaultProgress(), unlocked: true }
     const clearedTierValue = tier !== undefined ? tier + 1 : 1
     const newMaxClearedTier = Math.max(current.maxClearedTier, clearedTierValue)
     await this.save(dungeonId, {

--- a/goblin_native/src/presentation/hooks/useDatabaseInit.ts
+++ b/goblin_native/src/presentation/hooks/useDatabaseInit.ts
@@ -23,6 +23,7 @@ async function ensureDefaults(): Promise<void> {
         cleared: dungeon.cleared ?? false,
         unlockNotified: false,
         maxClearedTier: 0,
+        maxClearedFloorsByTier: dungeon.cleared ? { 0: dungeon.floors } : {},
       })
     }
   }

--- a/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
+++ b/goblin_native/src/presentation/hooks/useExpeditionFlow.ts
@@ -34,7 +34,7 @@ import { useTutorialStore } from '../stores/useTutorialStore'
 import { useExpeditionNotification } from '../hooks/useExpeditionNotification'
 import { getDungeonName } from '../../shared/i18n/entityLocalization'
 import { computeDungeonExplorationTime, getDungeonTierAreaLevel, getDungeonTierDisplayName } from '../../shared/types'
-import { isDungeonCompleted } from '../../shared/utils/expeditionClear'
+import { getMaxClearedFloorFromReplay, isDungeonCompleted } from '../../shared/utils/expeditionClear'
 import { computeCurrentFloor } from '../../shared/utils/expeditionFloor'
 import { getExpeditionTimeMultiplierFromSkills } from '../../shared/data/characterSkills'
 import { EquipmentService } from '../../core/services/EquipmentService'
@@ -102,6 +102,7 @@ export const useExpeditionFlow = ({
   const isBaseLoading = useBaseStore(s => s.isLoading)
   const baseStateRepository = getBaseStateRepository()
   const markDungeonCleared = useDungeonStore((state) => state.markDungeonCleared)
+  const markDungeonFloorCleared = useDungeonStore((state) => state.markDungeonFloorCleared)
   const checkAndUnlockStories = useStoryStore((state) => state.checkAndUnlockStories)
   const expeditionRecords = useExpeditionStore((state) => state.expeditionRecords)
   const getPartyExpeditionHistory = useExpeditionStore((state) => state.getPartyExpeditionHistory)
@@ -149,11 +150,16 @@ export const useExpeditionFlow = ({
     const dungeon = areasData.find(area => area.id === record.dungeonId)
     if (!dungeon) return
 
+    const tier = record.replay.meta.tier as DungeonTier | undefined
+    const maxClearedFloor = getMaxClearedFloorFromReplay(record.replay)
+    if (maxClearedFloor > 0) {
+      await markDungeonFloorCleared(dungeon, maxClearedFloor, tier)
+    }
+
     const cleared = isDungeonCompleted(record.replay) &&
-      record.replay.summary.maxFloorReached >= dungeon.floors
+      maxClearedFloor >= dungeon.floors
     if (!cleared) return
 
-    const tier = record.replay.meta.tier as DungeonTier | undefined
     await markDungeonCleared(dungeon, true, tier)
     await checkAndUnlockStories(dungeon.id)
 
@@ -195,6 +201,7 @@ export const useExpeditionFlow = ({
     isBaseLoading,
     isPendingLoading,
     markDungeonCleared,
+    markDungeonFloorCleared,
     rank,
   ])
 
@@ -211,12 +218,19 @@ export const useExpeditionFlow = ({
     }
 
     const tierCleared = (dungeon.maxClearedTier ?? 0) > tier
-    const baseTime = computeDungeonExplorationTime(
+    const fullFirstTime = computeDungeonExplorationTime(
       dungeon.id,
       dungeon.exploration_time_sec_first,
       dungeon.exploration_time_sec,
       tier,
-      tierCleared,
+      false,
+    )
+    const fullClearedTime = computeDungeonExplorationTime(
+      dungeon.id,
+      dungeon.exploration_time_sec_first,
+      dungeon.exploration_time_sec,
+      tier,
+      true,
     )
     const multiplierMap: Record<ExpeditionRequest['returnPolicy'], number> = {
       never: 1.0,
@@ -228,11 +242,22 @@ export const useExpeditionFlow = ({
     const normalizedTargetFloor = typeof targetFloor === 'number' && Number.isFinite(targetFloor)
       ? Math.max(1, Math.min(dungeon.floors, Math.floor(targetFloor)))
       : dungeon.floors
-    const floorMultiplier = normalizedTargetFloor / dungeon.floors
+    const maxClearedFloor = tierCleared
+      ? dungeon.floors
+      : Math.max(0, Math.min(
+          dungeon.floors,
+          Math.floor(dungeon.maxClearedFloorsByTier?.[tier] ?? 0),
+        ))
+    const clearedTargetFloors = Math.min(normalizedTargetFloor, maxClearedFloor)
+    const unclearedTargetFloors = normalizedTargetFloor - clearedTargetFloors
+    const baseTime = (
+      fullClearedTime * clearedTargetFloors +
+      fullFirstTime * unclearedTargetFloors
+    ) / dungeon.floors
     const speedMultiplier = getSpeedMultiplier()
     const goldenAcornSpeed = goldenAcornUsed ? GOLDEN_ACORN_SPEED_MULTIPLIER : 1
     return Math.floor(
-      baseTime * floorMultiplier * multiplier * speedMultiplier * partyExpeditionTimeMultiplier * goldenAcornSpeed,
+      baseTime * multiplier * speedMultiplier * partyExpeditionTimeMultiplier * goldenAcornSpeed,
     )
   }, [instantDungeonExploration])
 

--- a/goblin_native/src/presentation/stores/useDungeonStore.ts
+++ b/goblin_native/src/presentation/stores/useDungeonStore.ts
@@ -14,6 +14,7 @@ const buildDefaultProgress = (): DungeonProgressState => {
       cleared: dungeon.cleared ?? false,
       unlockNotified: false,
       maxClearedTier: 0,
+      maxClearedFloorsByTier: dungeon.cleared ? { 0: dungeon.floors } : {},
     }
   })
   return defaults
@@ -25,6 +26,7 @@ const buildDungeons = (progress: DungeonProgressState): Dungeon[] =>
     cleared: progress[dungeon.id]?.cleared ?? dungeon.cleared ?? false,
     unlocked: progress[dungeon.id]?.unlocked ?? dungeon.unlocked ?? false,
     maxClearedTier: progress[dungeon.id]?.maxClearedTier ?? 0,
+    maxClearedFloorsByTier: progress[dungeon.id]?.maxClearedFloorsByTier ?? {},
   }))
 
 interface DungeonStoreState {
@@ -38,6 +40,7 @@ interface DungeonStoreActions {
   refresh: () => Promise<void>
   updateProgress: (updater: (prev: DungeonProgressState) => DungeonProgressState) => Promise<void>
   markDungeonCleared: (dungeon: Dungeon, cleared: boolean, tier?: DungeonTier) => Promise<void>
+  markDungeonFloorCleared: (dungeon: Dungeon, floor: number, tier?: DungeonTier) => Promise<void>
   markUnlockNotified: (dungeonId: string) => Promise<void>
 }
 
@@ -87,18 +90,28 @@ export const useDungeonStore = create<DungeonStoreState & DungeonStoreActions>()
           cleared: false,
           unlockNotified: false,
           maxClearedTier: 0,
+          maxClearedFloorsByTier: {},
         }
 
         const clearedTierValue = tier !== undefined ? tier + 1 : 1
         const newMaxClearedTier = cleared
           ? Math.max(current.maxClearedTier, clearedTierValue)
           : current.maxClearedTier
+        const tierKey = tier ?? 0
+        const currentFloors = current.maxClearedFloorsByTier ?? {}
+        const maxClearedFloorsByTier = cleared
+          ? {
+              ...currentFloors,
+              [tierKey]: Math.max(currentFloors[tierKey] ?? 0, dungeon.floors),
+            }
+          : currentFloors
 
         nextProgress[dungeon.id] = {
           ...current,
           unlocked: true,
           cleared: cleared || current.cleared,
           maxClearedTier: newMaxClearedTier,
+          maxClearedFloorsByTier,
         }
 
         if (cleared) {
@@ -111,13 +124,38 @@ export const useDungeonStore = create<DungeonStoreState & DungeonStoreActions>()
             const target = nextProgress[unlockTarget]
             if (!target || !target.unlocked) {
               nextProgress[unlockTarget] = {
-                ...(target ?? { cleared: false, unlockNotified: false, maxClearedTier: 0 }),
+                ...(target ?? { cleared: false, unlockNotified: false, maxClearedTier: 0, maxClearedFloorsByTier: {} }),
                 unlocked: true,
               }
             }
           }
         }
 
+        return nextProgress
+      })
+    },
+
+    markDungeonFloorCleared: async (dungeon: Dungeon, floor: number, tier?: DungeonTier) => {
+      const normalizedFloor = Math.max(1, Math.min(dungeon.floors, Math.floor(floor)))
+      await updateProgress(prev => {
+        const nextProgress: DungeonProgressState = { ...prev }
+        const current = nextProgress[dungeon.id] ?? {
+          unlocked: dungeon.unlocked ?? false,
+          cleared: false,
+          unlockNotified: false,
+          maxClearedTier: 0,
+          maxClearedFloorsByTier: {},
+        }
+        const tierKey = tier ?? 0
+        const currentFloors = current.maxClearedFloorsByTier ?? {}
+        nextProgress[dungeon.id] = {
+          ...current,
+          unlocked: true,
+          maxClearedFloorsByTier: {
+            ...currentFloors,
+            [tierKey]: Math.max(currentFloors[tierKey] ?? 0, normalizedFloor),
+          },
+        }
         return nextProgress
       })
     },
@@ -130,6 +168,7 @@ export const useDungeonStore = create<DungeonStoreState & DungeonStoreActions>()
           cleared: false,
           unlockNotified: false,
           maxClearedTier: 0,
+          maxClearedFloorsByTier: {},
         }
         nextProgress[dungeonId] = { ...current, unlockNotified: true }
         return nextProgress

--- a/goblin_native/src/shared/types/Dungeon.ts
+++ b/goblin_native/src/shared/types/Dungeon.ts
@@ -16,4 +16,5 @@ export type Dungeon = {
   isBaseCapture?: boolean           // 拠点化可能か
   rankUpTarget?: number             // このダンジョン制圧で到達するランク
   maxClearedTier?: number           // 最大クリア済みティア（0=未クリア, 1=通常, 2=魔性, 3=宿った, 4=伝説, 5=恐ろしい, 6=壊れた）
+  maxClearedFloorsByTier?: Record<number, number> // tier 別の最大クリア済みフロア
 }

--- a/goblin_native/src/shared/types/DungeonProgress.ts
+++ b/goblin_native/src/shared/types/DungeonProgress.ts
@@ -1,4 +1,10 @@
 export type DungeonProgressState = Record<
   string,
-  { unlocked: boolean; cleared: boolean; unlockNotified: boolean; maxClearedTier: number }
+  {
+    unlocked: boolean
+    cleared: boolean
+    unlockNotified: boolean
+    maxClearedTier: number
+    maxClearedFloorsByTier: Record<number, number>
+  }
 >

--- a/goblin_native/src/shared/utils/__tests__/expeditionClear.test.ts
+++ b/goblin_native/src/shared/utils/__tests__/expeditionClear.test.ts
@@ -1,0 +1,72 @@
+import type { ExpeditionReplay } from '../../types'
+import { getMaxClearedFloorFromReplay } from '../expeditionClear'
+
+const baseReplay = (events: ExpeditionReplay['events']): ExpeditionReplay => ({
+  meta: {
+    expeditionId: 'test',
+    areaId: 'test_area',
+    areaName: 'テスト',
+    floors: 3,
+    baseDurationSec: 300,
+    party: ['1'],
+    partyRewardMultipliers: { gold: 1, rare: 1, title: 1 },
+    returnPolicy: 'never',
+    seed: 1,
+  },
+  durationSec: 300,
+  events,
+  summary: {
+    success: true,
+    maxFloorReached: 1,
+    xpGained: 0,
+    goldGained: 0,
+    casualties: [],
+  },
+})
+
+describe('getMaxClearedFloorFromReplay', () => {
+  it('階末戦に勝って目標フロア帰還したフロアをクリア扱いにする', () => {
+    const replay = baseReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'floor_end', at: 100, floor: 1 },
+      {
+        type: 'battle',
+        at: 100,
+        floor: 1,
+        enemy: { id: 'e1', name: '敵', lvl: 1, count: 1, gold: 0 },
+        combat: { rounds: 1, outcome: 'win', allyHPDelta: [0], enemyDefeated: 1 },
+        xp: 1,
+      },
+      { type: 'return', at: 100, reason: 'policy_return' },
+    ])
+
+    expect(getMaxClearedFloorFromReplay(replay)).toBe(1)
+  })
+
+  it('階末戦で敗北したフロアはクリア扱いにしない', () => {
+    const replay = baseReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'floor_end', at: 100, floor: 1 },
+      {
+        type: 'battle',
+        at: 100,
+        floor: 1,
+        enemy: { id: 'e1', name: '敵', lvl: 1, count: 1, gold: 0 },
+        combat: { rounds: 1, outcome: 'lose', allyHPDelta: [-10], enemyDefeated: 0 },
+        xp: 0,
+      },
+      { type: 'return', at: 100, reason: 'defeated' },
+    ])
+
+    expect(getMaxClearedFloorFromReplay(replay)).toBe(0)
+  })
+
+  it('踏破時は全フロアをクリア扱いにする', () => {
+    const replay = baseReplay([
+      { type: 'move_start', at: 0, floor: 1 },
+      { type: 'return', at: 300, reason: 'completed' },
+    ])
+
+    expect(getMaxClearedFloorFromReplay(replay)).toBe(3)
+  })
+})

--- a/goblin_native/src/shared/utils/expeditionClear.ts
+++ b/goblin_native/src/shared/utils/expeditionClear.ts
@@ -3,3 +3,31 @@ import type { ExpeditionReplay } from '../types'
 export function isDungeonCompleted(replay: ExpeditionReplay): boolean {
   return replay.events.some(event => event.type === 'return' && event.reason === 'completed')
 }
+
+export function getMaxClearedFloorFromReplay(replay: ExpeditionReplay): number {
+  if (isDungeonCompleted(replay)) {
+    return replay.meta.floors
+  }
+
+  let maxClearedFloor = 0
+  for (let index = 0; index < replay.events.length; index++) {
+    const event = replay.events[index]
+    if (event.type === 'floor_up') {
+      maxClearedFloor = Math.max(maxClearedFloor, event.from)
+      continue
+    }
+
+    if (event.type !== 'floor_end') continue
+
+    for (const nextEvent of replay.events.slice(index + 1)) {
+      if (nextEvent.type !== 'battle' && nextEvent.type !== 'boss') continue
+      if (nextEvent.floor !== event.floor || nextEvent.at !== event.at) continue
+      if (nextEvent.combat.outcome === 'win') {
+        maxClearedFloor = Math.max(maxClearedFloor, event.floor)
+      }
+      break
+    }
+  }
+
+  return maxClearedFloor
+}


### PR DESCRIPTION
## Summary
- `DungeonProgress` に `maxClearedFloorsByTier` を追加し、SQLite に v16 マイグレーションで永続化
- 結果画面（`result.tsx`）と遠征フロー（`useExpeditionFlow`）でフロア単位のクリア状態を記録
- 遠征時間計算をクリア済みフロアと未クリアフロアで個別に算出するように変更
- `getMaxClearedFloorFromReplay` ヘルパー（リプレイから階末勝利フロアを抽出）と単体テストを追加

## Test plan
- [ ] `npx tsc --noEmit` で型チェックが通ること
- [ ] `npm test -- expeditionClear` でテストが通ること
- [ ] 既存セーブデータからの起動時に v16 マイグレーションが実行され、既クリアダンジョンに `cleared_floors_json` が設定されること
- [ ] 階の途中まで進んで帰還した場合、その階数までがクリア扱いとして保存されること
- [ ] クリア済みフロアの再探索時に時間短縮が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)