### PR TITLE
feat(expedition): 戦闘後のレベルアップ詳細ログ画面を追加

### DIFF
--- a/goblin_native/app/(tabs)/formation/_layout.tsx
+++ b/goblin_native/app/(tabs)/formation/_layout.tsx
@@ -78,6 +78,14 @@ export default function FormationLayout() {
           headerShown: false,
         }}
       />
+      <Stack.Screen
+        name="level-up-log"
+        options={{
+          title: t('ui.formation.layout.levelUpLog'),
+          presentation: 'card',
+          headerShown: false,
+        }}
+      />
     </Stack>
   )
 }

--- a/goblin_native/app/(tabs)/formation/level-up-log.tsx
+++ b/goblin_native/app/(tabs)/formation/level-up-log.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo } from 'react'
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { router, useLocalSearchParams } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { clearLevelUpLog, getLevelUpLog } from '@/presentation/contexts/levelUpLogStore'
+
+export default function LevelUpLogScreen() {
+  const { t } = useTranslation()
+  const { logId } = useLocalSearchParams<{ logId?: string }>()
+
+  const stored = useMemo(() => {
+    if (!logId) return null
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return null
+    return getLevelUpLog(raw)
+  }, [logId])
+
+  useEffect(() => {
+    const raw = Array.isArray(logId) ? logId[0] : logId
+    if (!raw) return undefined
+    return () => {
+      clearLevelUpLog(raw)
+    }
+  }, [logId])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity
+          onPress={() => {
+            if (router.canGoBack()) {
+              router.back()
+              return
+            }
+            router.replace('/formation/playback')
+          }}
+        >
+          <Text style={styles.navBack}>← {t('ui.formation.common.back')}</Text>
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>{t('ui.formation.levelUpLog.title')}</Text>
+        <View style={styles.navSpacer} />
+      </View>
+
+      {!stored && (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>{t('ui.formation.levelUpLog.loadFailed')}</Text>
+        </View>
+      )}
+
+      {stored && (
+        <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
+          {stored.levelUps.map((levelUp, index) => (
+            <View key={`${levelUp.memberName}-${index}`} style={styles.card}>
+              <Text style={styles.memberName}>{levelUp.memberName}</Text>
+              <Text style={styles.levelLine}>Lv{levelUp.oldLevel} → {levelUp.newLevel}</Text>
+
+              <View style={styles.statList}>
+                {levelUp.statChanges.map(change => (
+                  <View key={change.key} style={styles.statRow}>
+                    <Text style={styles.statName}>{t(`ui.stat.${change.key}`)}</Text>
+                    <Text style={styles.statValue}>{change.oldValue} → {change.newValue}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          ))}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F3F4F6',
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    backgroundColor: '#FFFFFF',
+  },
+  navBack: {
+    fontSize: 14,
+    color: '#4B5563',
+  },
+  navTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#111827',
+    flex: 1,
+    textAlign: 'center',
+  },
+  navSpacer: {
+    width: 60,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  body: {
+    flex: 1,
+  },
+  bodyContent: {
+    padding: 12,
+    gap: 10,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    padding: 14,
+  },
+  memberName: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  levelLine: {
+    marginTop: 4,
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#92400E',
+  },
+  statList: {
+    marginTop: 10,
+    gap: 6,
+  },
+  statRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  statName: {
+    fontSize: 14,
+    color: '#374151',
+  },
+  statValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+})

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -7,11 +7,13 @@ import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionStore } from '@/presentation/stores/useExpeditionStore'
-import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason, Party, TreasureDrop } from '@/shared/types'
+import type { TimelineEvent, ExpeditionReplay, ExpeditionRecord, ExpeditionEndReason, Party, TreasureDrop, GoblinBaseAttributes } from '@/shared/types'
 import type { BattleLogEntry, BattleLogMeta } from '@/shared/types'
 import { storeBattleLog } from '@/presentation/contexts/battleLogStore'
+import { storeLevelUpLog, type LevelUpLogDetail, type LevelUpStatChange } from '@/presentation/contexts/levelUpLogStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getEffectiveStats } from '@/shared/utils/goblinStats'
+import { getGoblinBaseAttributesAtLevel } from '@/shared/utils/goblinHp'
 import { getDungeonName, getEquipmentDisplayName } from '@/shared/i18n/entityLocalization'
 import { getEquipmentTemplate } from '@/shared/data/equipmentPoolLoader'
 import { getDungeonTierDisplayName } from '@/shared/types'
@@ -24,7 +26,17 @@ interface LogEntry {
   text: string
   detail?: BattleLogEntry[]
   meta?: BattleLogMeta
+  levelUps?: LevelUpLogDetail[]
 }
+
+const BASE_ATTRIBUTE_KEYS: Array<keyof GoblinBaseAttributes> = [
+  'power',
+  'wisdom',
+  'spirit',
+  'vitality',
+  'agility',
+  'luck',
+]
 
 function resolveTreasureName(item: TreasureDrop): string {
   const template = getEquipmentTemplate(item.templateId)
@@ -130,6 +142,11 @@ export default function ExpeditionPlaybackScreen() {
     router.push(`/formation/battle-log?logId=${encodeURIComponent(logId)}` as Href)
   }, [partyGoblins])
 
+  const openLevelUpLog = useCallback((levelUps: LevelUpLogDetail[]) => {
+    const logId = storeLevelUpLog(levelUps)
+    router.push(`/formation/level-up-log?logId=${encodeURIComponent(logId)}` as Href)
+  }, [])
+
   const getReturnReasonText = useCallback((reason: ExpeditionEndReason) => {
     if (reason === 'completed') return t('ui.formation.playback.completed')
     if (reason === 'defeated') return t('ui.formation.playback.defeated')
@@ -139,9 +156,14 @@ export default function ExpeditionPlaybackScreen() {
   }, [t])
 
   const buildLogEntries = useCallback((event: TimelineEvent): LogEntry[] => {
-    const createEntry = (text: string, detail?: BattleLogEntry[], meta?: BattleLogMeta) => {
+    const createEntry = (
+      text: string,
+      detail?: BattleLogEntry[],
+      meta?: BattleLogMeta,
+      levelUps?: LevelUpLogDetail[],
+    ) => {
       logIdRef.current += 1
-      return { id: `${logIdRef.current}`, text, detail, meta }
+      return { id: `${logIdRef.current}`, text, detail, meta, levelUps }
     }
     switch (event.type) {
       case 'move_start':
@@ -164,7 +186,11 @@ export default function ExpeditionPlaybackScreen() {
           .map((_, index) => index)
           .filter(index => (partyHpRef.current[index] ?? 0) > 0)
         const xpPerMember = aliveIndices.length > 0 ? Math.floor(rewardedXp / aliveIndices.length) : 0
-        const levelUps = new Map<number, { oldLevel: number; newLevel: number }>()
+        const levelUps = new Map<number, {
+          oldLevel: number
+          newLevel: number
+          statChanges: LevelUpStatChange[]
+        }>()
 
         // 各メンバーのEXPボーナス倍率を計算
         const memberExpMultipliers = partyMembers.map((_, idx) => {
@@ -178,6 +204,7 @@ export default function ExpeditionPlaybackScreen() {
           const nextExpState = partyExpRef.current.map(state => ({ ...state }))
           for (const index of aliveIndices) {
             const current = nextExpState[index]
+            const goblin = partyGoblins[index]
             if (!current) continue
 
             const boostedXp = Math.floor(xpPerMember * memberExpMultipliers[index])
@@ -187,9 +214,26 @@ export default function ExpeditionPlaybackScreen() {
               experience: levelUp.remainingExp,
             }
             if (levelUp.didLevelUp) {
+              const oldAttributes = goblin
+                ? getGoblinBaseAttributesAtLevel(goblin, levelUp.oldLevel)
+                : null
+              const newAttributes = goblin
+                ? getGoblinBaseAttributesAtLevel(goblin, levelUp.newLevel)
+                : null
+              const statChanges = oldAttributes && newAttributes
+                ? BASE_ATTRIBUTE_KEYS
+                    .map(key => ({
+                      key,
+                      oldValue: oldAttributes[key],
+                      newValue: newAttributes[key],
+                    }))
+                    .filter(change => change.newValue > change.oldValue)
+                : []
+
               levelUps.set(index, {
                 oldLevel: levelUp.oldLevel,
                 newLevel: levelUp.newLevel,
+                statChanges,
               })
             }
           }
@@ -224,6 +268,19 @@ export default function ExpeditionPlaybackScreen() {
             meta,
           ),
         ]
+        const levelUpDetails = Array.from(levelUps.entries()).map(([idx, levelUp]) => {
+          const memberId = partyMembers[idx]
+          const goblin = partyGoblins[idx]
+          return {
+            memberName: goblin?.name ?? `ID:${memberId}`,
+            oldLevel: levelUp.oldLevel,
+            newLevel: levelUp.newLevel,
+            statChanges: levelUp.statChanges,
+          }
+        })
+        if (levelUpDetails.length > 0) {
+          entries.push(createEntry(t('ui.formation.playback.levelUpTitle'), undefined, undefined, levelUpDetails))
+        }
         if (rewardedXp > 0) {
           entries.push(createEntry(t('ui.formation.playback.xpGain', { value: rewardedXp })))
         }
@@ -567,6 +624,22 @@ export default function ExpeditionPlaybackScreen() {
               )
             }
 
+            if (entry.levelUps) {
+              return (
+                <TouchableOpacity
+                  key={entry.id}
+                  style={styles.logRow}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
+                  onPress={() => openLevelUpLog(entry.levelUps!)}
+                >
+                  <Text style={styles.logText}>{baseText}</Text>
+                  <Text style={styles.logDetail}>{t('ui.formation.playback.detail')}</Text>
+                </TouchableOpacity>
+              )
+            }
+
             return (
               <View key={entry.id} style={styles.logRow}>
                 <Text style={styles.logText}>{baseText}</Text>
@@ -739,5 +812,36 @@ const styles = StyleSheet.create({
     color: '#2563EB',
     fontWeight: '600',
     fontSize: 12,
+  },
+  levelUpLogRow: {
+    flexDirection: 'column',
+    gap: 4,
+    paddingVertical: 4,
+  },
+  levelUpLogTitle: {
+    fontSize: 12,
+    color: '#92400E',
+    fontWeight: '700',
+    fontFamily: 'Courier',
+  },
+  levelUpMemberBlock: {
+    paddingLeft: 12,
+    paddingTop: 2,
+  },
+  levelUpMemberName: {
+    fontSize: 12,
+    color: '#111827',
+    fontWeight: '700',
+    fontFamily: 'Courier',
+  },
+  levelUpLine: {
+    fontSize: 12,
+    color: '#374151',
+    fontFamily: 'Courier',
+  },
+  levelUpStatLine: {
+    fontSize: 12,
+    color: '#4B5563',
+    fontFamily: 'Courier',
   },
 })

--- a/goblin_native/src/presentation/contexts/levelUpLogStore.ts
+++ b/goblin_native/src/presentation/contexts/levelUpLogStore.ts
@@ -1,0 +1,36 @@
+import type { GoblinBaseAttributes } from '@/shared/types'
+
+export interface LevelUpStatChange {
+  key: keyof GoblinBaseAttributes
+  oldValue: number
+  newValue: number
+}
+
+export interface LevelUpLogDetail {
+  memberName: string
+  oldLevel: number
+  newLevel: number
+  statChanges: LevelUpStatChange[]
+}
+
+interface StoredLevelUpLog {
+  levelUps: LevelUpLogDetail[]
+}
+
+const levelUpLogStore = new Map<string, StoredLevelUpLog>()
+let logCounter = 0
+
+export const storeLevelUpLog = (levelUps: LevelUpLogDetail[]): string => {
+  logCounter += 1
+  const id = `${Date.now()}-${logCounter}`
+  levelUpLogStore.set(id, { levelUps })
+  return id
+}
+
+export const getLevelUpLog = (id: string): StoredLevelUpLog | null => {
+  return levelUpLogStore.get(id) ?? null
+}
+
+export const clearLevelUpLog = (id: string): void => {
+  levelUpLogStore.delete(id)
+}

--- a/goblin_native/src/shared/i18n/resources/en.ts
+++ b/goblin_native/src/shared/i18n/resources/en.ts
@@ -305,6 +305,7 @@ const en = {
         result: 'Expedition Result',
         log: 'Expedition Log',
         battleLog: 'Battle Log',
+        levelUpLog: 'Level Up Details',
       },
       common: {
         back: 'Back',
@@ -449,6 +450,7 @@ const en = {
         win: 'Win',
         lose: 'Lose',
         encounter: '{{label}} encountered {{enemy}} Lv{{level}} x{{count}} -> {{result}}[Detail]',
+        levelUpTitle: 'Level up!',
         xpGain: 'Gained {{value}} XP',
         treasureFound: 'Found a treasure chest!',
         treasureItem: 'Contained {{name}}!',
@@ -491,6 +493,10 @@ const en = {
         xpLine: 'Exp +{{totalXp}} {{name}} ({{baseXp}} x {{multiplier}}x)',
         levelUpLine: 'Level up! Lv{{oldLevel}} -> Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
+      },
+      levelUpLog: {
+        title: 'Level Up Details',
+        loadFailed: 'Could not load the level up details.',
       },
       log: {
         title: 'Expedition Log',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -305,6 +305,7 @@ const ja = {
         result: '遠征結果',
         log: '遠征ログ',
         battleLog: '戦闘ログ',
+        levelUpLog: 'レベルアップ詳細',
       },
       common: {
         back: '戻る',
@@ -449,6 +450,7 @@ const ja = {
         win: '勝利',
         lose: '敗北',
         encounter: '{{label}} {{enemy}} Lv{{level}} ×{{count}}体と遭遇 → {{result}}[詳細]',
+        levelUpTitle: 'レベルアップ！',
         xpGain: '{{value}}XP獲得',
         treasureFound: '宝箱を発見！',
         treasureItem: '{{name}}が入っていた！',
@@ -491,6 +493,10 @@ const ja = {
         xpLine: 'Exp +{{totalXp}} {{name}} ({{baseXp}} x {{multiplier}}倍)',
         levelUpLine: 'レベルアップ！ Lv{{oldLevel}} → Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
+      },
+      levelUpLog: {
+        title: 'レベルアップ詳細',
+        loadFailed: 'レベルアップ詳細を読み込めませんでした。',
       },
       log: {
         title: '遠征ログ',

--- a/goblin_native/src/shared/i18n/resources/ko.ts
+++ b/goblin_native/src/shared/i18n/resources/ko.ts
@@ -304,6 +304,7 @@ const ko = {
         result: '원정 결과',
         log: '원정 로그',
         battleLog: '전투 로그',
+        levelUpLog: '레벨 업 상세',
       },
       common: {
         back: '뒤로',
@@ -440,6 +441,7 @@ const ko = {
         win: '승리',
         lose: '패배',
         encounter: '{{label}} {{enemy}} Lv{{level}} x{{count}}체와 조우 -> {{result}}[상세]',
+        levelUpTitle: '레벨 업!',
         xpGain: '{{value}}XP 획득',
         treasureFound: '보물상자를 발견!',
         treasureItem: '{{name}}이 들어 있었다!',
@@ -482,6 +484,10 @@ const ko = {
         xpLine: 'Exp +{{totalXp}} {{name}} ({{baseXp}} x {{multiplier}}배)',
         levelUpLine: '레벨 업! Lv{{oldLevel}} -> Lv{{newLevel}}',
         memberLine: '({{hp}}/{{maxHp}}) {{name}} Lv{{level}}',
+      },
+      levelUpLog: {
+        title: '레벨 업 상세',
+        loadFailed: '레벨 업 상세를 불러올 수 없습니다.',
       },
       log: {
         title: '원정 로그',


### PR DESCRIPTION
## Summary
- 戦闘後のレベルアップを集計し、各メンバーのレベル変化・上昇したベース能力値を確認できる詳細ログ画面 (`/formation/level-up-log`) を追加
- 遠征再生画面のログ行から詳細画面に遷移できるよう、`playback.tsx` にエントリ生成と遷移処理を追加
- 詳細ログを画面間で受け渡すための軽量メモリストア `levelUpLogStore` を新設
- 関連 i18n リソース（ja / en / ko）に新画面のタイトル・読み込み失敗メッセージ、レベルアップタイトルを追加

## Test plan
- [ ] 遠征を再生し、戦闘後にレベルアップが発生したケースでログに「レベルアップ！」行が表示されること
- [ ] その行をタップすると新画面に遷移し、メンバーごとに Lv 変化と上昇したベース能力値（power/wisdom/spirit/vitality/agility/luck）が表示されること
- [ ] ログ画面で戻る操作が問題なく動作すること
- [ ] レベルアップが発生しない戦闘ではレベルアップ行が出現しないこと
- [ ] ja / en / ko 各言語で文言が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)