### PR TITLE
fix(base): 拠点ランクアップ解放条件を統合後のエリアIDに修正

### DIFF
--- a/goblin_native/src/core/services/BaseRankSystem.ts
+++ b/goblin_native/src/core/services/BaseRankSystem.ts
@@ -19,7 +19,7 @@ export const BASE_RANK_CONFIGS: BaseRankConfig[] = [
     ivBonus: 2,
     upgradeCost: 100,  // ランク2への引っ越し資金
     unlockCondition: {
-      dungeonId: 'goblin_village_3',  // ゴブリン集落・中枢
+      dungeonId: 'goblin_village_1',  // ゴブリン集落
       clearCount: 1,
     },
   },
@@ -52,7 +52,7 @@ export const BASE_RANK_CONFIGS: BaseRankConfig[] = [
     ivBonus: 8,
     upgradeCost: 4000,
     unlockCondition: {
-      dungeonId: 'human_fortress_3',
+      dungeonId: 'human_fortress_1',
       clearCount: 1,
     },
   },

--- a/goblin_native/src/shared/data/__tests__/expeditionArea.test.ts
+++ b/goblin_native/src/shared/data/__tests__/expeditionArea.test.ts
@@ -1,4 +1,5 @@
 import { areasData } from '..'
+import { BASE_RANK_CONFIGS } from '../../../core/services/BaseRankSystem'
 import { getEnemyDatabase } from '../enemy'
 import { getAreaConfig } from '../expeditionArea'
 
@@ -25,6 +26,14 @@ describe('expedition areas', () => {
       for (const targetId of unlockTargets) {
         expect(areaIds.has(targetId)).toBe(true)
       }
+    }
+  })
+
+  it('拠点ランクアップ条件が統合後の制圧対象エリアIDと一致している', () => {
+    for (const area of areasData.filter(area => area.isBaseCapture)) {
+      const rankConfig = BASE_RANK_CONFIGS.find(config => config.rank === area.rankUpTarget)
+
+      expect(rankConfig?.unlockCondition.dungeonId).toBe(area.id)
     }
   })
 


### PR DESCRIPTION
## 概要

ゴブリン集落・人間要塞のエリアID統合に伴い、拠点ランクアップの解放条件 `dungeonId` を修正しました。

## 変更内容

- `BaseRankSystem.ts`: ランクアップ解放条件の `dungeonId` を統合後のエリアIDに修正
  - `goblin_village_3` → `goblin_village_1`
  - `human_fortress_3` → `human_fortress_1`
- `expeditionArea.test.ts`: 拠点ランクアップ解放条件IDが制圧対象エリアIDと一致することを検証するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)