### PR TITLE
feat(balance): 純ゴブリンの経験値倍率スキル削除とマルクの+40%調整

### DIFF
--- a/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
+++ b/goblin_native/src/core/services/__tests__/GoblinBirthService.test.ts
@@ -282,7 +282,6 @@ describe('GoblinBirthService', () => {
       expect(goblin.factors).toEqual(['wolf'])
       expect(goblin.skills.map((skill) => skill.id)).toEqual([
         'goblin_pack_tactics',
-        'exp_bonus_70',
         'talent_accuracy_150',
         'attack_count_up_2',
         'equipment_accuracy_200',

--- a/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
+++ b/goblin_native/src/shared/data/__tests__/characterSkills.test.ts
@@ -561,7 +561,7 @@ describe('characterSkills - 物理ダメージ軽減', () => {
   it('純粋なゴブリンのデフォルトスキルに群れを含める', () => {
     expect(getDefaultSkillsForRace('ゴブリン').map((skill) => skill.id)).toContain('goblin_pack_tactics')
     expect(getDefaultSkillsForRace('始祖ゴブリン').map((skill) => skill.id)).toEqual(
-      expect.arrayContaining(['exp_bonus_70', 'goblin_pack_tactics']),
+      expect.arrayContaining(['exp_bonus_40', 'goblin_pack_tactics']),
     )
     expect(getDefaultSkillsForRace('ウルフゴブリン').map((skill) => skill.id)).not.toContain('goblin_pack_tactics')
   })

--- a/goblin_native/src/shared/data/founderGoblin.ts
+++ b/goblin_native/src/shared/data/founderGoblin.ts
@@ -38,7 +38,7 @@ export const founderGoblinSeed: FounderGoblinSeed = {
     evasion: 15
   },
   defaultSkillIds: [
-    "exp_bonus_70",
+    "exp_bonus_40",
     "goblin_pack_tactics",
     "factor_drop_bonus_50"
   ]

--- a/goblin_native/src/shared/data/pureGoblin.ts
+++ b/goblin_native/src/shared/data/pureGoblin.ts
@@ -17,7 +17,6 @@ export const pureGoblinSeed: PureGoblinSeed = {
   },
   hpCoefficient: 0.8,
   defaultSkillIds: [
-    "exp_bonus_70",
     "goblin_pack_tactics"
   ]
 }

--- a/goblin_native/src/shared/data/races.ts
+++ b/goblin_native/src/shared/data/races.ts
@@ -83,7 +83,7 @@ export const races: RaceDict = {
       "goblin"
     ],
     skillIds: [
-      "exp_bonus_70"
+      "exp_bonus_40"
     ]
   },
   human: {

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -734,6 +734,11 @@ export const CHARACTER_SKILL_CATALOG = {
     expBonusPercent: 30,
   },
 
+  exp_bonus_40: {
+    id: 'exp_bonus_40',
+    expBonusPercent: 40,
+  },
+
   exp_bonus_50: {
     id: 'exp_bonus_50',
     expBonusPercent: 50,

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -806,6 +806,7 @@ const ja = {
       survive_lethal_hp1: { name: '気合い' },
       exp_bonus_10: { name: '[+10%]獲得経験値' },
       exp_bonus_30: { name: '[+30%]獲得経験値' },
+      exp_bonus_40: { name: '[+40%]獲得経験値' },
       exp_bonus_50: { name: '[+50%]獲得経験値' },
       exp_bonus_60: { name: '[+60%]獲得経験値' },
       exp_bonus_70: { name: '[+70%]獲得経験値' },


### PR DESCRIPTION
## 概要

ゴブリンの経験値倍率スキルのバランス調整です。

## 変更内容

### 純ゴブリン: 経験値倍率+70% を削除
- `pureGoblin.ts` のデフォルトスキルから `exp_bonus_70` を削除（`goblin_pack_tactics` のみに）

### マルク（始祖ゴブリン）: 経験値倍率を +70% → +40% に変更
- `founderGoblin.ts` の個体デフォルトスキルを `exp_bonus_70` → `exp_bonus_40`
- `races.ts` の `founder` 種族スキルを `exp_bonus_70` → `exp_bonus_40`
  - マルクは種族スキルと個体スキルの両方に持っていたため両方を修正

### 新スキルの追加
- `skillCatalog.ts` に `exp_bonus_40`（`expBonusPercent: 40`）を追加
- `ja.ts` に `[+40%]獲得経験値` の表示名を追加

### テスト
- `GoblinBirthService.test.ts` — 純ゴブリン生成時の期待スキルから `exp_bonus_70` を削除
- `characterSkills.test.ts` — 始祖ゴブリンのデフォルトスキル期待値を `exp_bonus_40` に変更

## 確認

- `npx tsc --noEmit` 通過
- 関連テスト（characterSkills / GoblinBirthService）108件 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)