### PR TITLE
fix(ui): 各画面のスクロール末尾が下部情報バッジに隠れないよう余白を追加

### DIFF
--- a/goblin_native/app/(tabs)/base.tsx
+++ b/goblin_native/app/(tabs)/base.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { useBaseStore, selectRank, selectMaxParties, selectMaxGoblins, selectCanRankUp } from '@/presentation/stores/useBaseStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { GOBLIN_TRAINING_UNLOCK_RANK } from '@/shared/data/goblinJobs'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { getBaseLocationName } from '@/shared/i18n/entityLocalization'
 import CapacityIcon from '../../assets/base/icon-capacity.svg'
 import EquipmentShopIcon from '../../assets/base/icon-equipment-shop.svg'
@@ -195,7 +196,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   contentContainer: {
-    paddingBottom: 88,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   header: {
     minHeight: 264,

--- a/goblin_native/app/(tabs)/encyclopedia.tsx
+++ b/goblin_native/app/(tabs)/encyclopedia.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { getDungeonName } from '@/shared/i18n/entityLocalization'
 
 export default function EncyclopediaDungeonListScreen() {
@@ -81,7 +82,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 12,
     gap: 8,
-    paddingBottom: 32,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   dungeonCard: {
     backgroundColor: '#FFFFFF',

--- a/goblin_native/app/(tabs)/formation/battle-log.tsx
+++ b/goblin_native/app/(tabs)/formation/battle-log.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import type { BattleLogEntry, BattleLogMeta, Goblin } from '@/shared/types'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { getBattleLog, clearBattleLog } from '@/presentation/contexts/battleLogStore'
 import { getGoblinBattleImage, getGoblinDisplayImageScale } from '@/shared/utils/goblinImages'
 import { getEnemyImage } from '@/shared/utils/enemyImages'
@@ -386,6 +387,7 @@ const styles = StyleSheet.create({
   bodyContent: {
     padding: 12,
     gap: 10,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   emptyState: {
     flex: 1,

--- a/goblin_native/app/(tabs)/formation/edit.tsx
+++ b/goblin_native/app/(tabs)/formation/edit.tsx
@@ -3,6 +3,7 @@ import { View, Text, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator, 
 import { router, useLocalSearchParams, Stack } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useTutorialStore } from '@/presentation/stores/useTutorialStore'
 import { useTutorialTarget } from '@/presentation/hooks/useTutorialTarget'
@@ -271,7 +272,7 @@ export default function PartyEditScreen() {
           title: t('ui.formation.edit.title'),
         }}
       />
-      <ScrollView style={styles.container}>
+      <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: BOTTOM_INFO_SPACING }}>
         {/* パーティメンバースロット */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>{t('ui.formation.edit.memberSlotsTitle', { max: MAX_PARTY_SIZE })}</Text>

--- a/goblin_native/app/(tabs)/formation/equipment-list.tsx
+++ b/goblin_native/app/(tabs)/formation/equipment-list.tsx
@@ -4,6 +4,7 @@ import { Stack, router, useLocalSearchParams } from 'expo-router'
 import { useFocusEffect } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { SQLiteEquipmentRepository } from '@/infrastructure/repositories/SQLiteEquipmentRepository'
 import { EquipmentService } from '@/core/services/EquipmentService'
@@ -227,6 +228,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 16,
     gap: 12,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   loadingContainer: {
     flex: 1,

--- a/goblin_native/app/(tabs)/formation/index.tsx
+++ b/goblin_native/app/(tabs)/formation/index.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, Stack } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useExpeditionFlow, type ExpeditionHistoryDisplay } from '@/presentation/hooks/useExpeditionFlow'
@@ -549,7 +550,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     paddingHorizontal: 16,
     paddingTop: 8,
-    paddingBottom: 48,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   prepTitle: {
     fontSize: 14,

--- a/goblin_native/app/(tabs)/formation/level-up-log.tsx
+++ b/goblin_native/app/(tabs)/formation/level-up-log.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { clearLevelUpLog, getLevelUpLog } from '@/presentation/contexts/levelUpLogStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 
 export default function LevelUpLogScreen() {
   const { t } = useTranslation()
@@ -116,6 +117,7 @@ const styles = StyleSheet.create({
   bodyContent: {
     padding: 12,
     gap: 10,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   card: {
     backgroundColor: '#FFFFFF',

--- a/goblin_native/app/(tabs)/formation/log.tsx
+++ b/goblin_native/app/(tabs)/formation/log.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { getDungeonName } from '@/shared/i18n/entityLocalization'
 
@@ -222,6 +223,7 @@ const styles = StyleSheet.create({
   backButton: {
     backgroundColor: '#374151',
     margin: 16,
+    marginBottom: BOTTOM_INFO_SPACING,
     padding: 16,
     borderRadius: 12,
     alignItems: 'center',

--- a/goblin_native/app/(tabs)/formation/party-info.tsx
+++ b/goblin_native/app/(tabs)/formation/party-info.tsx
@@ -4,6 +4,7 @@ import { Stack, router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
 import { getFactorImage } from '@/shared/utils/factorImages'
 import { calculateGoblinEffectiveStats, getEffectiveStats } from '@/shared/utils/goblinStats'
@@ -440,7 +441,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 16,
     gap: 16,
-    paddingBottom: 88,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   loadingContainer: {
     flex: 1,

--- a/goblin_native/app/(tabs)/formation/playback.tsx
+++ b/goblin_native/app/(tabs)/formation/playback.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams, type Href } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
 import { useExpeditionStore } from '@/presentation/stores/useExpeditionStore'
@@ -605,7 +606,7 @@ export default function ExpeditionPlaybackScreen() {
       </View>
 
       <View style={styles.eventLog}>
-        <ScrollView style={styles.logScroll}>
+        <ScrollView style={styles.logScroll} contentContainerStyle={{ paddingBottom: BOTTOM_INFO_SPACING }}>
           {eventLog.map(entry => {
             const baseText = entry.text.replace('[Detail]', '').replace('[詳細]', '').replace('[상세]', '')
             if (entry.detail) {

--- a/goblin_native/app/(tabs)/formation/preparation.tsx
+++ b/goblin_native/app/(tabs)/formation/preparation.tsx
@@ -3,6 +3,7 @@ import { View, Text, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator
 import { router, useLocalSearchParams, Stack, useFocusEffect } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
 import { useBaseStore, selectRank } from '@/presentation/stores/useBaseStore'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
@@ -513,7 +514,7 @@ export default function ExpeditionPreparationScreen() {
           title: t('ui.formation.preparation.title'),
         }}
       />
-      <ScrollView style={styles.container}>
+      <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: BOTTOM_INFO_SPACING }}>
         {/* パーティセクション */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>{t('ui.formation.preparation.sectionParty')}</Text>

--- a/goblin_native/app/(tabs)/formation/result.tsx
+++ b/goblin_native/app/(tabs)/formation/result.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useDungeonStore } from '@/presentation/stores/useDungeonStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useExpeditionStore } from '@/presentation/stores/useExpeditionStore'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
 import { getGoblinDisplayImage } from '@/shared/utils/goblinImages'
@@ -274,7 +275,7 @@ export default function ExpeditionResultScreen() {
         <View style={styles.navSpacer} />
       </View>
 
-      <ScrollView style={styles.scrollView}>
+      <ScrollView style={styles.scrollView} contentContainerStyle={{ paddingBottom: BOTTOM_INFO_SPACING }}>
         <View style={styles.headerSection}>
           <Text style={styles.headerTitle}>
             {dungeonDisplayName ?? t('ui.result.expeditionFallback')}: {getHeaderText()}

--- a/goblin_native/app/(tabs)/index.tsx
+++ b/goblin_native/app/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
 import { useGoblinStore } from '@/presentation/stores/useGoblinStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useBaseStore, selectMaxGoblins, selectRank } from '@/presentation/stores/useBaseStore'
 import { usePartyStore } from '@/presentation/stores/usePartyStore'
 import { GoblinCard } from '@/presentation/components/GoblinCard'
@@ -868,7 +869,7 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
   },
   scrollContent: {
-    paddingBottom: 32,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   cardWrapper: {
     backgroundColor: '#F9FAFB',

--- a/goblin_native/app/(tabs)/settings.tsx
+++ b/goblin_native/app/(tabs)/settings.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useReset } from '@/presentation/contexts/ResetContext'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 import { useDebugSettingsStore } from '@/presentation/stores/useDebugSettingsStore'
 import { useSaveDataBackup } from '@/presentation/hooks/useSaveDataBackup'
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '@/shared/i18n/keys'
@@ -243,7 +244,7 @@ const styles = StyleSheet.create({
   content: {
     padding: 16,
     gap: 16,
-    paddingBottom: 32,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   section: {
     backgroundColor: '#FFFFFF',

--- a/goblin_native/app/(tabs)/story/index.tsx
+++ b/goblin_native/app/(tabs)/story/index.tsx
@@ -5,6 +5,7 @@ import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
 import { useTutorialTarget } from '@/presentation/hooks/useTutorialTarget'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 
 export default function StoryTabScreen() {
   const { t } = useTranslation()
@@ -98,7 +99,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     padding: 16,
     paddingTop: 0,
-    paddingBottom: 88,
+    paddingBottom: BOTTOM_INFO_SPACING,
     gap: 4,
   },
   screenTitle: {

--- a/goblin_native/app/(tabs)/story/reader.tsx
+++ b/goblin_native/app/(tabs)/story/reader.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { router, useLocalSearchParams } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { useStoryStore } from '@/presentation/stores/useStoryStore'
+import { BOTTOM_INFO_SPACING } from '@/shared/constants/layout'
 
 export default function StoryReaderScreen() {
   const { t } = useTranslation()
@@ -187,7 +188,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     padding: 24,
-    paddingBottom: 48,
+    paddingBottom: BOTTOM_INFO_SPACING,
   },
   storyTitle: {
     fontSize: 22,

--- a/goblin_native/src/shared/constants/layout.ts
+++ b/goblin_native/src/shared/constants/layout.ts
@@ -1,0 +1,4 @@
+// 画面下部には時刻・ゴールド・金のどんぐり・TIPS バッジが固定で重ねて表示される。
+// 各画面のスクロール内容の末尾がこれらの裏に隠れないよう、スクロール領域
+// (ScrollView/FlatList の contentContainerStyle 等) の下部にこの分の余白を入れる。
+export const BOTTOM_INFO_SPACING = 88


### PR DESCRIPTION
## 概要

画面下部に固定で重ねて表示される **時刻 / ゴールド / 金のどんぐり / TIPS バッジ** の裏に、各画面でスクロールした際の末尾コンテンツが隠れてしまう問題を修正しました。

「画面下部の要素はそのまま」にして、**各画面のスクロール内容の下に固定マージンを追加**する方式です（`base.tsx` が元々行っていたパターンに全画面を統一）。

## 変更内容

- 共通定数 `BOTTOM_INFO_SPACING`（= 88）を `src/shared/constants/layout.ts` に新設
- タブ配下でバッジが重なる各スクロール画面の `contentContainerStyle` 下部余白を、この定数に統一・追加
  - 一覧 / 拠点 / 図鑑 / 設定 / ストーリー（一覧・本文）
  - 編成（一覧・編集・装備一覧・パーティ情報・準備・結果）
  - 遠征フロー（ログ・バトルログ・再生・レベルアップログ）
- 遠征ログの固定「戻る」ボタンは下マージンで対応

## 補足

- 装備ショップ・ゴブリン詳細など `(tabs)` 外（ルート Stack）の画面はバッジが表示されないため変更なし
- グローバルな `sceneStyle` は変更していません（一旦試した変更は revert 済み）
- `npx tsc --noEmit` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)