### PR TITLE
feat(expedition): シミュレーション時間がTier相当に伸びてもフロアイベント密度を維持

### DIFF
--- a/goblin_native/src/core/services/ExpeditionEngine.ts
+++ b/goblin_native/src/core/services/ExpeditionEngine.ts
@@ -534,7 +534,11 @@ export class ExpeditionEngine {
     const floorDuration = totalDuration / explorationFloors
     const floorStart = (floor - 1) * floorDuration
     const floorEnd = floorStart + floorDuration
-    const eventIntervalSec = Math.max(1, area.encounter.eventIntervalSec ?? floorDuration)
+    const baseDurationForFloors = area.baseDurationSec * (explorationFloors / area.floors)
+    const durationScale = baseDurationForFloors > 0
+      ? Math.max(1, totalDuration / baseDurationForFloors)
+      : 1
+    const eventIntervalSec = Math.max(1, (area.encounter.eventIntervalSec ?? floorDuration) * durationScale)
     const events: Array<{ at: number; isFloorEnd: boolean }> = []
 
     for (let at = floorStart + eventIntervalSec; at < floorEnd; at += eventIntervalSec) {

--- a/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
+++ b/goblin_native/src/core/services/__tests__/ExpeditionEngine.test.ts
@@ -524,6 +524,42 @@ describe('ExpeditionEngine compressed duration', () => {
     expect(Math.max(...replay.events.map(event => event.at))).toBeLessThanOrEqual(1)
     expect(floorEventCount).toBeGreaterThan(2)
   })
+
+  it('シミュレーション時間がTier相当に伸びてもフロアイベント数を増やさない', async () => {
+    const battleSystem = {
+      executeBattle: jest.fn(() => ({
+        rounds: 1,
+        outcome: 'win',
+        allyHPDelta: [0],
+        enemyDefeated: 1,
+        detailedLog: [],
+      })),
+    }
+
+    const createReplay = (durationSec: number) => new ExpeditionEngine(1, battleSystem as any).generateExpedition(
+      {
+        partyId: '1',
+        areaId: 'slime_cave',
+        returnPolicy: 'never',
+        clientVersion: 'test',
+        durationSec,
+        simulationDurationSec: durationSec,
+      },
+      party,
+      DEFAULT_PARTY_REWARD_MULTIPLIERS,
+    )
+
+    const baseReplay = await createReplay(30)
+    const tierReplay = await createReplay(570)
+
+    const countFloorEvents = (events: TimelineEvent[]) => events.filter(
+      event => event.type === 'battle' || event.type === 'exploring' || event.type === 'gold_treasure',
+    ).length
+
+    expect(tierReplay.durationSec).toBe(570)
+    expect(tierReplay.meta.baseDurationSec).toBe(570)
+    expect(countFloorEvents(tierReplay.events)).toBe(countFloorEvents(baseReplay.events))
+  })
 })
 
 describe('ExpeditionEngine combat stats', () => {

--- a/tools/studio/src/lib/runExpedition.ts
+++ b/tools/studio/src/lib/runExpedition.ts
@@ -1,4 +1,5 @@
 import { ExpeditionEngine } from '@app/core/services/ExpeditionEngine'
+import { computeDungeonExplorationTime } from '@app/shared/types'
 import type {
   Goblin,
   GoblinStats,
@@ -6,10 +7,19 @@ import type {
   ExpeditionRequest,
   DungeonTier,
 } from '@app/shared/types'
+import allAreaData from '@app/shared/data/expeditionArea/allArea.json'
 
 import type { BackupGoblin, BackupGoblinStats } from './goblinMapper'
 
 export type ReturnPolicy = ExpeditionRequest['returnPolicy']
+
+type AreaDurationMeta = {
+  id: string
+  exploration_time_sec_first?: number
+  exploration_time_sec?: number
+}
+
+const AREA_DURATION_META = (allAreaData as { areas?: AreaDurationMeta[] }).areas ?? []
 
 const DEFAULT_STATS: GoblinStats = {
   hp: 0,
@@ -22,6 +32,18 @@ const DEFAULT_STATS: GoblinStats = {
   evasion: 0,
   magicHeal: 0,
   criticalRate: 0,
+}
+
+function getSimulationDurationSec(areaId: string, tier: DungeonTier | undefined): number | undefined {
+  const area = AREA_DURATION_META.find((entry) => entry.id === areaId)
+  if (!area || area.exploration_time_sec_first === undefined) return undefined
+  return computeDungeonExplorationTime(
+    areaId,
+    area.exploration_time_sec_first,
+    area.exploration_time_sec ?? area.exploration_time_sec_first,
+    tier ?? 0,
+    false,
+  )
 }
 
 function fillStats(partial: BackupGoblinStats | undefined): GoblinStats {
@@ -103,12 +125,15 @@ export async function runSimulationBatch(
   } = opts
 
   const goblinParty = party.map(backupGoblinToGoblin)
+  const durationSec = getSimulationDurationSec(areaId, tier)
   const baseRequest: ExpeditionRequest = {
     partyId: 'studio',
     areaId,
     tier,
     returnPolicy,
     clientVersion: 'studio',
+    durationSec,
+    simulationDurationSec: durationSec,
   }
 
   let successCount = 0
@@ -209,12 +234,15 @@ export async function runSingleExpedition(
   const trialSeed =
     seed !== undefined ? seed : Math.floor(Math.random() * 0x7fffffff)
   const goblinParty = party.map(backupGoblinToGoblin)
+  const durationSec = getSimulationDurationSec(areaId, tier)
   const baseRequest: ExpeditionRequest = {
     partyId: 'studio',
     areaId,
     tier,
     returnPolicy,
     clientVersion: 'studio',
+    durationSec,
+    simulationDurationSec: durationSec,
   }
   const engine = new ExpeditionEngine(trialSeed)
   const replay = await engine.generateExpedition(baseRequest, goblinParty)


### PR DESCRIPTION
## 概要

遠征のシミュレーション時間（`simulationDurationSec`）がTier相当に長くなった場合でも、フロアあたりのイベント数が増えないように調整しました。

## 変更内容

- `ExpeditionEngine.ts`
  - `eventIntervalSec` を `baseDurationSec` に対する実行時間の倍率（`durationScale`）でスケールするよう変更。これによりシミュレーション時間が伸びてもフロアイベント密度を一定に保つ。
- `tools/studio/src/lib/runExpedition.ts`
  - studio の遠征シミュレーションでも Tier に応じた探索時間（`computeDungeonExplorationTime`）を `durationSec` / `simulationDurationSec` として request に渡すよう対応。
- `ExpeditionEngine.test.ts`
  - シミュレーション時間がTier相当に伸びてもフロアイベント数が増えないことを検証するテストを追加。

## テスト

- `npx jest src/core/services/__tests__/ExpeditionEngine.test.ts` → 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)