### PR TITLE
feat(items): 参考ゲーム由来スキルでレア再設計＋戦闘ロジック実装

### DIFF
--- a/goblin_native/docs/rare_item_design.md
+++ b/goblin_native/docs/rare_item_design.md
@@ -1,6 +1,6 @@
 # レアアイテム設計 進捗ログ
 
-参考ゲーム「冒険者ギルド物語2」の設計思想(複合効果＋トレードオフ／同一効果の段階ID差し替えでレア度スケール)を参考に、レアアイテムのステータス・スキルを **ドロップ元ダンジョンの Tier と floor難易度に応じて** 設計する作業の記録。方法論の土台は [`balance_simulation.md`](./balance_simulation.md)、エリア難易度は `scripts/balance/out/tierSweep.csv`。
+参考ゲームの設計思想(複合効果＋トレードオフ／同一効果の段階ID差し替えでレア度スケール)を参考に、レアアイテムのステータス・スキルを **ドロップ元ダンジョンの Tier と floor難易度に応じて** 設計する作業の記録。方法論の土台は [`balance_simulation.md`](./balance_simulation.md)、エリア難易度は `scripts/balance/out/tierSweep.csv`。
 
 ---
 
@@ -67,7 +67,66 @@
 
 ### 最終状態
 - レア総数 **242** / 設計済み(配線済み)**216** / 未配線26(店売り18＋ボス保留8)。
-- 残り1ペア(shield_rare_012/018)完全一致、`physical_damage`序盤強度は後日バランス調整。
+- 完全一致は `armor_rare_006/018`(ボス固定・保留)のみ(§3.5 の第2次再設計で 7組→1組に削減)。
+- `physical_damage`序盤強度は後日バランス調整。
+- 参考ゲーム由来の新スキル群を band ゲート付きで配線済み(§3.5)。**戦闘ロジックも全実装済み**(§4)。残タスクは敵専用スキル3種の敵JSON配線。
+
+## 3.5 参考ゲーム由来スキルの導入(2026-07-10 第2次再設計)
+
+初回再設計(#318)が既存カタログスキルのみで構成されていた反省から、参考ゲームの実データ
+(ローカル参照のスキルデータ 1,895件 / 装備データ 998件)を再分析し、
+**流用可能なスキル概念を翻案**(名称・数値は変更、コピーはしない)してレアに配線した。
+
+**仕分け方法**: 参考の全スキルを573ファミリーに正規化し、items.json の付与状況で
+「一般装備(店売り/汎用)」「NPC/私物専用(固有キャラ・ボス級)」「アイテム付与なし(職業/敵専用)」に分類。
+一般装備で入手できた概念はプレイヤー側レアに、NPC専用級・ボス級の概念は敵専用スキルとして翻案した。
+
+### 導入したプレイヤー側スキル(band解禁ゲート付き)
+
+| 新ID | 名称 | 効果(翻案) | 参考元 | 解禁band |
+|---|---|---|---|---|
+| `lifesteal_5/8/12` | 吸血 | 与ダメのN%回復(上限:最大HP25%/回) | 吸収能力Lv1-3 | C/D/E |
+| `hp_degen_5/10` | 血の代償 | ターン終了時HP N%減少(トレードオフ用) | HPダメージLvN | E(強スキルの対価) |
+| `party_heal_regen_10/20` | 癒しの霊気 | ターン終了時、味方全員を魔法回復量のN%回復 | 全体回復LvN | B/D |
+| `battle_fervor_4/6` | 闘志 | 攻撃行動ごとに与ダメ+N%(上限40/60%) | 激闘 | C/D |
+| `mana_surge_4/6` | 魔力高揚 | ターン経過ごとに魔法攻撃力+N%(上限40/60%) | トランス(速度上昇は削除) | C/D |
+| `mighty_blow_180` | 渾身の一撃 | 攻撃回数1のとき攻撃力1.8倍 | 一撃必殺(2.0→1.8に調整) | C |
+| `deadeye_200` | 精密照準 | 攻撃回数1のとき命中2倍 | 精密射撃 | B |
+| `ward_physical_2/3` | 物理障壁 | 敵の攻撃をN回1/3に軽減(PT保護) | 物理結界LvN | B/D |
+| `ward_magic_2/3` | 魔法障壁 | 敵の魔法をN回1/3に軽減(PT保護) | 魔法結界LvN | C/D |
+| `war_cry_1_2/1_3` | 鬨の声 | PT全員の攻撃ダメージ1.2/1.3倍(重複無効) | 単騎突撃/指揮 | D/E |
+| `pursuit_30` | 追い打ち | 敵撃破時30%で再攻撃 | 殺意/闘争心 | C |
+| `crit_guard_30/50` | 急所守り | 必殺被ダメN%軽減 | クリティカル・ガード | B/D |
+| `pierce_guard_30/50` | 対貫通装甲 | 追加ダメージ被ダメN%軽減 | 貫通防御 | B/D |
+| `action_order_200` | [戦術]神速 | 行動順速さ2.0倍 | 高速行動 | D |
+| `bulwark_stance_30` | 城塞の構え | 攻撃回数半減→半減回数×30防御力 | 攻撃回数→防御力 | D |
+| `mystic_stance_30` | 魔導の構え | 攻撃回数半減→半減回数×30魔法攻撃力 | 攻撃回数→魔法攻撃力 | D |
+| `spell_siphon_30` | 魔力簒奪 | 通常攻撃時30%で使用済み魔法1回復 | 魔力吸収(NPC級→E/T3限定で許可) | E/T3 |
+| `frost_nova_t4` | 氷霧の大渦 | 4ターン目開始時、敵全体に魔攻150%魔法 | フロストノヴァ(Lv99級→T3限定) | E/T3 |
+
+- **配線結果**: 83箇所(77件の一括注入＋重複解消・テーマ整合の個別調整6件)。
+  既存の汎用フィラー枠(`base_*_up_*`)を差し替える方式でスキル総数は維持
+  (トレードオフ2件のみ `battle_fervor_6`+`hp_degen_5` で+1)。
+- **条件スキルの配線先**は攻撃回数マイナスの一撃型装備(狩猟弓/アサシンボウ/鍬槍 等)に限定し、シナジーを保証。
+- **テーマ整合の個別調整**: 再生肉→`hp_regen_10`、遠見の矢羽→`deadeye_200`、裏道の鍵→`action_order_200`、
+  奪魔のロッド→`spell_siphon_30`、怨声の指輪→`pursuit_30`。
+- **コピペ解消**: HEAD時点で残っていた完全一致7組(進捗ログの「残り1ペア」は過小計上)を1組まで削減。
+  残る `armor_rare_006/018` はボス固定装備(保留8件)のため次回対応。
+- **検証**: `tsc` clean / 全32スイート536テスト合格 / round-trip差分ゼロ / 完全一致 7→1組。
+
+### 敵専用スキル(装備には付与しない)
+
+参考ゲームのボス/敵専用級の概念はカタログに敵専用として翻案登録済み(戦闘ロジック実装済み。**敵JSONへの配線は未着手**、`enemy/*.json` の `skills` にIDを追加すれば有効):
+
+| 新ID | 名称 | 効果 | 参考元 |
+|---|---|---|---|
+| `enemy_royal_pressure_30` | 王の威圧 | 自分よりLvが低い相手からの被ダメ30%軽減 | 君臨 |
+| `enemy_chain_reattack_30` | 連撃衝動 | 攻撃後30%で再攻撃を繰り返す | 無双連撃 |
+| `enemy_thunder_call` | 招雷の角 | 毎ターン開始時、敵全体に魔攻60%の雷撃 | 招雷 |
+
+**将来の敵スキル候補(アイデアのみ、未登録)**: 生贄の儀(1体に攻撃集中)、闇の契約/神の試練(1ターン全体の魔防/防御半減)、
+天威降臨(1ターン全員必殺100%)、アシッドブレス(全体ブレス+防御劣化)、覚醒(1ターン与ダメ2倍)、突然変異(HP2倍エリート個体)。
+状態異常系(毒/麻痺/眠り/混乱/石化/即死)は状態異常システム自体が未実装のため見送り。
 
 ## 4. 未実装スキルの記録
 
@@ -75,11 +134,32 @@
 
 **判定基準**: `CharacterSkill` の効果フィールドが実行時(`BattleSystem` / `battle/unitFactory` / `GoblinStatCalculator` / `ExpeditionEngine` / `CompleteExpeditionUseCase` 等)で消費されているか。集約層 `src/shared/data/characterSkills.ts` の `getXxxFromSkills` / `hasXxxSkill` の呼び出し元で確認できる。
 
-**現状の確認結果(2026-07)**: カタログ `CHARACTER_SKILL_CATALOG` の全効果フィールドは実行時に消費されており、**未実装は無し**。
+**2026-07-10 第2次再設計で追加した新スキル群(§3.5)は、同日中に戦闘ロジックを一括実装済み**。
+現在、カタログ `CHARACTER_SKILL_CATALOG` の全効果フィールドは実行時に消費されており、**未実装は無し**。
 
-| band | 付与した未実装スキル | 備考 |
+実装箇所の要約(後から挙動を追う際のガイド):
+
+| フィールド | 対象スキルID | 実装箇所 |
 |---|---|---|
-| A〜E | **なし**(全て実装済みカタログスキルのみ使用) | 使用ID132種すべてカタログ実在＋実行時消費を確認 |
+| `lifestealPercent` | lifesteal_5/8/12 | `BattleSystem.executeBasicAttack` ダメージ適用後(回復上限=最大HP25%/回) |
+| `hpRegenPercent`の負値 | hp_degen_5/10 | ターン終了時に負値対応済み(**HP下限1**、actionEffect='damage'でログ) |
+| `partyHpRegenFromMagicHealPercent` | party_heal_regen_10/20 | ターン終了時、自分の魔法回復量×%で味方全員回復 |
+| `damageRampPerAttackPercent/Max` | battle_fervor_4/6 | 通常攻撃行動の後にスタック加算→次の攻撃から与ダメ係数 |
+| `magicAtkRampPerTurnPercent/Max` | mana_surge_4/6 | ターン開始時に基準値から magicAtk を再計算(unit/combatant両方) |
+| `singleStrikeAttackMultiplier` | mighty_blow_180 | `unitFactory`(味方/敵とも)。最終攻撃回数==1のとき atk へ乗算 |
+| `singleStrikeAccuracyMultiplier` | deadeye_200 | 同上。accuracy へ乗算 |
+| `physicalBarrierCharges` / `magicBarrierCharges` | ward_physical/magic_2/3 | 戦闘開始時にPT共有 `barrierState` 生成(重複無効=最大値)。被弾ごとに1消費で1/3軽減 |
+| `partyPhysicalDamageMultiplier` | war_cry_1_2/1_3 | 戦闘開始時PT効果(magic_field と同型、最大値のみ) |
+| `reattackOnKillChancePercent` | pursuit_30 | `tryReattacks`: 撃破時1回のみ再攻撃(追撃/反撃からは発動しない) |
+| `chainReattackChancePercent` | enemy_chain_reattack_30 | `tryReattacks`: 確率連鎖、安全上限5回 |
+| `criticalDamageTakenReductionPercent` | crit_guard_30/50 | 必殺時の criticalDamageFactor に乗算 |
+| `additionalDamageTakenReductionPercent` | pierce_guard_30/50 | 追加ダメージへ乗算(切り捨て) |
+| `halveAttackCountToDefRate` / `...MagicAtkRate` | bulwark/mystic_stance_30 | `GoblinStatCalculator.applyPassiveSkillEffects`(defToHp等より先に適用) |
+| `recoverUsedSpellOnAttackChancePercent` | spell_siphon_30 | 通常攻撃行動の後に確率で使用済みチャージ+1 |
+| `turnStartAoeMagic` | frost_nova_t4, enemy_thunder_call | ターン開始時(魔力高揚の更新後)。魔防系軽減・障壁・王の威圧を適用 |
+| `lowerLevelDamageTakenReductionPercent` | enemy_royal_pressure_30 | 物理/魔法/ターン開始AoEの被ダメ計算(攻撃側Lv<自Lvで軽減) |
+
+**検証(2026-07-10)**: 全16ケースの一時スモークテスト(吸血/血の代償HP下限/癒しの霊気/障壁/鬨の声/闘志/魔力高揚+AoE/連撃上限5/追い打ち1回/渾身/精密/急所守り/対貫通/王の威圧/魔力簒奪/構え×2)で挙動確認後、方針(新規テストは追加しない)に従い削除。`tsc` clean / 既存536テスト合格。
 
 > 今後 floor未確定99件を設計する際に新規/未実装スキルを付けたら、ここに追記する。
 

--- a/goblin_native/src/core/services/BattleSystem.ts
+++ b/goblin_native/src/core/services/BattleSystem.ts
@@ -2,15 +2,29 @@ import type { AttackTargetDetail, BattleLogEntry, Enemy, Goblin } from '../../sh
 import {
   getActionOrderMultiplierFromSkills,
   getAdditionalDamageFromSkills,
+  getAdditionalDamageTakenReductionFromSkills,
+  getChainReattackChancePercentFromSkills,
+  getCriticalDamageTakenReductionFromSkills,
   getMagicDamageFollowUpFromSkills,
   getCriticalAttackFollowUpFromSkills,
+  getDamageRampFromSkills,
+  getLifestealPercentFromSkills,
+  getLowerLevelDamageTakenReductionFromSkills,
+  getMagicAtkRampFromSkills,
+  getMagicBarrierChargesFromSkills,
+  getPartyHpRegenFromMagicHealPercentFromSkills,
+  getPartyPhysicalDamageMultiplierFromSkills,
+  getPhysicalBarrierChargesFromSkills,
   getPhysicalCounterAttackFromSkills,
   getCounterAttackAvoidanceRateFromSkills,
+  getReattackOnKillChancePercentFromSkills,
+  getRecoverUsedSpellOnAttackChanceFromSkills,
   getSpellTakenMultiplierFromSkills,
   getSpellDamageMultiplierFromSkills,
   getPartyMagicDamageMultiplierFromSkills,
   getHpRegenPercentFromSkills,
   getHpRegenAmountFromSkills,
+  getTurnStartAoeMagicSkillFromSkills,
 } from '../../shared/data/characterSkills'
 import type { SpellDef } from '../../shared/types/Spell'
 import { CombatantManager } from './CombatantManager'
@@ -100,6 +114,27 @@ export class BattleSystem {
     const livingUnits = units.filter(unit => unit.currentHP > 0)
     if (livingUnits.length === 0) return
 
+    const pushPartyEffectLog = (
+      provider: BattleUnit,
+      action: string,
+      actionEffect: BattleLogEntry['actionEffect'],
+    ) => {
+      detailedLog.push({
+        turn: 0,
+        actorId: provider.combatant.id,
+        actorName: getLogName(provider),
+        actorRow: provider.row + 1,
+        action,
+        attackCount: 0,
+        hitCount: 0,
+        actorHP: provider.currentHP,
+        actorMaxHP: provider.maxHP,
+        isAlly: provider.isAlly,
+        actionEffect,
+        targets: [],
+      })
+    }
+
     const strongestMagicField = livingUnits
       .map(unit => ({
         unit,
@@ -108,26 +143,70 @@ export class BattleSystem {
       .filter(entry => entry.multiplier > 1)
       .sort((a, b) => b.multiplier - a.multiplier)[0]
 
-    if (!strongestMagicField) return
-
-    for (const unit of livingUnits) {
-      unit.magicFieldDamageMultiplier = Math.max(unit.magicFieldDamageMultiplier, strongestMagicField.multiplier)
+    if (strongestMagicField) {
+      for (const unit of livingUnits) {
+        unit.magicFieldDamageMultiplier = Math.max(unit.magicFieldDamageMultiplier, strongestMagicField.multiplier)
+      }
+      pushPartyEffectLog(
+        strongestMagicField.unit,
+        getSkillLabel({ id: 'magic_field', partyMagicDamageMultiplier: strongestMagicField.multiplier }),
+        'magic_field',
+      )
     }
 
-    detailedLog.push({
-      turn: 0,
-      actorId: strongestMagicField.unit.combatant.id,
-      actorName: getLogName(strongestMagicField.unit),
-      actorRow: strongestMagicField.unit.row + 1,
-      action: getSkillLabel({ id: 'magic_field', partyMagicDamageMultiplier: strongestMagicField.multiplier }),
-      attackCount: 0,
-      hitCount: 0,
-      actorHP: strongestMagicField.unit.currentHP,
-      actorMaxHP: strongestMagicField.unit.maxHP,
-      isAlly: strongestMagicField.unit.isAlly,
-      actionEffect: 'magic_field',
-      targets: [],
-    })
+    // 鬨の声: PT全員の物理与ダメージ倍率(重複無効=最大値のみ)
+    const strongestWarCry = livingUnits
+      .map(unit => ({
+        unit,
+        multiplier: getPartyPhysicalDamageMultiplierFromSkills(unit.skills),
+      }))
+      .filter(entry => entry.multiplier > 1)
+      .sort((a, b) => b.multiplier - a.multiplier)[0]
+
+    if (strongestWarCry) {
+      for (const unit of livingUnits) {
+        unit.warCryDamageMultiplier = Math.max(unit.warCryDamageMultiplier ?? 1, strongestWarCry.multiplier)
+      }
+      pushPartyEffectLog(
+        strongestWarCry.unit,
+        getSkillLabel({ id: strongestWarCry.multiplier >= 1.3 ? 'war_cry_1_3' : 'war_cry_1_2' }),
+        'attack_up',
+      )
+    }
+
+    // 物理/魔法障壁: パーティ共有チャージ(重複無効=最大値のみ)
+    const strongestPhysicalWard = livingUnits
+      .map(unit => ({ unit, charges: getPhysicalBarrierChargesFromSkills(unit.skills) }))
+      .filter(entry => entry.charges > 0)
+      .sort((a, b) => b.charges - a.charges)[0]
+    const strongestMagicWard = livingUnits
+      .map(unit => ({ unit, charges: getMagicBarrierChargesFromSkills(unit.skills) }))
+      .filter(entry => entry.charges > 0)
+      .sort((a, b) => b.charges - a.charges)[0]
+
+    if (strongestPhysicalWard || strongestMagicWard) {
+      const barrierState = {
+        physicalCharges: strongestPhysicalWard?.charges ?? 0,
+        magicCharges: strongestMagicWard?.charges ?? 0,
+      }
+      for (const unit of units) {
+        unit.barrierState = barrierState
+      }
+      if (strongestPhysicalWard) {
+        pushPartyEffectLog(
+          strongestPhysicalWard.unit,
+          getSkillLabel({ id: `ward_physical_${strongestPhysicalWard.charges}` }),
+          'barrier',
+        )
+      }
+      if (strongestMagicWard) {
+        pushPartyEffectLog(
+          strongestMagicWard.unit,
+          getSkillLabel({ id: `ward_magic_${strongestMagicWard.charges}` }),
+          'barrier',
+        )
+      }
+    }
   }
 
   public executeBattle(
@@ -178,6 +257,33 @@ export class BattleSystem {
 
       const turnActedUnitKeys = new Set<string>()
       const turnConsumedUnitKeys = new Set<string>()
+
+      // 魔力高揚: ターン経過ごとに魔法攻撃力を上昇(上限あり)
+      for (const unit of [...allyUnits, ...enemyUnits]) {
+        if (unit.currentHP <= 0) continue
+        const ramp = getMagicAtkRampFromSkills(unit.skills)
+        if (!ramp) continue
+        if (unit.rampBaseMagicAtk === undefined) {
+          unit.rampBaseMagicAtk = unit.magicAtk
+          unit.rampBaseCombatantMagicAtk = unit.combatant.magicAtk
+        }
+        const rampPercent = Math.min(ramp.maxPercent, (currentTurn - 1) * ramp.perAttackPercent)
+        const rampFactor = 1 + rampPercent / 100
+        unit.magicAtk = Math.floor(unit.rampBaseMagicAtk * rampFactor)
+        if (unit.rampBaseCombatantMagicAtk !== undefined) {
+          unit.combatant.magicAtk = Math.floor(unit.rampBaseCombatantMagicAtk * rampFactor)
+        }
+      }
+
+      // ターン開始時全体魔法(氷霧の大渦/招雷の角)
+      this.executeTurnStartAoeMagic(
+        allyUnits,
+        enemyUnits,
+        currentTurn,
+        detailedLog,
+        turnActedUnitKeys,
+        turnConsumedUnitKeys,
+      )
 
       const actingUnits = [...allyUnits, ...enemyUnits]
         .filter(unit => unit.currentHP > 0)
@@ -309,6 +415,30 @@ export class BattleSystem {
             turnConsumedUnitKeys,
             rng,
           )
+          // 闘志: 攻撃行動を行うたびにスタック蓄積(次の攻撃行動から有効)
+          const fervorRamp = getDamageRampFromSkills(unit.skills)
+          if (fervorRamp) {
+            unit.fervorStackPercent = Math.min(
+              fervorRamp.maxPercent,
+              (unit.fervorStackPercent ?? 0) + fervorRamp.perAttackPercent,
+            )
+          }
+          // 魔力簒奪: 通常攻撃時、確率で使用済み魔法を回復
+          this.tryRecoverUsedSpellOnAttack(unit, rng)
+          // 追い打ち/連撃衝動: 再攻撃判定
+          this.tryReattacks(
+            unit,
+            damagedTargets,
+            targetGroup,
+            sourceGroup,
+            allyUnits,
+            enemyUnits,
+            currentTurn,
+            detailedLog,
+            turnActedUnitKeys,
+            turnConsumedUnitKeys,
+            rng,
+          )
           turnActedUnitKeys.add(unitKey)
         } else {
           unit.isDefending = true
@@ -336,28 +466,66 @@ export class BattleSystem {
         if (allEnemiesDefeated || allAlliesDefeated) break
       }
 
-      // ターン終了時：HP回復能力を持つ生存ユニットのHP回復
+      // ターン終了時：癒しの霊気(味方全員を自分の魔法回復量の一定割合で回復)
+      for (const unit of [...allyUnits, ...enemyUnits]) {
+        if (unit.currentHP <= 0) continue
+        const partyHealPercent = getPartyHpRegenFromMagicHealPercentFromSkills(unit.skills)
+        if (partyHealPercent <= 0) continue
+        const healAmount = Math.floor(unit.magicHeal * partyHealPercent / 100)
+        if (healAmount <= 0) continue
+
+        const partyUnits = unit.isAlly ? allyUnits : enemyUnits
+        const targetDetails: Map<string, AttackTargetDetail> = new Map()
+        for (const target of partyUnits) {
+          if (target.currentHP <= 0) continue
+          const healed = applyHealing(target, healAmount)
+          if (healed <= 0) continue
+          accumulateTargetDetail(targetDetails, target, -healed)
+        }
+        if (targetDetails.size === 0) continue
+
+        detailedLog.push({
+          turn: currentTurn,
+          actorId: unit.combatant.id,
+          actorName: getLogName(unit),
+          actorRow: unit.row + 1,
+          action: i18n.t('battle.partyHealRegenAction'),
+          attackCount: 0,
+          hitCount: targetDetails.size,
+          actorHP: unit.currentHP,
+          actorMaxHP: unit.maxHP,
+          isAlly: unit.isAlly,
+          actionEffect: 'regen',
+          targets: getSortedTargetDetails(targetDetails),
+        })
+      }
+
+      // ターン終了時：HP回復能力(正)と血の代償(負)の合算適用。減少時もHPは1で止まる
       for (const unit of [...allyUnits, ...enemyUnits]) {
         if (unit.currentHP <= 0) continue
         const regenPercent = getHpRegenPercentFromSkills(unit.skills)
         const regenFlat = getHpRegenAmountFromSkills(unit.skills)
         const regenAmount = Math.floor(unit.maxHP * regenPercent / 100) + regenFlat
-        if (regenAmount <= 0) continue
+        if (regenAmount === 0) continue
         const before = unit.currentHP
-        unit.currentHP = Math.min(unit.maxHP, unit.currentHP + regenAmount)
-        if (unit.currentHP > before) {
+        if (regenAmount > 0) {
+          unit.currentHP = Math.min(unit.maxHP, unit.currentHP + regenAmount)
+        } else {
+          unit.currentHP = Math.max(1, unit.currentHP + regenAmount)
+        }
+        if (unit.currentHP !== before) {
           detailedLog.push({
             turn: currentTurn,
             actorId: unit.combatant.id,
             actorName: getLogName(unit),
             actorRow: unit.row + 1,
-            action: i18n.t('battle.hpRegenAction'),
+            action: regenAmount > 0 ? i18n.t('battle.hpRegenAction') : i18n.t('battle.hpDegenAction'),
             attackCount: 0,
             hitCount: 0,
             actorHP: unit.currentHP,
             actorMaxHP: unit.maxHP,
             isAlly: unit.isAlly,
-            actionEffect: 'regen',
+            actionEffect: regenAmount > 0 ? 'regen' : 'damage',
             targets: [{
               targetId: unit.combatant.id,
               targetName: getLogName(unit),
@@ -384,6 +552,96 @@ export class BattleSystem {
     }
 
     return createBattleResult(currentTurn, 'retreat', allyUnits, enemyUnits, detailedLog)
+  }
+
+  /**
+   * ターン開始時全体魔法(turnStartAoeMagic)を発動する
+   */
+  private executeTurnStartAoeMagic(
+    allyUnits: BattleUnit[],
+    enemyUnits: BattleUnit[],
+    currentTurn: number,
+    detailedLog: BattleLogEntry[],
+    turnActedUnitKeys: Set<string>,
+    turnConsumedUnitKeys: Set<string>,
+  ): void {
+    for (const unit of [...allyUnits, ...enemyUnits]) {
+      if (unit.currentHP <= 0) continue
+      const aoeSkill = getTurnStartAoeMagicSkillFromSkills(unit.skills)
+      const aoe = aoeSkill?.turnStartAoeMagic
+      if (!aoeSkill || !aoe) continue
+      if (!aoe.everyTurn && aoe.turn !== currentTurn) continue
+
+      const targetGroup = unit.isAlly ? enemyUnits : allyUnits
+      const aliveTargets = targetGroup.filter(target => target.currentHP > 0)
+      if (aliveTargets.length === 0) continue
+
+      const targetDetails: Map<string, AttackTargetDetail> = new Map()
+      let totalHitCount = 0
+
+      for (const target of aliveTargets) {
+        const baseDamage = unit.magicAtk * aoe.powerPercent / 100
+        const reductionFactor = 1 - target.damageReduction / 100
+        const magicReductionFactor = 1 - target.magicDamageReduction / 100
+        const magicBarrierFactor = 1 - target.magicBarrierDamageReduction / 100
+        const magicProtectionFactor = getRearMagicGuardReductionFactor(target, targetGroup)
+        const royalPressureFactor = this.getRoyalPressureFactor(unit, target)
+        let damage = Math.max(1, Math.floor(
+          baseDamage * reductionFactor * magicReductionFactor * magicBarrierFactor * magicProtectionFactor * royalPressureFactor,
+        ))
+        damage = this.applyMagicWard(target, damage)
+
+        applyDamage(target, damage)
+        totalHitCount++
+        accumulateTargetDetail(targetDetails, target, damage)
+      }
+
+      detailedLog.push({
+        turn: currentTurn,
+        actorId: unit.combatant.id,
+        actorName: getLogName(unit),
+        actorRow: unit.row + 1,
+        action: getSkillLabel(aoeSkill),
+        attackCount: totalHitCount,
+        hitCount: totalHitCount,
+        actorHP: unit.currentHP,
+        actorMaxHP: unit.maxHP,
+        isAlly: unit.isAlly,
+        actionEffect: 'damage',
+        targets: getSortedTargetDetails(targetDetails),
+      })
+
+      tryImmediateReviveForFallenAllies(
+        targetGroup,
+        currentTurn,
+        detailedLog,
+        turnActedUnitKeys,
+        turnConsumedUnitKeys,
+      )
+    }
+  }
+
+  /** 王の威圧: 自分よりLvが低い相手からの被ダメージを軽減する係数 */
+  private getRoyalPressureFactor(attacker: BattleUnit, target: BattleUnit): number {
+    if (attacker.level >= target.level) return 1
+    const reduction = getLowerLevelDamageTakenReductionFromSkills(target.skills)
+    return 1 - reduction / 100
+  }
+
+  /** 物理障壁: チャージが残っていればダメージを1/3に軽減して1消費 */
+  private applyPhysicalWard(target: BattleUnit, damage: number): number {
+    const barrier = target.barrierState
+    if (!barrier || barrier.physicalCharges <= 0) return damage
+    barrier.physicalCharges--
+    return Math.max(1, Math.floor(damage / 3))
+  }
+
+  /** 魔法障壁: チャージが残っていればダメージを1/3に軽減して1消費 */
+  private applyMagicWard(target: BattleUnit, damage: number): number {
+    const barrier = target.barrierState
+    if (!barrier || barrier.magicCharges <= 0) return damage
+    barrier.magicCharges--
+    return Math.max(1, Math.floor(damage / 3))
   }
 
   private executeBasicAttack(
@@ -455,7 +713,9 @@ export class BattleSystem {
           rng,
         )
         const dmgMod = getDamageModifier(landedHitNumber)
-        const additionalDamage = getAdditionalDamageFromSkills(unit.skills)
+        // 対貫通装甲: 受ける追加ダメージを軽減
+        const additionalDamageTakenFactor = 1 - getAdditionalDamageTakenReductionFromSkills(attackTarget.skills) / 100
+        const additionalDamage = Math.floor(getAdditionalDamageFromSkills(unit.skills) * additionalDamageTakenFactor)
         const rearDamageMultiplier = getRearDamageMultiplier(unit, sourceGroup)
         const rowDamageMultiplier = getUnitRowDamageMultiplier(unit)
         const reductionFactor = 1 - attackTarget.damageReduction / 100
@@ -467,15 +727,33 @@ export class BattleSystem {
         const protectionFactor = getRearGuardReductionFactor(attackTarget, allyUnits)
         const defendingFactor = getDefendingDamageFactor(attackTarget)
         const physicalDamageFactor = 1 + unit.physicalDamagePercent / 100
+        // 闘志: 攻撃行動で蓄積した与ダメ増加
+        const fervorFactor = 1 + (unit.fervorStackPercent ?? 0) / 100
+        // 鬨の声: PT物理与ダメージ倍率
+        const warCryFactor = unit.warCryDamageMultiplier ?? 1
+        // 急所守り: 必殺攻撃の被ダメージ軽減
         const criticalDamageFactor = isCritical
-          ? 1 + (unit.criticalDamageBonusPercent ?? 0) / 100
+          ? (1 + (unit.criticalDamageBonusPercent ?? 0) / 100)
+            * (1 - getCriticalDamageTakenReductionFromSkills(attackTarget.skills) / 100)
           : 1
-        const damage = Math.max(
+        const royalPressureFactor = this.getRoyalPressureFactor(unit, attackTarget)
+        let damage = Math.max(
           1,
-          Math.floor((baseDamage * dmgMod * rearDamageMultiplier * rowDamageMultiplier + additionalDamage) * physicalDamageFactor * criticalDamageFactor * unit.physicalDamageDealtMultiplier * reductionFactor * physicalReductionFactor * rangedAttackReductionFactor * shieldBarrierReductionFactor * protectionFactor * defendingFactor * damageMultiplier),
+          Math.floor((baseDamage * dmgMod * rearDamageMultiplier * rowDamageMultiplier + additionalDamage) * physicalDamageFactor * criticalDamageFactor * fervorFactor * warCryFactor * unit.physicalDamageDealtMultiplier * reductionFactor * physicalReductionFactor * rangedAttackReductionFactor * shieldBarrierReductionFactor * protectionFactor * defendingFactor * royalPressureFactor * damageMultiplier),
         )
+        // 物理障壁: チャージ消費で1/3に軽減
+        damage = this.applyPhysicalWard(attackTarget, damage)
 
         applyDamage(attackTarget, damage)
+        // 吸血: 与ダメージの一部を回復(1回の回復上限は最大HPの25%)
+        const lifestealPercent = getLifestealPercentFromSkills(unit.skills)
+        if (lifestealPercent > 0 && unit.currentHP > 0) {
+          const lifestealAmount = Math.min(
+            Math.floor(damage * lifestealPercent / 100),
+            Math.floor(unit.maxHP * 0.25),
+          )
+          if (lifestealAmount > 0) applyHealing(unit, lifestealAmount)
+        }
         damagedTargets.set(getUnitKey(attackTarget), attackTarget)
         tryImmediateReviveForFallenAlly(
           attackTarget,
@@ -491,6 +769,103 @@ export class BattleSystem {
     }
 
     return { targetDetails, totalHitCount, isCritical, damagedTargets }
+  }
+
+  /** 魔力簒奪: 通常攻撃時、確率で使用済み魔法チャージを1回復する */
+  private tryRecoverUsedSpellOnAttack(unit: BattleUnit, rng: () => number): void {
+    const chance = getRecoverUsedSpellOnAttackChanceFromSkills(unit.skills)
+    if (chance <= 0) return
+    if (rng() * 100 >= chance) return
+
+    const usedCharges = unit.spellCharges.filter(charge => charge.remaining < charge.maxCharges)
+    if (usedCharges.length === 0) return
+
+    const selected = usedCharges[Math.floor(rng() * usedCharges.length)]
+    selected.remaining = Math.min(selected.remaining + 1, selected.maxCharges)
+  }
+
+  /**
+   * 追い打ち(敵撃破時に1回)/連撃衝動(確率で連鎖)による再攻撃。
+   * 参考ゲーム同様、再攻撃は追撃・反撃からは発動しない(通常攻撃行動の直後のみ)。
+   */
+  private tryReattacks(
+    unit: BattleUnit,
+    initialDamagedTargets: Map<string, BattleUnit>,
+    targetGroup: BattleUnit[],
+    sourceGroup: BattleUnit[],
+    allyUnits: BattleUnit[],
+    enemyUnits: BattleUnit[],
+    currentTurn: number,
+    detailedLog: BattleLogEntry[],
+    turnActedUnitKeys: Set<string>,
+    turnConsumedUnitKeys: Set<string>,
+    rng: () => number,
+  ): void {
+    const pursuitChance = getReattackOnKillChancePercentFromSkills(unit.skills)
+    const chainChance = getChainReattackChancePercentFromSkills(unit.skills)
+    if (pursuitChance <= 0 && chainChance <= 0) return
+
+    const MAX_REATTACKS = 5
+    let defeatedInLastAttack = [...initialDamagedTargets.values()].some(target => target.currentHP <= 0)
+    let pursuitUsed = false
+
+    for (let i = 0; i < MAX_REATTACKS; i++) {
+      if (unit.currentHP <= 0) return
+      if (!targetGroup.some(target => target.currentHP > 0)) return
+
+      const pursuitTrigger = !pursuitUsed
+        && pursuitChance > 0
+        && defeatedInLastAttack
+        && rng() * 100 < pursuitChance
+      const chainTrigger = chainChance > 0 && rng() * 100 < chainChance
+      if (!pursuitTrigger && !chainTrigger) return
+      if (pursuitTrigger) pursuitUsed = true // 追い打ちは1行動につき1回のみ
+
+      const { targetDetails, totalHitCount, isCritical, damagedTargets } = this.executeBasicAttack(
+        unit,
+        targetGroup,
+        sourceGroup,
+        allyUnits,
+        currentTurn,
+        detailedLog,
+        turnActedUnitKeys,
+        turnConsumedUnitKeys,
+        rng,
+        unit.attackCount,
+        unit.criticalRate,
+      )
+
+      detailedLog.push({
+        turn: currentTurn,
+        actorId: unit.combatant.id,
+        actorName: getLogName(unit),
+        actorRow: unit.row + 1,
+        action: i18n.t('battle.reattackAction'),
+        attackCount: unit.attackCount,
+        hitCount: totalHitCount,
+        actorHP: unit.currentHP,
+        actorMaxHP: unit.maxHP,
+        isAlly: unit.isAlly,
+        isCritical,
+        actionEffect: 'damage',
+        targets: getSortedTargetDetails(targetDetails),
+      })
+
+      this.tryPhysicalCounterAttacks(
+        unit,
+        damagedTargets,
+        allyUnits,
+        enemyUnits,
+        currentTurn,
+        detailedLog,
+        turnActedUnitKeys,
+        turnConsumedUnitKeys,
+        rng,
+      )
+
+      defeatedInLastAttack = [...damagedTargets.values()].some(target => target.currentHP <= 0)
+      if (chainChance <= 0) return // 追い打ちのみの場合は連鎖しない
+    }
   }
 
   private tryPhysicalCounterAttacks(
@@ -818,7 +1193,9 @@ export class BattleSystem {
         const magicBarrierFactor = 1 - target.magicBarrierDamageReduction / 100
         const magicProtectionFactor = getRearMagicGuardReductionFactor(target, targetGroup)
         const defendingFactor = getDefendingDamageFactor(target)
-        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * spellDamageFactor * spellTakenMultiplier * reductionFactor * magicReductionFactor * magicBarrierFactor * magicProtectionFactor * defendingFactor))
+        const royalPressureFactor = this.getRoyalPressureFactor(unit, target)
+        let damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * spellDamageFactor * spellTakenMultiplier * reductionFactor * magicReductionFactor * magicBarrierFactor * magicProtectionFactor * defendingFactor * royalPressureFactor))
+        damage = this.applyMagicWard(target, damage)
 
         applyDamage(target, damage)
         totalHitCount++
@@ -860,7 +1237,9 @@ export class BattleSystem {
         const magicBarrierFactor = 1 - target.magicBarrierDamageReduction / 100
         const magicProtectionFactor = getRearMagicGuardReductionFactor(target, targetGroup)
         const defendingFactor = getDefendingDamageFactor(target)
-        const damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * spellDamageFactor * spellTakenMultiplier * reductionFactor * magicReductionFactor * magicBarrierFactor * magicProtectionFactor * defendingFactor))
+        const royalPressureFactor = this.getRoyalPressureFactor(unit, target)
+        let damage = Math.max(1, Math.floor(baseDamage * rearDamageMultiplier * spellDamageFactor * spellTakenMultiplier * reductionFactor * magicReductionFactor * magicBarrierFactor * magicProtectionFactor * defendingFactor * royalPressureFactor))
+        damage = this.applyMagicWard(target, damage)
 
         applyDamage(target, damage)
         totalHitCount++

--- a/goblin_native/src/core/services/GoblinStatCalculator.ts
+++ b/goblin_native/src/core/services/GoblinStatCalculator.ts
@@ -183,6 +183,23 @@ export class GoblinStatCalculator {
     stats: GoblinStats,
     skills: CharacterSkill[],
   ): void {
+    // 構え系(攻撃回数半減→ステータス変換)を先に適用し、変換後の値を他の変換の入力にする
+    for (const skill of getUniqueSkillsById(skills)) {
+      if (skill.halveAttackCountToDefRate === undefined && skill.halveAttackCountToMagicAtkRate === undefined) {
+        continue
+      }
+      const halvedCount = Math.max(1, Math.ceil(stats.attackCount / 2))
+      const lostCount = stats.attackCount - halvedCount
+      if (lostCount <= 0) continue
+      if (skill.halveAttackCountToDefRate !== undefined) {
+        stats.def += lostCount * skill.halveAttackCountToDefRate
+      }
+      if (skill.halveAttackCountToMagicAtkRate !== undefined) {
+        stats.magicAtk += lostCount * skill.halveAttackCountToMagicAtkRate
+      }
+      stats.attackCount = halvedCount
+    }
+
     for (const skill of getUniqueSkillsById(skills)) {
       if (skill.defToHpPercent !== undefined) {
         stats.hp += Math.floor(stats.def * skill.defToHpPercent / 100)

--- a/goblin_native/src/core/services/battle/types.ts
+++ b/goblin_native/src/core/services/battle/types.ts
@@ -11,6 +11,12 @@ export interface SpellCharge {
   category: SpellCategory
 }
 
+/** 片側パーティで共有する障壁チャージ(参照共有で消費を同期する) */
+export interface SideBarrierState {
+  physicalCharges: number
+  magicCharges: number
+}
+
 export interface BattleUnit {
   instanceId?: string
   combatant: Combatant
@@ -52,6 +58,11 @@ export interface BattleUnit {
   battleActionPolicy: BattleActionPolicy
   isDefending: boolean
   attackType: 'melee' | 'range'
+  fervorStackPercent?: number       // 闘志: 攻撃行動で蓄積した与ダメ増加(%)
+  rampBaseMagicAtk?: number         // 魔力高揚: 上昇前の魔法攻撃力(unit側)
+  rampBaseCombatantMagicAtk?: number // 魔力高揚: 上昇前の魔法攻撃力(combatant側)
+  warCryDamageMultiplier?: number   // 鬨の声: PT物理与ダメージ倍率
+  barrierState?: SideBarrierState   // 物理/魔法障壁の残チャージ(パーティ共有)
 }
 
 export interface BattleResult {

--- a/goblin_native/src/core/services/battle/unitFactory.ts
+++ b/goblin_native/src/core/services/battle/unitFactory.ts
@@ -8,6 +8,8 @@ import {
   getPhysicalDamageReductionFromSkills,
   getPureGoblinPartyStatBonusPercentFromSkills,
   getRangedAttackDamageReductionFromSkills,
+  getSingleStrikeAccuracyMultiplierFromSkills,
+  getSingleStrikeAttackMultiplierFromSkills,
   getSpellDamagePercentFromSkills,
   getUniqueSkillsById,
 } from '../../../shared/data/characterSkills'
@@ -97,7 +99,11 @@ export function createAllyUnit(
     getPureGoblinPartyStatBonusPercentFromSkills(skills, goblin.level) * pureGoblinCount
   const packStatMultiplier = 1 + packBonusPercent / 100
   const maxHP = Math.floor(effectiveStats.hp * packStatMultiplier)
-  const atk = Math.floor(combatant.atk * packStatMultiplier)
+  // 渾身の一撃/精密照準: 攻撃回数1のときのみ有効
+  const isSingleStrike = effectiveStats.attackCount === 1
+  const singleStrikeAtkMultiplier = isSingleStrike ? getSingleStrikeAttackMultiplierFromSkills(skills) : 1
+  const singleStrikeAccMultiplier = isSingleStrike ? getSingleStrikeAccuracyMultiplierFromSkills(skills) : 1
+  const atk = Math.floor(combatant.atk * packStatMultiplier * singleStrikeAtkMultiplier)
   combatant.atk = atk
   const hp = initialHP === undefined || initialHP >= effectiveStats.hp
     ? maxHP
@@ -117,7 +123,7 @@ export function createAllyUnit(
     agility: actionOrderAgility ?? baseAttributes.agility,
     luck: baseAttributes.luck,
     attackCount: effectiveStats.attackCount,
-    accuracy: effectiveStats.accuracy,
+    accuracy: Math.floor(effectiveStats.accuracy * singleStrikeAccMultiplier),
     evasion: effectiveStats.evasion,
     isAlly: true,
     originalIndex,
@@ -162,6 +168,11 @@ export function createEnemyUnit(
   combatant.buffs = toCombatBuffsFromSkills(skills)
   const learnedSpells = mergeLearnedSpells(enemy.spells, skills, enemy.level)
   const raceResistance = getRaceResistanceTotals(enemy.raceTags)
+  // 渾身の一撃/精密照準: 攻撃回数1のときのみ有効
+  const isSingleStrike = enemy.attackCount === 1
+  const singleStrikeAtkMultiplier = isSingleStrike ? getSingleStrikeAttackMultiplierFromSkills(skills) : 1
+  const singleStrikeAccMultiplier = isSingleStrike ? getSingleStrikeAccuracyMultiplierFromSkills(skills) : 1
+  combatant.atk = Math.floor(combatant.atk * singleStrikeAtkMultiplier)
   return {
     instanceId: `enemy:${combatant.id}:${originalIndex}`,
     combatant,
@@ -172,7 +183,7 @@ export function createEnemyUnit(
     agility: enemy.baseAttributes.agility,
     luck: enemy.baseAttributes.luck,
     attackCount: enemy.attackCount,
-    accuracy: enemy.accuracy,
+    accuracy: Math.floor(enemy.accuracy * singleStrikeAccMultiplier),
     evasion: enemy.evasion,
     isAlly: false,
     originalIndex,

--- a/goblin_native/src/shared/data/characterSkills.ts
+++ b/goblin_native/src/shared/data/characterSkills.ts
@@ -799,6 +799,128 @@ export function getHpRegenAmountFromSkills(skills: CharacterSkill[]): number {
   )
 }
 
+export function getLifestealPercentFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.lifestealPercent ?? 0),
+    0,
+  )
+}
+
+export function getPartyHpRegenFromMagicHealPercentFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.partyHpRegenFromMagicHealPercent ?? 0),
+    0,
+  )
+}
+
+export type DamageRamp = {
+  perAttackPercent: number
+  maxPercent: number
+}
+
+export function getDamageRampFromSkills(skills: CharacterSkill[]): DamageRamp | undefined {
+  const ramps = getUniqueSkillsById(skills).filter(
+    (skill) => skill.damageRampPerAttackPercent !== undefined,
+  )
+  if (ramps.length === 0) return undefined
+  return {
+    perAttackPercent: ramps.reduce((sum, skill) => sum + (skill.damageRampPerAttackPercent ?? 0), 0),
+    maxPercent: ramps.reduce((max, skill) => Math.max(max, skill.damageRampMaxPercent ?? 0), 0),
+  }
+}
+
+export function getMagicAtkRampFromSkills(skills: CharacterSkill[]): DamageRamp | undefined {
+  const ramps = getUniqueSkillsById(skills).filter(
+    (skill) => skill.magicAtkRampPerTurnPercent !== undefined,
+  )
+  if (ramps.length === 0) return undefined
+  return {
+    perAttackPercent: ramps.reduce((sum, skill) => sum + (skill.magicAtkRampPerTurnPercent ?? 0), 0),
+    maxPercent: ramps.reduce((max, skill) => Math.max(max, skill.magicAtkRampMaxPercent ?? 0), 0),
+  }
+}
+
+export function getSingleStrikeAttackMultiplierFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.singleStrikeAttackMultiplier ?? 1),
+    1,
+  )
+}
+
+export function getSingleStrikeAccuracyMultiplierFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.singleStrikeAccuracyMultiplier ?? 1),
+    1,
+  )
+}
+
+export function getPhysicalBarrierChargesFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.physicalBarrierCharges ?? 0),
+    0,
+  )
+}
+
+export function getMagicBarrierChargesFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.magicBarrierCharges ?? 0),
+    0,
+  )
+}
+
+export function getPartyPhysicalDamageMultiplierFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.partyPhysicalDamageMultiplier ?? 1),
+    1,
+  )
+}
+
+export function getReattackOnKillChancePercentFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.reattackOnKillChancePercent ?? 0),
+    0,
+  )
+}
+
+export function getChainReattackChancePercentFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.chainReattackChancePercent ?? 0),
+    0,
+  )
+}
+
+export function getCriticalDamageTakenReductionFromSkills(skills: CharacterSkill[]): number {
+  return Math.min(100, getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.criticalDamageTakenReductionPercent ?? 0),
+    0,
+  ))
+}
+
+export function getAdditionalDamageTakenReductionFromSkills(skills: CharacterSkill[]): number {
+  return Math.min(100, getUniqueSkillsById(skills).reduce(
+    (sum, skill) => sum + (skill.additionalDamageTakenReductionPercent ?? 0),
+    0,
+  ))
+}
+
+export function getRecoverUsedSpellOnAttackChanceFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.recoverUsedSpellOnAttackChancePercent ?? 0),
+    0,
+  )
+}
+
+export function getTurnStartAoeMagicSkillFromSkills(skills: CharacterSkill[]): CharacterSkill | undefined {
+  return getUniqueSkillsById(skills).find((skill) => skill.turnStartAoeMagic !== undefined)
+}
+
+export function getLowerLevelDamageTakenReductionFromSkills(skills: CharacterSkill[]): number {
+  return getUniqueSkillsById(skills).reduce(
+    (max, skill) => Math.max(max, skill.lowerLevelDamageTakenReductionPercent ?? 0),
+    0,
+  )
+}
+
 function getEquipmentValueMultiplier(
   skills: CharacterSkill[],
   category: EquipmentCategory | undefined,

--- a/goblin_native/src/shared/data/equipmentPool.json
+++ b/goblin_native/src/shared/data/equipmentPool.json
@@ -1951,7 +1951,7 @@
       "grantedSkillIds": [
         "ranged_attack_reduction_18",
         "rare_guardian",
-        "base_vitality_up_3"
+        "ward_physical_2"
       ],
       "price": 25000,
       "isRare": true
@@ -1977,7 +1977,7 @@
       "grantedSkillIds": [
         "ranged_attack_reduction_18",
         "rare_guardian",
-        "base_vitality_up_4"
+        "ward_physical_2"
       ],
       "price": 50000,
       "isRare": true
@@ -2029,7 +2029,7 @@
       "grantedSkillIds": [
         "ranged_attack_reduction_22",
         "rare_guardian",
-        "base_power_up_5"
+        "bulwark_stance_30"
       ],
       "price": 600000,
       "isRare": true
@@ -2916,7 +2916,7 @@
       "grantedSkillIds": [
         "def_to_hp_6",
         "beast_slayer_1_5",
-        "base_power_up_4"
+        "lifesteal_5"
       ],
       "range": "melee",
       "price": 25000,
@@ -2988,7 +2988,7 @@
       "grantedSkillIds": [
         "def_to_hp_7",
         "dragon_slayer_2_0",
-        "base_power_up_5"
+        "action_order_200"
       ],
       "range": "melee",
       "price": 50000,
@@ -3055,7 +3055,7 @@
       ],
       "grantedSkillIds": [
         "critical_damage_bonus_9",
-        "base_agility_up_4",
+        "pursuit_30",
         "beast_slayer_1_5"
       ],
       "range": "ranged",
@@ -3119,7 +3119,7 @@
       ],
       "grantedSkillIds": [
         "critical_damage_bonus_11",
-        "base_agility_up_5",
+        "lifesteal_8",
         "dragon_slayer_2_0"
       ],
       "range": "ranged",
@@ -3151,7 +3151,7 @@
       ],
       "grantedSkillIds": [
         "critical_damage_bonus_7",
-        "base_luck_up_3",
+        "deadeye_200",
         "human_slayer_1_5"
       ],
       "range": "ranged",
@@ -3225,7 +3225,7 @@
       "grantedSkillIds": [
         "def_to_hp_6",
         "beast_slayer_1_5",
-        "base_power_up_4"
+        "battle_fervor_4"
       ],
       "range": "melee",
       "price": 12500,
@@ -3371,7 +3371,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_9",
-        "base_vitality_up_3",
+        "pierce_guard_30",
         "attack_resistant_4_5"
       ]
     },
@@ -3742,7 +3742,7 @@
       "grantedSkillIds": [
         "evasion_up_30",
         "breath_reduction_9",
-        "base_vitality_up_3"
+        "ward_physical_2"
       ]
     },
     {
@@ -3759,7 +3759,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "party_rare_mult_1_1",
-        "base_luck_up_5"
+        "action_order_200"
       ]
     },
     {
@@ -3903,7 +3903,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_9",
-        "base_power_up_3"
+        "crit_guard_30"
       ]
     },
     {
@@ -3982,7 +3982,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_11",
         "grant_magic_barrier",
-        "base_spirit_up_5"
+        "party_heal_regen_20"
       ]
     },
     {
@@ -4037,7 +4037,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_9",
-        "base_spirit_up_3"
+        "pierce_guard_30"
       ]
     },
     {
@@ -4063,7 +4063,7 @@
       "grantedSkillIds": [
         "ranged_attack_reduction_22",
         "rare_guardian",
-        "base_spirit_up_5"
+        "ward_physical_3"
       ]
     },
     {
@@ -4125,7 +4125,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_7",
-        "base_power_up_3",
+        "deadeye_200",
         "human_slayer_1_5"
       ]
     },
@@ -4183,7 +4183,7 @@
         "magic_resistant_4_5",
         "magic_reduction_14",
         "hp_multiplier_8",
-        "base_spirit_up_3"
+        "party_heal_regen_10"
       ]
     },
     {
@@ -4364,7 +4364,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_11",
-        "base_vitality_up_4",
+        "crit_guard_30",
         "attack_resistant_4_5"
       ]
     },
@@ -4383,7 +4383,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_luck_up_6"
+        "spell_siphon_30"
       ]
     },
     {
@@ -4436,7 +4436,7 @@
         "magic_resistant_4_5",
         "magic_reduction_18",
         "hp_multiplier_10",
-        "base_wisdom_up_4",
+        "ward_magic_2",
         "rare_spell_echo"
       ]
     },
@@ -4455,7 +4455,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_power_up_6"
+        "action_order_200"
       ]
     },
     {
@@ -4510,7 +4510,7 @@
         "magic_resistant_4_5",
         "magic_reduction_18",
         "hp_multiplier_10",
-        "base_spirit_up_4",
+        "mana_surge_4",
         "rare_spell_echo"
       ]
     },
@@ -4529,7 +4529,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_agility_up_6"
+        "war_cry_1_3"
       ]
     },
     {
@@ -4559,7 +4559,7 @@
       "grantedSkillIds": [
         "evasion_up_30",
         "breath_reduction_9",
-        "base_spirit_up_3"
+        "ward_physical_2"
       ]
     },
     {
@@ -4602,7 +4602,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_wisdom_up_6"
+        "lifesteal_12"
       ]
     },
     {
@@ -4662,7 +4662,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_spirit_up_6"
+        "pursuit_30"
       ]
     },
     {
@@ -4684,7 +4684,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_9",
         "grant_magic_barrier",
-        "base_spirit_up_3",
+        "party_heal_regen_10",
         "rare_spell_echo"
       ]
     },
@@ -4744,7 +4744,7 @@
       "grantedSkillIds": [
         "spell_damage_20",
         "grant_magic_arrow",
-        "base_wisdom_up_6",
+        "frost_nova_t4",
         "rare_spell_echo"
       ]
     },
@@ -4797,7 +4797,7 @@
       "grantedSkillIds": [
         "beast_slayer_2_0",
         "physical_damage_40",
-        "base_vitality_up_5"
+        "war_cry_1_2"
       ]
     },
     {
@@ -4822,7 +4822,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_14",
-        "base_vitality_up_6",
+        "crit_guard_50",
         "attack_resistant_4_5"
       ]
     },
@@ -4859,7 +4859,7 @@
         "magic_resistant_4_5",
         "magic_reduction_22",
         "hp_multiplier_12",
-        "base_wisdom_up_5"
+        "ward_magic_3"
       ]
     },
     {
@@ -4881,7 +4881,7 @@
       "grantedSkillIds": [
         "spell_damage_20",
         "grant_magic_arrow",
-        "base_luck_up_6"
+        "mana_surge_6"
       ]
     },
     {
@@ -4947,7 +4947,7 @@
       "grantedSkillIds": [
         "evasion_up_50",
         "breath_reduction_11",
-        "base_vitality_up_5"
+        "ward_physical_3"
       ]
     },
     {
@@ -4972,7 +4972,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_14",
-        "base_power_up_6"
+        "bulwark_stance_30"
       ]
     },
     {
@@ -5031,7 +5031,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_12",
-        "base_vitality_up_5",
+        "pierce_guard_50",
         "attack_resistant_4_5"
       ]
     },
@@ -5050,7 +5050,7 @@
       "grantedSkillIds": [
         "beast_slayer_2_0",
         "physical_damage_50",
-        "base_vitality_up_6"
+        "pursuit_30"
       ]
     },
     {
@@ -5088,7 +5088,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_40",
-        "base_agility_up_5"
+        "lifesteal_8"
       ]
     },
     {
@@ -5110,7 +5110,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_12",
         "grant_heal",
-        "base_spirit_up_6"
+        "spell_siphon_30"
       ]
     },
     {
@@ -5146,7 +5146,7 @@
         "magic_resistant_4_5",
         "magic_reduction_22",
         "hp_multiplier_12",
-        "base_spirit_up_5"
+        "mystic_stance_30"
       ]
     },
     {
@@ -5168,7 +5168,7 @@
       "grantedSkillIds": [
         "spell_damage_20",
         "grant_fireball",
-        "base_spirit_up_6"
+        "mystic_stance_30"
       ]
     },
     {
@@ -5261,7 +5261,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_12",
-        "base_power_up_5",
+        "crit_guard_50",
         "rare_guardian"
       ]
     },
@@ -5280,7 +5280,8 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_agility_up_6"
+        "battle_fervor_6",
+        "hp_degen_5"
       ]
     },
     {
@@ -5346,7 +5347,7 @@
       "grantedSkillIds": [
         "evasion_up_50",
         "breath_reduction_11",
-        "base_spirit_up_5"
+        "crit_guard_50"
       ]
     },
     {
@@ -5364,7 +5365,8 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_wisdom_up_6"
+        "battle_fervor_6",
+        "hp_degen_5"
       ]
     },
     {
@@ -5389,7 +5391,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_9",
-        "base_luck_up_3"
+        "crit_guard_30"
       ]
     },
     {
@@ -5424,7 +5426,7 @@
       "grantedSkillIds": [
         "undead_slayer_2_0",
         "physical_damage_50",
-        "base_spirit_up_6"
+        "hp_regen_10"
       ]
     },
     {
@@ -5466,7 +5468,7 @@
       "grantedSkillIds": [
         "spell_damage_16",
         "grant_magic_arrow",
-        "base_wisdom_up_5"
+        "mana_surge_6"
       ]
     },
     {
@@ -5515,7 +5517,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_7",
-        "base_wisdom_up_3",
+        "deadeye_200",
         "undead_slayer_1_5"
       ]
     },
@@ -5547,7 +5549,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_10",
-        "base_luck_up_5",
+        "battle_fervor_6",
         "undead_slayer_2_0"
       ]
     },
@@ -5625,7 +5627,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_12",
-        "base_spirit_up_5"
+        "bulwark_stance_30"
       ]
     },
     {
@@ -5698,7 +5700,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_12",
-        "base_luck_up_5"
+        "pierce_guard_50"
       ]
     },
     {
@@ -5734,7 +5736,7 @@
       "grantedSkillIds": [
         "def_to_hp_8",
         "undead_slayer_2_0",
-        "base_power_up_6"
+        "battle_fervor_6"
       ]
     },
     {
@@ -5799,7 +5801,7 @@
       "grantedSkillIds": [
         "spell_damage_16",
         "grant_magic_arrow",
-        "base_luck_up_5",
+        "mana_surge_6",
         "rare_spell_echo"
       ]
     },
@@ -5876,7 +5878,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_12",
-        "base_agility_up_5"
+        "crit_guard_50"
       ]
     },
     {
@@ -5894,7 +5896,7 @@
       "grantedSkillIds": [
         "human_slayer_2_0",
         "physical_damage_50",
-        "base_spirit_up_6"
+        "action_order_200"
       ]
     },
     {
@@ -5957,7 +5959,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_10",
-        "base_power_up_5",
+        "pursuit_30",
         "human_slayer_2_0"
       ]
     },
@@ -6027,7 +6029,7 @@
         "additional_damage_3",
         "additional_damage_12",
         "rare_ambush",
-        "base_agility_up_6",
+        "lifesteal_12",
         "human_slayer_2_0"
       ]
     },
@@ -6119,7 +6121,7 @@
       "grantedSkillIds": [
         "evasion_up_60",
         "breath_reduction_12",
-        "base_vitality_up_6"
+        "ward_physical_3"
       ]
     },
     {
@@ -6160,7 +6162,7 @@
         "magic_resistant_4_5",
         "magic_reduction_22",
         "hp_multiplier_12",
-        "base_luck_up_5",
+        "ward_magic_3",
         "rare_spell_echo"
       ]
     },
@@ -6183,7 +6185,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_12",
         "grant_magic_barrier",
-        "base_wisdom_up_6"
+        "spell_siphon_30"
       ]
     },
     {
@@ -6514,7 +6516,7 @@
       "grantedSkillIds": [
         "evasion_up_50",
         "breath_reduction_11",
-        "base_power_up_5"
+        "ward_physical_3"
       ]
     },
     {
@@ -6624,7 +6626,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_14",
-        "base_spirit_up_6"
+        "pierce_guard_50"
       ]
     },
     {
@@ -6687,7 +6689,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_10",
-        "base_wisdom_up_5",
+        "battle_fervor_6",
         "human_slayer_2_0"
       ]
     },
@@ -6706,7 +6708,7 @@
       "grantedSkillIds": [
         "human_slayer_2_0",
         "physical_damage_50",
-        "base_spirit_up_6"
+        "deadeye_200"
       ]
     },
     {
@@ -6768,7 +6770,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_12",
         "grant_magic_barrier",
-        "base_luck_up_6"
+        "party_heal_regen_20"
       ]
     },
     {
@@ -6938,7 +6940,7 @@
       "grantedSkillIds": [
         "evasion_up_60",
         "breath_reduction_12",
-        "base_spirit_up_6",
+        "ward_physical_3",
         "rare_guardian"
       ]
     },
@@ -7032,7 +7034,7 @@
       "grantedSkillIds": [
         "def_to_hp_8",
         "human_slayer_2_0",
-        "base_vitality_up_6",
+        "lifesteal_12",
         "rare_guardian"
       ]
     },
@@ -7098,7 +7100,7 @@
       "grantedSkillIds": [
         "magic_heal_to_hp_11",
         "grant_magic_barrier",
-        "base_wisdom_up_5",
+        "party_heal_regen_20",
         "rare_spell_echo"
       ]
     },
@@ -7527,7 +7529,7 @@
       "grantedSkillIds": [
         "def_to_hp_6",
         "human_slayer_1_5",
-        "base_power_up_4"
+        "mighty_blow_180"
       ]
     },
     {
@@ -7582,7 +7584,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_14",
-        "base_luck_up_6"
+        "crit_guard_50"
       ]
     },
     {
@@ -7618,7 +7620,7 @@
       "grantedSkillIds": [
         "def_to_hp_6",
         "human_slayer_1_5",
-        "base_vitality_up_4"
+        "battle_fervor_4"
       ]
     },
     {
@@ -7706,7 +7708,7 @@
         "additional_damage_3",
         "additional_damage_10",
         "rare_ambush",
-        "base_agility_up_5",
+        "pursuit_30",
         "human_slayer_2_0"
       ]
     },
@@ -7772,7 +7774,7 @@
       "grantedSkillIds": [
         "evasion_up_40",
         "breath_reduction_10",
-        "base_vitality_up_4",
+        "ward_physical_2",
         "rare_guardian"
       ]
     },
@@ -7874,7 +7876,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "physical_reduction_14",
-        "base_wisdom_up_6",
+        "pierce_guard_50",
         "attack_resistant_4_5"
       ]
     },
@@ -7893,7 +7895,7 @@
       "grantedSkillIds": [
         "beast_slayer_2_0",
         "physical_damage_50",
-        "base_agility_up_6"
+        "war_cry_1_3"
       ]
     },
     {
@@ -7975,7 +7977,7 @@
       "grantedSkillIds": [
         "beast_slayer_2_0",
         "physical_damage_50",
-        "base_wisdom_up_6"
+        "lifesteal_12"
       ]
     },
     {
@@ -8125,7 +8127,7 @@
         "magic_resistant_4_5",
         "magic_reduction_26",
         "hp_multiplier_13",
-        "base_wisdom_up_6",
+        "ward_magic_3",
         "rare_spell_echo"
       ]
     },
@@ -8179,7 +8181,7 @@
       "isRare": true,
       "grantedSkillIds": [
         "critical_damage_bonus_10",
-        "base_vitality_up_5",
+        "lifesteal_8",
         "human_slayer_2_0"
       ]
     },

--- a/goblin_native/src/shared/data/skillCatalog.ts
+++ b/goblin_native/src/shared/data/skillCatalog.ts
@@ -978,6 +978,195 @@ export const CHARACTER_SKILL_CATALOG = {
   mage_magic_lv6: createMageMagicSkill(6),
   mage_magic_lv7: createMageMagicSkill(7),
 
+  // --- 参考ゲーム由来の新スキル群(2026-07 レア再設計) ---
+  // 戦闘ロジック未実装のものは docs/rare_item_design.md §4 に記録。
+
+  lifesteal_5: {
+    id: 'lifesteal_5',
+    descriptionKey: 'entities.skill.lifesteal_5.description',
+    lifestealPercent: 5,
+  },
+  lifesteal_8: {
+    id: 'lifesteal_8',
+    descriptionKey: 'entities.skill.lifesteal_8.description',
+    lifestealPercent: 8,
+  },
+  lifesteal_12: {
+    id: 'lifesteal_12',
+    descriptionKey: 'entities.skill.lifesteal_12.description',
+    lifestealPercent: 12,
+  },
+
+  hp_degen_5: {
+    id: 'hp_degen_5',
+    descriptionKey: 'entities.skill.hp_degen_5.description',
+    hpRegenPercent: -5,
+  },
+  hp_degen_10: {
+    id: 'hp_degen_10',
+    descriptionKey: 'entities.skill.hp_degen_10.description',
+    hpRegenPercent: -10,
+  },
+
+  party_heal_regen_10: {
+    id: 'party_heal_regen_10',
+    descriptionKey: 'entities.skill.party_heal_regen_10.description',
+    partyHpRegenFromMagicHealPercent: 10,
+  },
+  party_heal_regen_20: {
+    id: 'party_heal_regen_20',
+    descriptionKey: 'entities.skill.party_heal_regen_20.description',
+    partyHpRegenFromMagicHealPercent: 20,
+  },
+
+  battle_fervor_4: {
+    id: 'battle_fervor_4',
+    descriptionKey: 'entities.skill.battle_fervor_4.description',
+    damageRampPerAttackPercent: 4,
+    damageRampMaxPercent: 40,
+  },
+  battle_fervor_6: {
+    id: 'battle_fervor_6',
+    descriptionKey: 'entities.skill.battle_fervor_6.description',
+    damageRampPerAttackPercent: 6,
+    damageRampMaxPercent: 60,
+  },
+
+  mana_surge_4: {
+    id: 'mana_surge_4',
+    descriptionKey: 'entities.skill.mana_surge_4.description',
+    magicAtkRampPerTurnPercent: 4,
+    magicAtkRampMaxPercent: 40,
+  },
+  mana_surge_6: {
+    id: 'mana_surge_6',
+    descriptionKey: 'entities.skill.mana_surge_6.description',
+    magicAtkRampPerTurnPercent: 6,
+    magicAtkRampMaxPercent: 60,
+  },
+
+  mighty_blow_180: {
+    id: 'mighty_blow_180',
+    descriptionKey: 'entities.skill.mighty_blow_180.description',
+    singleStrikeAttackMultiplier: 1.8,
+  },
+  deadeye_200: {
+    id: 'deadeye_200',
+    descriptionKey: 'entities.skill.deadeye_200.description',
+    singleStrikeAccuracyMultiplier: 2.0,
+  },
+
+  ward_physical_2: {
+    id: 'ward_physical_2',
+    descriptionKey: 'entities.skill.ward_physical_2.description',
+    physicalBarrierCharges: 2,
+  },
+  ward_physical_3: {
+    id: 'ward_physical_3',
+    descriptionKey: 'entities.skill.ward_physical_3.description',
+    physicalBarrierCharges: 3,
+  },
+  ward_magic_2: {
+    id: 'ward_magic_2',
+    descriptionKey: 'entities.skill.ward_magic_2.description',
+    magicBarrierCharges: 2,
+  },
+  ward_magic_3: {
+    id: 'ward_magic_3',
+    descriptionKey: 'entities.skill.ward_magic_3.description',
+    magicBarrierCharges: 3,
+  },
+
+  war_cry_1_2: {
+    id: 'war_cry_1_2',
+    descriptionKey: 'entities.skill.war_cry_1_2.description',
+    partyPhysicalDamageMultiplier: 1.2,
+  },
+  war_cry_1_3: {
+    id: 'war_cry_1_3',
+    descriptionKey: 'entities.skill.war_cry_1_3.description',
+    partyPhysicalDamageMultiplier: 1.3,
+  },
+
+  pursuit_30: {
+    id: 'pursuit_30',
+    descriptionKey: 'entities.skill.pursuit_30.description',
+    reattackOnKillChancePercent: 30,
+  },
+
+  crit_guard_30: {
+    id: 'crit_guard_30',
+    descriptionKey: 'entities.skill.crit_guard_30.description',
+    criticalDamageTakenReductionPercent: 30,
+  },
+  crit_guard_50: {
+    id: 'crit_guard_50',
+    descriptionKey: 'entities.skill.crit_guard_50.description',
+    criticalDamageTakenReductionPercent: 50,
+  },
+
+  pierce_guard_30: {
+    id: 'pierce_guard_30',
+    descriptionKey: 'entities.skill.pierce_guard_30.description',
+    additionalDamageTakenReductionPercent: 30,
+  },
+  pierce_guard_50: {
+    id: 'pierce_guard_50',
+    descriptionKey: 'entities.skill.pierce_guard_50.description',
+    additionalDamageTakenReductionPercent: 50,
+  },
+
+  action_order_200: {
+    id: 'action_order_200',
+    actionOrderMultiplier: 2.0,
+  },
+
+  bulwark_stance_30: {
+    id: 'bulwark_stance_30',
+    descriptionKey: 'entities.skill.bulwark_stance_30.description',
+    halveAttackCountToDefRate: 30,
+  },
+  mystic_stance_30: {
+    id: 'mystic_stance_30',
+    descriptionKey: 'entities.skill.mystic_stance_30.description',
+    halveAttackCountToMagicAtkRate: 30,
+  },
+
+  spell_siphon_30: {
+    id: 'spell_siphon_30',
+    descriptionKey: 'entities.skill.spell_siphon_30.description',
+    recoverUsedSpellOnAttackChancePercent: 30,
+  },
+
+  frost_nova_t4: {
+    id: 'frost_nova_t4',
+    descriptionKey: 'entities.skill.frost_nova_t4.description',
+    turnStartAoeMagic: {
+      turn: 4,
+      powerPercent: 150,
+    },
+  },
+
+  // --- 敵専用スキル(参考ゲームの敵/ボス級能力の翻案。装備には付与しない) ---
+  enemy_royal_pressure_30: {
+    id: 'enemy_royal_pressure_30',
+    descriptionKey: 'entities.skill.enemy_royal_pressure_30.description',
+    lowerLevelDamageTakenReductionPercent: 30,
+  },
+  enemy_chain_reattack_30: {
+    id: 'enemy_chain_reattack_30',
+    descriptionKey: 'entities.skill.enemy_chain_reattack_30.description',
+    chainReattackChancePercent: 30,
+  },
+  enemy_thunder_call: {
+    id: 'enemy_thunder_call',
+    descriptionKey: 'entities.skill.enemy_thunder_call.description',
+    turnStartAoeMagic: {
+      everyTurn: true,
+      powerPercent: 60,
+    },
+  },
+
   weapon_melee_attack: {
     id: 'weapon_melee_attack',
     descriptionKey: 'entities.skill.weapon_melee_attack.description',

--- a/goblin_native/src/shared/i18n/resources/ja.ts
+++ b/goblin_native/src/shared/i18n/resources/ja.ts
@@ -869,6 +869,131 @@ const ja = {
       hp_regen_20: { name: '[20%]回復能力' },
       hp_regen_10: { name: '[10%]回復能力' },
       hp_regen_flat_10: { name: '[10]回復能力' },
+      lifesteal_5: {
+        name: '[5%]吸血',
+        description: '攻撃で与えたダメージの5%の量、HPが回復します。（一度に回復できる最大値は最大HPの25%）',
+      },
+      lifesteal_8: {
+        name: '[8%]吸血',
+        description: '攻撃で与えたダメージの8%の量、HPが回復します。（一度に回復できる最大値は最大HPの25%）',
+      },
+      lifesteal_12: {
+        name: '[12%]吸血',
+        description: '攻撃で与えたダメージの12%の量、HPが回復します。（一度に回復できる最大値は最大HPの25%）',
+      },
+      hp_degen_5: {
+        name: '[-5%]血の代償',
+        description: '戦闘中、ターン終了時にHPが5%減少します。',
+      },
+      hp_degen_10: {
+        name: '[-10%]血の代償',
+        description: '戦闘中、ターン終了時にHPが10%減少します。',
+      },
+      party_heal_regen_10: {
+        name: '[10%]癒しの霊気',
+        description: 'ターン終了時に味方全員のHPを自分の魔法回復量の10%分回復します。',
+      },
+      party_heal_regen_20: {
+        name: '[20%]癒しの霊気',
+        description: 'ターン終了時に味方全員のHPを自分の魔法回復量の20%分回復します。',
+      },
+      battle_fervor_4: {
+        name: '[+4%]闘志',
+        description: '攻撃行動を行うたびに攻撃ダメージが4%増大します（最大40%）。効果は戦闘の間持続します。',
+      },
+      battle_fervor_6: {
+        name: '[+6%]闘志',
+        description: '攻撃行動を行うたびに攻撃ダメージが6%増大します（最大60%）。効果は戦闘の間持続します。',
+      },
+      mana_surge_4: {
+        name: '[+4%]魔力高揚',
+        description: 'ターンを経過するごとに魔法攻撃力が4%上昇します（最大40%）。効果は戦闘の間持続します。',
+      },
+      mana_surge_6: {
+        name: '[+6%]魔力高揚',
+        description: 'ターンを経過するごとに魔法攻撃力が6%上昇します（最大60%）。効果は戦闘の間持続します。',
+      },
+      mighty_blow_180: {
+        name: '渾身の一撃',
+        description: '攻撃回数が1回のとき、攻撃力が1.8倍になります。',
+      },
+      deadeye_200: {
+        name: '精密照準',
+        description: '攻撃回数が1回のとき、命中精度が2倍になります。',
+      },
+      ward_physical_2: {
+        name: '[Lv2]物理障壁',
+        description: '敵の攻撃を2回、1/3に軽減する障壁で味方全員を保護します。',
+      },
+      ward_physical_3: {
+        name: '[Lv3]物理障壁',
+        description: '敵の攻撃を3回、1/3に軽減する障壁で味方全員を保護します。',
+      },
+      ward_magic_2: {
+        name: '[Lv2]魔法障壁',
+        description: '敵の魔法攻撃を2回、1/3に軽減する障壁で味方全員を保護します。',
+      },
+      ward_magic_3: {
+        name: '[Lv3]魔法障壁',
+        description: '敵の魔法攻撃を3回、1/3に軽減する障壁で味方全員を保護します。',
+      },
+      war_cry_1_2: {
+        name: '[1.2倍]鬨の声',
+        description: '味方全員の攻撃ダメージが1.2倍になります。（重複無効）',
+      },
+      war_cry_1_3: {
+        name: '[1.3倍]鬨の声',
+        description: '味方全員の攻撃ダメージが1.3倍になります。（重複無効）',
+      },
+      pursuit_30: {
+        name: '追い打ち',
+        description: '攻撃で敵を倒したとき、30%の確率で再攻撃を行います。',
+      },
+      crit_guard_30: {
+        name: '[30%]急所守り',
+        description: '必殺攻撃で受けるダメージを30%軽減します。',
+      },
+      crit_guard_50: {
+        name: '[50%]急所守り',
+        description: '必殺攻撃で受けるダメージを50%軽減します。',
+      },
+      pierce_guard_30: {
+        name: '[30%]対貫通装甲',
+        description: '攻撃で受ける追加ダメージを30%軽減します。',
+      },
+      pierce_guard_50: {
+        name: '[50%]対貫通装甲',
+        description: '攻撃で受ける追加ダメージを50%軽減します。',
+      },
+      action_order_200: { name: '[戦術] 神速' },
+      bulwark_stance_30: {
+        name: '城塞の構え',
+        description: '攻撃回数が半減する代わりに、半減した回数×30の数値だけ防御力が上昇します。',
+      },
+      mystic_stance_30: {
+        name: '魔導の構え',
+        description: '攻撃回数が半減する代わりに、半減した回数×30の数値だけ魔法攻撃力が上昇します。',
+      },
+      spell_siphon_30: {
+        name: '魔力簒奪',
+        description: '通常攻撃時、30%の確率で使用済みの魔法が1つ使用可能になります。',
+      },
+      frost_nova_t4: {
+        name: '氷霧の大渦',
+        description: '4ターン目の開始時、敵全体に魔法攻撃力の150%の魔法ダメージを与えます。',
+      },
+      enemy_royal_pressure_30: {
+        name: '王の威圧',
+        description: '自分よりLvが低い相手から受けるダメージを30%軽減します。',
+      },
+      enemy_chain_reattack_30: {
+        name: '連撃衝動',
+        description: '攻撃の後、30%の確率で再攻撃を行い続けます。',
+      },
+      enemy_thunder_call: {
+        name: '招雷の角',
+        description: '毎ターン開始時、敵全体に魔法攻撃力の60%の雷撃ダメージを与えます。',
+      },
       weapon_melee_attack: {
         name: '[武器]近距離攻撃',
         description: '隊列の後ろに行くほど通常攻撃のダメージが低下します。',
@@ -973,6 +1098,9 @@ const ja = {
     hpRegen: '[{{value}}%]毎ターン終了時に最大HPの{{value}}%を回復',
     hpRegenFlat: '[{{value}}]毎ターン終了時にHPを{{value}}回復',
     hpRegenAction: '回復能力',
+    hpDegenAction: '血の代償',
+    partyHealRegenAction: '癒しの霊気',
+    reattackAction: '再攻撃',
     itemSlotsBonus: 'アイテム装備可能数が増加する',
   },
   dungeonTier: {

--- a/goblin_native/src/shared/types/CharacterSkill.ts
+++ b/goblin_native/src/shared/types/CharacterSkill.ts
@@ -16,6 +16,15 @@ export type PhysicalCounterAttack = {
   criticalRateMultiplier: number
 }
 
+export type TurnStartAoeMagic = {
+  /** 発動ターン(1始まり)。everyTurn 指定時は不要 */
+  turn?: number
+  /** 毎ターン発動する場合 true */
+  everyTurn?: boolean
+  /** 魔法攻撃力に対するダメージ倍率(%) */
+  powerPercent: number
+}
+
 export interface CharacterSkill {
   id: string
   descriptionKey?: string
@@ -80,4 +89,44 @@ export interface CharacterSkill {
   counterAttackAvoidanceRate?: number
   pureGoblinPartyStatBonusPercent?: number
   pureGoblinPartyStatBonusMinLevel?: number
+  /** 攻撃で与えたダメージのN%だけHP回復(1回の回復上限は最大HPの25%) */
+  lifestealPercent?: number
+  /** ターン終了時、味方全員のHPを自分の魔法回復量のN%回復 */
+  partyHpRegenFromMagicHealPercent?: number
+  /** 攻撃行動のたびに与ダメージ+N%(戦闘中持続・加算) */
+  damageRampPerAttackPercent?: number
+  /** damageRampPerAttackPercent の上限(%) */
+  damageRampMaxPercent?: number
+  /** ターン経過ごとに魔法攻撃力+N%(戦闘中持続・加算) */
+  magicAtkRampPerTurnPercent?: number
+  /** magicAtkRampPerTurnPercent の上限(%) */
+  magicAtkRampMaxPercent?: number
+  /** 攻撃回数が1のとき攻撃力に掛かる倍率 */
+  singleStrikeAttackMultiplier?: number
+  /** 攻撃回数が1のとき命中精度に掛かる倍率 */
+  singleStrikeAccuracyMultiplier?: number
+  /** 敵の物理攻撃をN回、1/3に軽減する障壁で味方全員を保護 */
+  physicalBarrierCharges?: number
+  /** 敵の魔法攻撃をN回、1/3に軽減する障壁で味方全員を保護 */
+  magicBarrierCharges?: number
+  /** 味方全員の物理攻撃ダメージ倍率(重複時は最大値のみ) */
+  partyPhysicalDamageMultiplier?: number
+  /** 攻撃で敵を倒したとき、N%の確率で再攻撃 */
+  reattackOnKillChancePercent?: number
+  /** 必殺攻撃で受けるダメージをN%軽減 */
+  criticalDamageTakenReductionPercent?: number
+  /** 受ける追加ダメージをN%軽減 */
+  additionalDamageTakenReductionPercent?: number
+  /** 攻撃回数が半減し、半減した回数×N だけ防御力上昇 */
+  halveAttackCountToDefRate?: number
+  /** 攻撃回数が半減し、半減した回数×N だけ魔法攻撃力上昇 */
+  halveAttackCountToMagicAtkRate?: number
+  /** 通常攻撃時、N%の確率で使用済み魔法が1つ使用可能に戻る */
+  recoverUsedSpellOnAttackChancePercent?: number
+  /** ターン開始時に敵全体へ魔法攻撃 */
+  turnStartAoeMagic?: TurnStartAoeMagic
+  /** 自分よりLvが低い相手から受けるダメージをN%軽減(敵専用想定) */
+  lowerLevelDamageTakenReductionPercent?: number
+  /** 攻撃後N%の確率で再攻撃を繰り返す(敵専用想定) */
+  chainReattackChancePercent?: number
 }


### PR DESCRIPTION
## 概要

初回再設計(#318)が既存カタログスキルのみで構成されていた反省から、参考ゲームの実データ(スキル1,895件 / 装備998件)を再分析し、流用可能なスキル概念を翻案(名称・数値は変更、コピーはしない)してレアアイテムを再設計。あわせて、これまで未実装だった新スキルの戦闘ロジックを一括実装しました。

## 変更内容

### スキルの仕分けと翻案
- 参考スキルを573ファミリーに正規化し、装備への付与状況で「一般装備」「NPC/ボス級」「敵専用」に仕分け。
- プレイヤー側28種＋敵専用3種(王の威圧/連撃衝動/招雷の角)をカタログに登録。

### レアへの配線
- レア83箇所にbandゲート付きで配線(汎用フィラー枠を差し替え、スキル総数は維持)。
- 完全一致の重複を **7組→1組**(ボス固定装備のみ)に削減。

### 戦闘ロジックの実装(全17メカニクス)
吸血 / 血の代償(HP下限1) / 癒しの霊気 / 闘志 / 魔力高揚 / 渾身の一撃 / 精密照準 / 物理・魔法障壁(PT共有) / 鬨の声 / 追い打ち / 連撃衝動 / 急所守り / 対貫通装甲 / 構え(攻撃回数半減変換) / 魔力簒奪 / ターン開始時全体魔法 / 王の威圧

- 実装箇所: `BattleSystem`, `battle/unitFactory`, `GoblinStatCalculator`, `characterSkills`(集約ヘルパー), `CharacterSkill`(型), `ja.ts`(i18n)。

## 検証
- `npx tsc --noEmit` clean
- 全32スイート536テスト合格
- 新スキル16ケースのスモークテストで挙動確認(方針に従い削除)

## 残タスク
- 敵専用スキル3種の敵JSON配線(`enemy/*.json` の `skills` にID追加で有効)
- ボス固定装備8件の設計
- 新スキルを含めたバランス再計測

詳細は `docs/rare_item_design.md` を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)